### PR TITLE
feat: JWT access·refresh 발급 및 JwtAuthGuard 적용

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,112 +1,52 @@
-StarChaser — Cursor Rules
-프로젝트 개요
-서비스: StarChaser — 별 관측 성공 확률(Star-Index) 특화 앱
-기술 스택: React Native + Expo (FE) / NestJS (BE) /
-PostgreSQL+PostGIS (Supabase) / NestJS 메모리 캐시 / Railway
-Phase 1: Docker·Redis·AWS·CI/CD 없이 로컬 직접 실행
 ---
-🎨 UI 스타일 규칙 (shadcn/ui 기반) — 코드 생성 시 매번 자동 실행
-⚡ 매 UI 컴포넌트 코드 생성 요청 시 반드시 아래를 수행하세요:
-shadcn/ui 공식 스타일 가이드를 웹에서 긁어오세요
-URL: https://ui.shadcn.com/docs/theming
-URL: https://ui.shadcn.com/themes
-OKLCH 다크 토큰 확인 후 `frontend/themes/themes.ts` 기준으로 적용합니다.
-반드시 `themes.ts`의 토큰 변수명을 그대로 사용합니다.
-(`theme.starGold`, `theme.border`, `theme.fontDisplay` 등)
-StyleSheet에서 반드시 themes.ts 토큰 변수명으로 참조합니다.
-(theme.primary, theme.mutedForeground, theme.border 등)
-className 방식 사용 금지
+description: 
+alwaysApply: true
 ---
-🚫 FE Design Principles — Anti-AI Style (절대 규칙)
-Drop Shadow & Glow 금지
-`elevation`, `shadowColor`, `shadowOpacity` 사용 절대 금지
-버튼·카드의 외부 `box-shadow` 금지
-호버·포커스 피드백은 border color 변화와 `scale(0.97)` 물리 반응만 허용
-딱 한 가지 예외: `starGold` 포커스 링 — `0 0 0 2px` 내부 링만 허용 (외부 glow 금지)
-Border 중심 디자인
-모든 컴포넌트 구분은 `1px border` + `borderSubtle`로 처리
-카드 안 섹션 구분: `0.5px borderSubtle` 수평선
-액티브 인디케이터: 상단 `2px` 라인 (BottomTab)
-Instrument Look — 계측 장비 느낌
-수치 데이터는 반드시 `theme.fontDisplay` (Space Mono)
-Star-Index 점수, Bortle 등급, 고도(m), 달 고도(°), PM2.5, 거리(km), 시간, 좌표
-라벨 텍스트: `fontSize: 8~10`, `letterSpacing: 1~2`, `textTransform: 'uppercase'`
-수치 외 UI 텍스트: `theme.fontBody` (Outfit)
-고밀도 레이아웃 (High Density)
-카드 padding: `12px` (큰 padding 지양 — `20px+` 금지)
-요소 간 gap: `4~8px` 이내로 촘촘하게
-한 화면에 더 많은 관측 데이터가 보여야 함
-컬러 팔레트 — 채도 낮게
-배경: `Deep Midnight Blue` (`oklch(0.09 0.012 265)`) — 순수 검정 금지
-강조: `Amber Gold` (`oklch(0.76 0.14 82)`) — 형광 금지, 핵심 데이터에만
-중간: `Steel Gray` (`oklch(0.38 0.04 258)`) — 구조 색상
-보라/파랑 네온 계열 금지 — `nebulaSteel`로 대체
-Border Radius — 단단하게
-기본값: `theme.radius` = `0.4rem` (≈ 6px) — 둥글둥글 금지
-뱃지: `radius * 0.6` — 더 각진 느낌
-풀 라운드(pill): 알림 닷, 인디케이터 라인만 허용
-Red Mode — 완전한 야간 시력 보호
-Blue/Green 계열 색상 완전 제거 → Dark Red/Grey로 치환
-이모지 아이콘 → ASCII 심볼로 교체 (`★ ◈ ◉ ≡ ○`)
-`theme.isRedMode === true`일 때 예외 없이 적용
-`data-night-vision="red"` 속성으로 전체 테마 전환 (웹 버전)
----
-색상 시스템 (themes.ts 토큰 레퍼런스)
-```
-// ── 핵심 토큰 ──
-theme.background      oklch(0.09 0.012 265)   // Deep Midnight Blue
-theme.foreground      oklch(0.88 0.015 240)   // 차가운 화이트
-theme.card            oklch(0.11 0.014 265)   // 카드 배경
-theme.border          oklch(0.20 0.022 268)   // 주 경계선 1px
-theme.borderSubtle    oklch(0.15 0.016 268)   // 미세 구분선 0.5px
-theme.muted           oklch(0.13 0.014 268)
-theme.mutedForeground oklch(0.48 0.03 258)    // Steel Gray 보조텍스트
 
-// ── StarChaser 전용 ──
-theme.starGold        oklch(0.76 0.14 82)     // Amber — 수치 강조, 핵심만
-theme.nebulaSteel     oklch(0.38 0.04 258)    // Steel — 구조 색상
-theme.moonlight       oklch(0.82 0.03 230)    // 달빛 텍스트
-theme.dimRed          oklch(0.52 0.18 25)     // Red Mode 전용
-```
 ---
