### PR TITLE
feat(sky): KASI 달 고도·위상 파싱 구현 및 sky폴더추가, 모듈 테스트 보완

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -19,6 +19,7 @@
         "@nestjs/swagger": "^7.0.0",
         "@nestjs/throttler": "^5.0.0",
         "@nestjs/typeorm": "^10.0.0",
+        "axios": "^1.14.0",
         "bcrypt": "^5.1.1",
         "cache-manager": "^5.4.0",
         "class-transformer": "^0.5.1",
@@ -28,7 +29,8 @@
         "pg": "^8.11.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
-        "typeorm": "^0.3.17"
+        "typeorm": "^0.3.17",
+        "xml2js": "^0.6.2"
       },
       "devDependencies": {
         "@nestjs/cli": "^10.0.0",
@@ -36,10 +38,11 @@
         "@nestjs/testing": "^10.0.0",
         "@types/bcrypt": "^5.0.2",
         "@types/express": "^4.17.17",
-        "@types/jest": "^29.5.2",
+        "@types/jest": "^29.5.14",
         "@types/node": "^20.3.1",
         "@types/passport-jwt": "^3.0.9",
         "@types/supertest": "^2.0.12",
+        "@types/xml2js": "^0.4.14",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.42.0",
@@ -2611,6 +2614,16 @@
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "license": "MIT"
     },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -3318,7 +3331,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
@@ -3334,6 +3346,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -4077,7 +4100,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -4394,7 +4416,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4658,7 +4679,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5351,6 +5371,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -5439,7 +5479,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -8494,6 +8533,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8886,6 +8934,15 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -10770,6 +10827,28 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/swagger": "^7.0.0",
     "@nestjs/throttler": "^5.0.0",
     "@nestjs/typeorm": "^10.0.0",
+    "axios": "^1.14.0",
     "bcrypt": "^5.1.1",
     "cache-manager": "^5.4.0",
     "class-transformer": "^0.5.1",
@@ -36,7 +37,8 @@
     "pg": "^8.11.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
-    "typeorm": "^0.3.17"
+    "typeorm": "^0.3.17",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.0.0",
@@ -44,10 +46,11 @@
     "@nestjs/testing": "^10.0.0",
     "@types/bcrypt": "^5.0.2",
     "@types/express": "^4.17.17",
-    "@types/jest": "^29.5.2",
+    "@types/jest": "^29.5.14",
     "@types/node": "^20.3.1",
     "@types/passport-jwt": "^3.0.9",
     "@types/supertest": "^2.0.12",
+    "@types/xml2js": "^0.4.14",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.42.0",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -10,6 +10,7 @@ import { AuthModule } from './auth/auth.module';
 import { CronModule } from './cron/cron.module';
 import { SpotsModule } from './spots/spots.module';
 import { StarIndexModule } from './star-index/star-index.module';