-코드 스타일
-언어: TypeScript 엄격 모드 (strict: true)
-포매터: Prettier (탭 대신 스페이스 2칸)
-린터: ESLint (airbnb-typescript 기반)
-함수 네이밍: camelCase / 컴포넌트: PascalCase
-파일 네이밍: kebab-case (예: star-index.service.ts)
-절대 하면 안 되는 것
-API 키·비밀번호를 코드에 하드코딩 — 반드시 .env 사용
-앱에서 외부 API 직접 호출 — 반드시 서버 경유
-console.log를 프로덕션 코드에 남기기 — NestJS Logger 사용
-any 타입 사용 금지 (부득이한 경우 주석 필수)
-UI: elevation/shadowColor/shadowOpacity 사용 금지 — Anti-AI 원칙
-UI: Inter, Roboto, Arial, System 폰트 금지 — Space Mono + Outfit만
-UI: 보라/파랑 네온 계열 직접 사용 금지 — themes.ts 토큰만 사용
-BE 규칙 (NestJS)
-모든 외부 API는 Cron이 수집 → 캐시 → 앱이 읽는 구조
-DB 직접 접근은 Repository 패턴만 사용 (서비스에서 dataSource 직접 호출 금지)
-캐시 접근은 CacheService 인터페이스로만 (Phase 2 Redis 교체 대비)
-환경변수: ConfigService 통해 접근 (process.env 직접 사용 금지)
-에러 처리: HttpException 또는 커스텀 Exception Filter
-FE 규칙 (React Native)
-스타일: RN StyleSheet — useTheme()으로 themes.ts 토큰 직접 참조
-       (NativeWind/className 방식 사용 금지)
-상태 관리: useState/useContext — ThemeContext로 테마 전역 관리
-네비게이션: Expo Router
-이미지: expo-image 사용
-Night Vision 토글: `useTheme().toggleRed()` 호출
-DB 규칙 (PostgreSQL + PostGIS via Supabase)
-위경도: 반드시 GEOMETRY(Point, 4326) — SRID 4326 필수
-인덱스: GEOMETRY 컬럼은 반드시 GIST 인덱스
-ST_MakePoint(경도, 위도) — 순서 주의!
-elevation_m 컬럼: 명소 시딩 시 반드시 입력 (Star-Index GPS 고도 변수)
-Star-Index 알고리즘 (10개 변수)
-운량×0.28 + PM2.5×0.17 + 광공해×0.17 + 달영향×0.12 + 습도×0.10
-GPS고도×0.06 + 풍속×0.04 + 시정×0.03 + 기온×0.02 + 보정×0.01
-달 고도(moonAltitude)와 GPS 고도(elevation_m)는 절대 생략 불가
-코드 생성 요청 시 항상 포함할 것
-TypeScript 타입 명시
-에러 핸들링 (try/catch 또는 NestJS ExceptionFilter)
-주요 로직에 한국어 주석
-UI 생성 시: shadcn theming 페이지 참조 + Anti-AI 원칙 적용
+description: 
+alwaysApply: true
+---
+
+# StarChaser --- Cursor Rules
+## 프로젝트 개요
+- 서비스: StarChaser --- 별 관측 성공 확률(Star-Index) 특화 앱
+- 기술 스택: React Native + Expo (FE) / NestJS (BE) /
+ PostgreSQL+PostGIS (Supabase) / NestJS 메모리 캐시 / Railway
+- Phase 1: Docker·Redis·AWS·CI/CD 없이 로컬 직접 실행
+## 코드 스타일
+- 언어: TypeScript 엄격 모드 (strict: true)
+- 포매터: Prettier (탭 대신 스페이스 2칸)
+- 린터: ESLint (airbnb-typescript 기반)
+- 함수 네이밍: camelCase / 컴포넌트: PascalCase
+- 파일 네이밍: kebab-case (예: star-index.service.ts)
+## 절대 하면 안 되는 것
+- API 키·비밀번호를 코드에 하드코딩 --- 반드시 .env 사용
+- 앱에서 외부 API 직접 호출 --- 반드시 서버 경유
+- console.log를 프로덕션 코드에 남기기 --- NestJS Logger 사용
+- any 타입 사용 금지 (부득이한 경우 주석 필수)
+## BE 규칙 (NestJS)
+- 모든 외부 API는 Cron이 수집 → 캐시 → 앱이 읽는 구조
+- DB 직접 접근은 Repository 패턴만 사용 (서비스에서 dataSource 직접 호출 금지)
+- 캐시 접근은 CacheService 인터페이스로만 (Phase 2 Redis 교체 대비)
+- 환경변수: ConfigService 통해 접근 (process.env 직접 사용 금지)
+- 에러 처리: HttpException 또는 커스텀 Exception Filter
+## FE 규칙 (React Native)
+- 스타일: NativeWind
+- 상태 관리: useState/useContext (zustand는 Phase 2부터)
+- 네비게이션: Expo Router
+- 이미지: expo-image 사용
+- primary color : 샤드시엔에 있는 스타일 가이드(tailwind css)의 대표적인 레퍼런스 스타일 가져오기
+- 배경은 검은색, 글씨는 흰색으로 모던하게
+## DB 규칙 (PostgreSQL + PostGIS via Supabase)
+- 위경도: 반드시 GEOMETRY(Point, 4326) --- SRID 4326 필수
+- 인덱스: GEOMETRY 컬럼은 반드시 GIST 인덱스
+- ST_MakePoint(경도, 위도) --- 순서 주의!
+- elevation_m 컬럼: 명소 시딩 시 반드시 입력 (Star-Index GPS 고도 변수)
+## Star-Index 알고리즘 (10개 변수)- 운량×0.28 + PM2.5×0.17 + 광공해×0.17 + 달영향×0.12 + 습도×0.10
+ + GPS고도×0.06 + 풍속×0.04 + 시정×0.03 + 기온×0.02 + 보정×0.01
+- 달 고도(moonAltitude)와 GPS 고도(elevation_m)는 절대 생략 불가
+## 코드 생성 요청 시 항상 포함할 것
+- TypeScript 타입 명시
+- 에러 핸들링 (try/catch 또는 NestJS ExceptionFilter)
+- 주요 로직에 한국어 주석

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -32,8 +32,8 @@ KAKAO_JS_KEY=
 # FCM Push 알림
 FCM_SERVER_KEY=
 
-# 서버 포트
-PORT=3000
+# 서버 포트 (로컬 Windows에서 3000 EACCES 시 3333 권장 — Railway는 플랫폼이 PORT 지정)
+PORT=3333
 
 # ── Phase 2 이후 추가 예정 ──────────────────
 # CACHE_DRIVER=redis

--- a/backend/sql/users-table-auth.sql
+++ b/backend/sql/users-table-auth.sql
@@ -1,0 +1,13 @@
+-- StarChaser JWT refresh 저장용 users 테이블 (Supabase에서 미생성 시 실행)
+-- 컬럼명이 ERD와 다르면 UserEntity만 팀 스키마에 맞게 수정
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email VARCHAR(255) NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  refresh_token TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_users_email ON users (email);

--- a/backend/src/auth/auth-env.validator.ts
+++ b/backend/src/auth/auth-env.validator.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/** 기동 시 JWT 환경변수 검증 — register 중간에 터지는 것 방지 */
+@Injectable()
+export class AuthEnvValidator implements OnModuleInit {
+  private readonly logger = new Logger(AuthEnvValidator.name);
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit(): void {
+    const access = this.config.get<string>('JWT_SECRET')?.trim();
+    const refresh = this.config.get<string>('JWT_REFRESH_SECRET')?.trim();
+    if (!access) {
+      throw new Error(
+        'JWT_SECRET이 비어 있습니다. backend/.env 에 설정하세요.',
+      );
+    }
+    if (!refresh) {
+      throw new Error(
+        'JWT_REFRESH_SECRET이 비어 있습니다. backend/.env 에 설정하세요.',
+      );
+    }
+    if (access === refresh) {
+      this.logger.warn(
+        'JWT_SECRET과 JWT_REFRESH_SECRET이 동일합니다. 서로 다른 랜덤 문자열을 권장합니다.',
+      );
+    }
+  }
+}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,48 +1,49 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiOkResponse,
+  ApiConflictResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
 import { AuthService } from './auth.service';