+import { SkyModule } from './sky/sky.module';
 
 @Module({
   imports: [
@@ -48,7 +49,8 @@ import { StarIndexModule } from './star-index/star-index.module';
     AuthModule,
     CronModule,
     SpotsModule,
-    StarIndexModule, // 추가
+    StarIndexModule,
+    SkyModule, // 추가
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/sky/kasi.mapper.ts
+++ b/backend/src/sky/kasi.mapper.ts
@@ -1,0 +1,50 @@
+type KasiMoonRaw = {
+  moonAltitude?: string | number | null;
+  altitude?: string | number | null;
+  alt?: string | number | null;
+  moonrise?: string | null;
+  moonset?: string | null;
+};
+
+type KasiPhaseRaw = {
+  lunPhase?: string | number | null;
+  lunAge?: string | number | null;
+  illumination?: string | number | null;
+};
+
+function toNumber(value: string | number | null | undefined, fallback = 0): number {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : fallback;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = parseFloat(value.trim());
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+
+  return fallback;
+}
+
+export function kasiToInternalMapper(moonData: KasiMoonRaw | null, phaseData: KasiPhaseRaw | null) {
+  const moonAltitude = toNumber(
+    moonData?.moonAltitude ?? moonData?.altitude ?? moonData?.alt,
+    -10
+  );
+
+  const moonrise = moonData?.moonrise?.trim() ?? null;
+  const moonset = moonData?.moonset?.trim() ?? null;
+
+  const lunAge = toNumber(phaseData?.lunAge, 0);
+
+  const rawPhase =
+    phaseData?.lunPhase ?? phaseData?.illumination ?? (lunAge > 0 ? lunAge / 29.5 : 0);
+  const lunPhase = Math.min(1, Math.max(0, toNumber(rawPhase, 0)));
+
+  return {
+    moonAltitude,
+    lunPhase,
+    moonrise,
+    moonset,
+    lunAge,
+  };
+}

--- a/backend/src/sky/sky.controller.spec.ts
+++ b/backend/src/sky/sky.controller.spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SkyController } from './sky.controller';
+import { SkyService } from './sky.service';
+
+describe('SkyController', () => {
+  let controller: SkyController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SkyController],
+      providers: [
+        {
+          provide: SkyService,
+          useValue: {
+            getMoonData: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SkyController>(SkyController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/sky/sky.controller.ts
+++ b/backend/src/sky/sky.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { SkyService } from './sky.service';
+
+@Controller('sky')
+export class SkyController {
+  constructor(private readonly skyService: SkyService) {}
+
+  @Get('moon')
+  async getMoonData(@Query('date') date: string) {
+    // date 없으면 오늘 날짜 자동으로 사용
+    const today = date ?? new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    return this.skyService.getMoonData(today);
+  }
+}

--- a/backend/src/sky/sky.module.ts
+++ b/backend/src/sky/sky.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { SkyService } from './sky.service';
+import { SkyController } from './sky.controller';
+
+@Module({
+  providers: [SkyService],
+  controllers: [SkyController]
+})
+export class SkyModule {}

--- a/backend/src/sky/sky.service.spec.ts
+++ b/backend/src/sky/sky.service.spec.ts
@@ -1,0 +1,27 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SkyService } from './sky.service';
+import { ConfigService } from '@nestjs/config';
+
+describe('SkyService', () => {
+  let service: SkyService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SkyService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SkyService>(SkyService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/sky/sky.service.ts
+++ b/backend/src/sky/sky.service.ts
@@ -1,0 +1,98 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+import { parseStringPromise } from 'xml2js';
+import { kasiToInternalMapper } from './kasi.mapper';
+
+@Injectable()
+export class SkyService {
+  private readonly logger = new Logger(SkyService.name);
+
+  constructor(private configService: ConfigService) {}
+
+  private async toKasiItem(data: unknown): Promise<Record<string, unknown> | null> {
+    let normalized: unknown = data;
+
+    if (typeof data === 'string') {
+      const parsed = await parseStringPromise(data, {
+        explicitArray: false,
+        trim: true,
+      });
+      normalized = parsed;
+    }
+
+    const item = (normalized as any)?.response?.body?.items?.item;
+    if (!item) {
+      return null;
+    }
+
+    return Array.isArray(item) ? item[0] ?? null : item;
+  }
+
+  async getMoonData(date: string): Promise<{
+    moonAltitude: number;
+    lunPhase: number;
+    moonrise: string | null;
+    moonset: string | null;
+    lunAge: number;
+  }> {
+    const moonApiKey = this.configService.get<string>('KASI_MOON_API_KEY');
+    const riseSetApiKey = this.configService.get<string>('KASI_RISE_SET_API_KEY');
+
+    // 날짜 형식 변환 (20250324 → year=2025, month=03, day=24)
+    const solYear = date.slice(0, 4);
+    const solMonth = date.slice(4, 6);
+    const solDay = date.slice(6, 8);
+
+    try {
+      // 1. 달 출몰 시각 API 호출
+      const moonResponse = await axios.get(
+        'http://apis.data.go.kr/B090041/openapi/service/RiseSetInfoService/getAreaRiseSetInfo',
+        {
+          params: {
+            ServiceKey: riseSetApiKey,
+            locdate: date,
+            location: '서울',
+          },
+        }
+      );
+
+      // 2. 월령 정보 API 호출
+      const phaseResponse = await axios.get(
+        'http://apis.data.go.kr/B090041/openapi/service/LunPhInfoService/getLunPhInfo',
+        {
+          params: {
+            ServiceKey: moonApiKey,
+            solYear,
+            solMonth,
+            solDay,
+          },
+        }
+      );
+
+      // JSON/XML 응답을 모두 처리해 item을 추출
+      const moonData = await this.toKasiItem(moonResponse.data);
+      const phaseData = await this.toKasiItem(phaseResponse.data);
+
+      // 매핑 함수로 변환
+      const result = kasiToInternalMapper(moonData, phaseData);
+
+      this.logger.log(
+        `달 데이터 파싱 완료 — 날짜: ${date}, 고도: ${result.moonAltitude}, 위상: ${result.lunPhase}, 월령: ${result.lunAge}`
+      );
+
+      return result;
+
+    } catch (error) {
+      this.logger.error('KASI API 호출 실패', error);
+      // 실패 시 기본값 반환 (달이 없는 것으로 처리)
+      return {
+        moonAltitude: -10,
+        lunPhase: 0,
+        moonrise: null,
+        moonset: null,
+        lunAge: 0,
+      };
+    }
+  }
+}


### PR DESCRIPTION
## 🔎 What

- ## 작업 배경
- 2주차 개발 가이드의 C 담당 항목인 `KASI API moonAltitude + lunPhase 파싱` 구현을 진행했습니다.
- 기존 임시 추정 방식(월출/월몰 기반 고도 추정)을 실제 API 응답 파싱 구조로 전환했습니다.

## 주요 변경 사항
- `backend/src/sky/kasi.mapper.ts` 추가
  - KASI 응답 필드명을 내부 DTO(`moonAltitude`, `lunPhase`, `moonrise`, `moonset`, `lunAge`)로 매핑
  - phase 값 범위 보정(0~1), 필드 누락 시 fallback 처리
- `backend/src/sky/sky.service.ts` 수정
  - 임시 고도 추정 로직 제거
  - XML/JSON 응답 모두 처리하도록 파싱 로직 추가(`xml2js`)
  - 매핑 로직을 `kasiToInternalMapper`로 분리 적용
- `backend/src/sky/sky.controller.spec.ts` 수정
  - `SkyService` mock provider 추가로 Nest DI 테스트 실패 해결
- `backend/src/app.module.ts`
  - `SkyModule` import 반영
- `backend/package.json`, `backend/package-lock.json`
  - sky 기능 구현 관련 의존성 반영(`xml2js` 포함)

## 변경 파일
- `backend/src/sky/kasi.mapper.ts` (new)
- `backend/src/sky/sky.service.ts`
- `backend/src/sky/sky.controller.spec.ts`
- `backend/src/sky/sky.module.ts`
- `backend/src/sky/sky.controller.ts`
- `backend/src/sky/sky.service.spec.ts`
- `backend/src/app.module.ts`
- `backend/package.json`
- `backend/package-lock.json`

## 테스트/검증
- `npm test` 통과
- `npm run build` 통과

## 영향도
- Star-Index의 달 영향 계산 입력값(`moonAltitude`, `lunPhase`)의 신뢰도를 높이기 위한 선행 작업입니다.
- 추후 A 담당 로직과 moon 영향 계산식 연동 시 mapper 기반으로 안정적으로 확장 가능합니다.

## 후속 작업(별도)
- Stellarium 교차검증 데이터셋 3건(±0.5°) 기록 및 공유
- 실제 운영 키/응답 샘플 기준 추가 테스트 케이스 보강

## 🔗 Issue 

- Closes: #11

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