-import { IsEmail, IsString, MinLength } from 'class-validator';
-
-class RegisterDto {
-  @IsEmail()
-  email: string;
-
-  @IsString()
-  @MinLength(6)
-  password: string;
-}
+import { AuthCredentialsDto } from './dto/auth-credentials.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  // 회원가입 — 60초 내 5회 제한 (브루트포스 방지)
   @Throttle({ default: { ttl: 60000, limit: 5 } })
   @Post('register')
-  @ApiOperation({ summary: '회원가입 (bcrypt 해싱)' })
-  async register(@Body() dto: RegisterDto) {
-    const hashedPassword = await this.authService.hashPassword(dto.password);
-    // TODO: 2주차 — DB 저장 로직 추가
-    return {
-      message: '회원가입 성공 (PoC)',
-      email: dto.email,
-      hashedPassword, // 실제 서비스에서는 절대 반환 금지
-    };
+  @ApiOperation({ summary: '회원가입 — access·refresh JWT 발급' })
+  @ApiOkResponse({
+    description: 'access 1h, refresh 30d — refresh는 users.refresh_token에 저장',
+  })
+  @ApiConflictResponse({ description: '이메일 중복' })
+  register(@Body() dto: AuthCredentialsDto) {
+    return this.authService.register(dto);
   }
 
-  // 로그인 — 60초 내 10회 제한
   @Throttle({ default: { ttl: 60000, limit: 10 } })
   @Post('login')
-  @ApiOperation({ summary: '로그인 (bcrypt 검증)' })
-  async login(@Body() dto: RegisterDto) {
-    // TODO: 2주차 — DB에서 유저 조회 후 검증
-    const testHash = await this.authService.hashPassword(dto.password);
-    const isValid = await this.authService.comparePassword(dto.password, testHash);
-    return {
-      message: isValid ? '로그인 성공 (PoC)' : '로그인 실패',
-      isValid,
-    };
+  @ApiOperation({ summary: '로그인 — JWT 쌍 발급' })
+  @ApiOkResponse({ description: 'accessToken, refreshToken 반환' })
+  @ApiUnauthorizedResponse({ description: '이메일/비밀번호 불일치' })
+  login(@Body() dto: AuthCredentialsDto) {
+    return this.authService.login(dto);
+  }
+
+  @Throttle({ default: { ttl: 60000, limit: 30 } })
+  @Post('refresh')
+  @ApiOperation({
+    summary: 'access token 재발급 — Body에 refreshToken(JSON 문자열)',
+  })
+  @ApiOkResponse({ description: '새 accessToken만 반환' })
+  @ApiUnauthorizedResponse({ description: 'refresh 무효/만료' })
+  refresh(@Body() dto: RefreshTokenDto) {
+    return this.authService.refreshTokens(dto);
   }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,10 +1,31 @@
 import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
+import { AuthEnvValidator } from './auth-env.validator';
+import { UserEntity } from '../users/user.entity';
+import { JwtStrategy } from './strategies/jwt.strategy';
 
 @Module({
+  imports: [
+    TypeOrmModule.forFeature([UserEntity]),
+    PassportModule.register({ defaultStrategy: 'jwt' }),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>('JWT_SECRET'),
+        signOptions: {
+          expiresIn: config.get<string>('JWT_EXPIRES_IN') ?? '1h',
+        },
+      }),
+      inject: [ConfigService],
+    }),
+  ],
   controllers: [AuthController],
-  providers: [AuthService],
-  exports: [AuthService], // 다른 모듈에서 사용 가능
+  providers: [AuthEnvValidator, AuthService, JwtStrategy],
+  exports: [AuthService, JwtModule, PassportModule],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,20 +1,165 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcrypt';
+import { UserEntity } from '../users/user.entity';
+import { AuthCredentialsDto } from './dto/auth-credentials.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+
+type RefreshPayload = { sub: string; type?: string };
 
 @Injectable()
 export class AuthService {
   private readonly logger = new Logger(AuthService.name);
   private readonly SALT_ROUNDS = 12;
 
-  // ── 비밀번호 해싱 ─────────────────────────────────────────
+  constructor(
+    @InjectRepository(UserEntity)
+    private readonly usersRepo: Repository<UserEntity>,
+    private readonly jwtService: JwtService,
+    private readonly config: ConfigService,
+  ) {}
+
   async hashPassword(password: string): Promise<string> {
-    const hashed = await bcrypt.hash(password, this.SALT_ROUNDS);
-    this.logger.log('비밀번호 해싱 완료');
-    return hashed;
+    return bcrypt.hash(password, this.SALT_ROUNDS);
   }
 
-  // ── 비밀번호 검증 ─────────────────────────────────────────
   async comparePassword(password: string, hashed: string): Promise<boolean> {
     return bcrypt.compare(password, hashed);
+  }
+
+  /** 회원가입 후 access·refresh JWT 발급 및 refresh_token DB 저장 */
+  async register(dto: AuthCredentialsDto) {
+    const existing = await this.usersRepo.findOne({
+      where: { email: dto.email.toLowerCase() },
+    });
+    if (existing) {
+      throw new ConflictException('이미 등록된 이메일입니다.');
+    }
+
+    const passwordHash = await this.hashPassword(dto.password);
+    const user = this.usersRepo.create({
+      email: dto.email.toLowerCase(),
+      passwordHash,
+    });
+    const saved = await this.usersRepo.save(user);
+    const tokens = await this.issueTokenPair(saved);
+    this.logger.log(`회원가입 완료: ${saved.email}`);
+
+    return {
+      user: { id: saved.id, email: saved.email },
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+    };
+  }
+
+  /** 로그인 성공 시 토큰 쌍 재발급(기존 refresh 무효화 후 갱신) */
+  async login(dto: AuthCredentialsDto) {
+    const user = await this.usersRepo.findOne({
+      where: { email: dto.email.toLowerCase() },
+    });
+    const valid =
+      user &&
+      (await this.comparePassword(dto.password, user.passwordHash));
+    if (!valid) {
+      throw new UnauthorizedException(
+        '이메일 또는 비밀번호가 올바르지 않습니다.',
+      );
+    }
+
+    const tokens = await this.issueTokenPair(user);
+    this.logger.log(`로그인 성공: ${user.email}`);
+
+    return {
+      user: { id: user.id, email: user.email },
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+    };
+  }
+
+  /**
+   * refresh JWT 검증 + DB 저장값과 일치 시 새 access token만 발급
+   * (만료된 access → 401 → 클라이언트가 이 엔드포인트 호출)
+   */
+  async refreshTokens(dto: RefreshTokenDto) {
+    const refreshSecret = this.config.get<string>('JWT_REFRESH_SECRET');
+    if (!refreshSecret) {
+      this.logger.error('JWT_REFRESH_SECRET 미설정');
+      throw new UnauthorizedException('서버 설정 오류로 갱신할 수 없습니다.');
+    }
+
+    let payload: RefreshPayload;
+    try {
+      payload = await this.jwtService.verifyAsync<RefreshPayload>(
+        dto.refreshToken,
+        { secret: refreshSecret },
+      );
+    } catch {
+      throw new UnauthorizedException(
+        '유효하지 않거나 만료된 refresh token입니다.',
+      );
+    }
+
+    if (payload.type !== 'refresh') {
+      throw new UnauthorizedException(
+        'refresh token이 아닙니다. access token으로는 갱신할 수 없습니다.',
+      );
+    }
+
+    const user = await this.usersRepo.findOne({ where: { id: payload.sub } });
+    if (!user?.refreshToken) {
+      throw new UnauthorizedException(
+        '세션이 종료되었습니다. 다시 로그인해 주세요.',
+      );
+    }
+
+    if (user.refreshToken !== dto.refreshToken) {
+      throw new UnauthorizedException('저장된 refresh token과 일치하지 않습니다.');
+    }
+
+    const accessToken = await this.signAccessToken(user);
+    return { accessToken };
+  }
+
+  private async issueTokenPair(
+    user: UserEntity,
+  ): Promise<{ accessToken: string; refreshToken: string }> {
+    const accessToken = await this.signAccessToken(user);
+    const refreshToken = await this.signRefreshToken(user);
+    await this.usersRepo.update(user.id, { refreshToken });
+    return { accessToken, refreshToken };
+  }
+
+  private async signAccessToken(user: UserEntity): Promise<string> {
+    const secret = this.config.get<string>('JWT_SECRET');
+    if (!secret) {
+      throw new Error('JWT_SECRET이 설정되지 않았습니다.');
+    }
+    const expiresIn =
+      this.config.get<string>('JWT_EXPIRES_IN') ?? '1h';
+    return this.jwtService.signAsync(
+      { sub: user.id, email: user.email },
+      { secret, expiresIn },
+    );
+  }
+
+  private async signRefreshToken(user: UserEntity): Promise<string> {
+    const secret = this.config.get<string>('JWT_REFRESH_SECRET');
+    if (!secret) {
+      throw new Error('JWT_REFRESH_SECRET이 설정되지 않았습니다.');
+    }
+    const expiresIn =
+      this.config.get<string>('JWT_REFRESH_EXPIRES_IN') ?? '30d';
+    return this.jwtService.signAsync(
+      { sub: user.id, type: 'refresh' },
+      { secret, expiresIn },
+    );
   }
 }

--- a/backend/src/auth/decorators/current-user.decorator.ts
+++ b/backend/src/auth/decorators/current-user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import type { JwtValidatedUser } from '../strategies/jwt.strategy';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): JwtValidatedUser => {
+    const request = ctx.switchToHttp().getRequest<{ user: JwtValidatedUser }>();
+    return request.user;
+  },
+);

--- a/backend/src/auth/dto/auth-credentials.dto.ts
+++ b/backend/src/auth/dto/auth-credentials.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export class AuthCredentialsDto {
+  @ApiProperty({ example: 'user@example.com' })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({ minLength: 6 })
+  @IsString()
+  @MinLength(6)
+  password: string;
+}

--- a/backend/src/auth/dto/refresh-token.dto.ts
+++ b/backend/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class RefreshTokenDto {
+  @ApiProperty({ description: '로그인 시 발급받은 refresh token (JWT)' })
+  @IsString()
+  @IsNotEmpty()
+  refreshToken: string;
+}

--- a/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/backend/src/auth/strategies/jwt.strategy.ts
+++ b/backend/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+export type JwtValidatedUser = { userId: string; email: string };
+
+type AccessPayload = {
+  sub: string;
+  email: string;
+};
+
+/** Authorization: Bearer <access JWT> 검증 — access 전용 시크릿 사용 */
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
+  constructor(config: ConfigService) {
+    const secret = config.get<string>('JWT_SECRET');
+    if (!secret) {
+      throw new Error('JWT_SECRET이 설정되지 않았습니다. .env를 확인하세요.');
+    }
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: secret,
+    });
+  }
+
+  validate(payload: AccessPayload): JwtValidatedUser {
+    return { userId: payload.sub, email: payload.email };
+  }
+}

--- a/backend/src/common/filters/all-exceptions.filter.ts
+++ b/backend/src/common/filters/all-exceptions.filter.ts
@@ -1,0 +1,48 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+/**
+ * 개발 환경에서 DB·설정 오류 원인을 응답에 포함 (프로덕션은 메시지 숨김)
+ */
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger(AllExceptionsFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    const isProd = process.env.NODE_ENV === 'production';
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      const res = exception.getResponse();
+      const body =
+        typeof res === 'string'
+          ? { statusCode: status, message: res, path: request.url }
+          : { statusCode: status, ...(res as object), path: request.url };
+      response.status(status).json(body);
+      return;
+    }
+
+    const err =
+      exception instanceof Error ? exception : new Error('Unknown error');
+    this.logger.error(`${request.method} ${request.url} — ${err.message}`);
+    if (err.stack) {
+      this.logger.error(err.stack);
+    }
+
+    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: isProd ? 'Internal server error' : err.message,
+      path: request.url,
+    });
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -2,10 +2,13 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, Logger } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const logger = new Logger('Bootstrap');
+
+  app.useGlobalFilters(new AllExceptionsFilter());
 
   // 전역 ValidationPipe — DTO 유효성 검사
   app.useGlobalPipes(
@@ -23,6 +26,13 @@ async function bootstrap() {
       : true,
   });
 
+  // Windows에서 3000번 EACCES(시스템 예약·Hyper-V 등)가 나오면 PORT=3333 등으로 변경
+  const port = Number(process.env.PORT ?? 3333);
+  // 로컬은 127.0.0.1 — 배포(Railway 등)는 NODE_ENV=production일 때 0.0.0.0
+  const host =
+    process.env.HOST ??
+    (process.env.NODE_ENV === 'production' ? '0.0.0.0' : '127.0.0.1');
+
   // Swagger API 문서 (개발 환경에서만)
   if (process.env.NODE_ENV !== 'production') {
     const config = new DocumentBuilder()
@@ -33,12 +43,11 @@ async function bootstrap() {
       .build();
     const document = SwaggerModule.createDocument(app, config);
     SwaggerModule.setup('api-docs', app, document);
-    logger.log('Swagger: http://localhost:3000/api-docs');
+    logger.log(`Swagger: http://localhost:${port}/api-docs`);
   }
 
-  const port = process.env.PORT ?? 3000;
-  await app.listen(port);
-  logger.log(`🚀 StarChaser API running on port ${port}`);
+  await app.listen(port, host);
+  logger.log(`🚀 StarChaser API on http://${host}:${port}`);
 }
 
 bootstrap();

--- a/backend/src/star-index/star-index.controller.ts
+++ b/backend/src/star-index/star-index.controller.ts
@@ -1,6 +1,9 @@
 import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { JwtValidatedUser } from '../auth/strategies/jwt.strategy';
 import { StarIndexService } from './star-index.service';
 
 @ApiTags('star-index')
@@ -8,23 +11,31 @@ import { StarIndexService } from './star-index.service';
 export class StarIndexController {
   constructor(private readonly starIndexService: StarIndexService) {}
 
-  // 현재 위치 기반 Star-Index 조회
+  // 현재 위치 기반 Star-Index 조회 — 인증 필요 (JwtAuthGuard 샘플 적용)
   // 60초 내 10회 제한 (기상 API 비용 보호)
   @Throttle({ default: { ttl: 60000, limit: 10 } })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @Get()
-  @ApiOperation({ summary: '현재 위치 Star-Index 조회 (0~100점)' })
+  @ApiOperation({ summary: '현재 위치 Star-Index 조회 (0~100점) — Bearer access JWT' })
   async getStarIndex(
+    @CurrentUser() user: JwtValidatedUser,
     @Query('spotId') spotId: string,
   ) {
     // TODO: 장성재(A) 2~3주차 구현
     // 1. CacheService에서 기상 데이터 조회
     // 2. StarIndexService.calcStarIndex() 호출
     // 3. 결과 반환
-    return { spotId, score: 0, message: '구현 예정' };
+    return {
+      spotId,
+      score: 0,
+      message: '구현 예정',
+      requestedBy: user.email,
+    };
   }
   @Get('poc-test')
-async pocTest() {
-  await this.starIndexService.testApiConnections();
-  return { message: '로그 확인하세요' };
-}
+  async pocTest() {
+    await this.starIndexService.testApiConnections();
+    return { message: '로그 확인하세요' };
+  }
 }

--- a/backend/src/star-index/star-index.module.ts
+++ b/backend/src/star-index/star-index.module.ts
@@ -4,10 +4,12 @@
 // ──────────────────────────────────────────────────────────────
 
 import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
 import { StarIndexController } from './star-index.controller';
 import { StarIndexService } from './star-index.service';
 
 @Module({
+  imports: [AuthModule],
   controllers: [StarIndexController],
   providers: [StarIndexService],
   exports: [StarIndexService],

--- a/backend/src/users/user.entity.ts
+++ b/backend/src/users/user.entity.ts
@@ -1,0 +1,30 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/** Supabase users 테이블과 매핑 — refresh_token은 로그인 시 갱신되는 JWT 문자열 */
+@Entity('users')
+export class UserEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255, unique: true })
+  email: string;
+
+  @Column({ name: 'password_hash', type: 'text' })
+  passwordHash: string;
+
+  /** 서명된 refresh JWT 전체 문자열 — 무효화 시 null */
+  @Column({ name: 'refresh_token', type: 'text', nullable: true })
+  refreshToken: string | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}


### PR DESCRIPTION
## 🔎 What

- JWT: access(JWT_SECRET, JWT_EXPIRES_IN 기본 1h) + refresh(JWT_REFRESH_SECRET, JWT_REFRESH_EXPIRES_IN 기본 30d) 발급, users.refresh_token에 refresh JWT 문자열 저장.
- API: POST /auth/register, POST /auth/login, POST /auth/refresh 구현 및 Swagger 문서화.
- 인증: JwtAuthGuard를 GET /star-index에만 적용(전역 미적용), 미인증 요청 시 401.
- 기타: UserEntity 및 Supabase용 users 테이블 참고 SQL 추가, 로컬 기동 시 127.0.0.1/기본 포트 3333로 Windows 포트 이슈 완화, 비프로덕션에서 500 시 원인 메시지 노출(AllExceptionsFilter), 기동 시 JWT 필수값 검증(AuthEnvValidator).

## 🔗 Issue 

- Closes: #13 

## test 결과
<img width="871" height="208" alt="화면 캡처 2026-04-05 230145" src="https://github.com/user-attachments/assets/ecab5177-1862-4cee-8d5d-d0a891850445" />
<img width="595" height="233" alt="화면 캡처 2026-04-05 230157" src="https://github.com/user-attachments/assets/2f394446-414d-406d-9c77-c44a776a13f2" />


## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?


## 추가 서술

## 왜 토큰(JWT)을 택했는가?
### 1. 모바일·SPA(Expo/React Native) 친화적
브라우저 중심인 쿠키는 SameSite, 도메인·크로스 오리진, WebView/네이티브 클라이언트에서 처리 방식이 달라지기 쉽다. Authorization 헤더의 Bearer 토큰은 클라이언트 종류와 무관하게 동일한 패턴으로 붙일 수 있다.

### 2. 역할 분리(access 짧게 / refresh 길게)
짧은 수명의 access로 탈취 피해를 줄이고, 긴 수명의 refresh로 재로그인 부담을 줄인다. refresh는 DB에 저장해 폐기·로그아웃이 가능해, “완전 무상태”와 “필요한 만큼의 상태” 사이를 맞추기 좋다.