### PR TITLE
feat: TypeOrmSpotRepository(PostGIS) 및 star-index spotId 연동

### DIFF
--- a/backend/sql/spots-gist-index.sql
+++ b/backend/sql/spots-gist-index.sql
@@ -1,0 +1,4 @@
+-- spots.location 반경 검색(ST_DWithin) 성능 — GIST 인덱스 (없을 때만 실행)
+-- Supabase: PostGIS 활성화 확인 후 SQL Editor에서 실행
+
+CREATE INDEX IF NOT EXISTS idx_spots_location_gist ON spots USING GIST (location);

--- a/backend/src/spots/spot.entity.ts
+++ b/backend/src/spots/spot.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+/**
+ * spots 테이블 — location(geometry Point 4326)는 PostGIS 전용이라
+ * 조회는 TypeOrmSpotRepository에서 ST_X/ST_Y/ST_DWithin raw SQL로 처리
+ */
+@Entity('spots')
+export class SpotEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar' })
+  name: string;
+
+  @Column({ name: 'bortle_class', type: 'smallint', nullable: true })
+  bortleClass: number | null;
+
+  @Column({ name: 'elevation_m', type: 'int' })
+  elevationM: number;
+
+  @Column({ name: 'has_parking', type: 'boolean', nullable: true })
+  hasParking: boolean | null;
+
+  @Column({ name: 'has_toilet', type: 'boolean', nullable: true })
+  hasToilet: boolean | null;
+
+  @Column({ name: 'location_radius_m', type: 'int', nullable: true })
+  locationRadiusM: number | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/spots/spots.controller.ts
+++ b/backend/src/spots/spots.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Get, Inject, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import {
+  SPOT_REPOSITORY,
+  type SpotRepository,
+} from '../common/interfaces/spot.repository';
+
+/** 샘플 명소·반경 조회 검증용 — 프로덕션에서는 라우트·권한 정책 팀 합의 */
+@ApiTags('spots')
+@Controller('spots')
+export class SpotsController {
+  constructor(
+    @Inject(SPOT_REPOSITORY)
+    private readonly spots: SpotRepository,
+  ) {}
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Get()
+  @ApiOperation({ summary: '전체 명소 목록 (DB 연동·시딩 검증)' })
+  findAll() {
+    return this.spots.findAll();
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Get('nearby')
+  @ApiOperation({
+    summary:
+      '반경 내 명소 — ST_DWithin (lat, lng: WGS84, radiusM: 미터, 예: 30000)',
+  })
+  findNearby(
+    @Query('lat') lat: string,
+    @Query('lng') lng: string,
+    @Query('radiusM') radiusM = '30000',
+  ) {
+    return this.spots.findNearby(
+      Number(lat),
+      Number(lng),
+      Number(radiusM) || 30000,
+    );
+  }
+}

--- a/backend/src/spots/spots.module.ts
+++ b/backend/src/spots/spots.module.ts
@@ -1,4 +1,18 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SPOT_REPOSITORY } from '../common/interfaces/spot.repository';
+import { SpotEntity } from './spot.entity';
+import { SpotsController } from './spots.controller';
+import { TypeOrmSpotRepository } from './typeorm-spot.repository';
+import { AuthModule } from '../auth/auth.module';
 
-@Module({})
+@Module({
+  imports: [TypeOrmModule.forFeature([SpotEntity]), AuthModule],
+  controllers: [SpotsController],
+  providers: [
+    TypeOrmSpotRepository,
+    { provide: SPOT_REPOSITORY, useExisting: TypeOrmSpotRepository },
+  ],
+  exports: [SPOT_REPOSITORY],
+})
 export class SpotsModule {}

--- a/backend/src/spots/typeorm-spot.repository.ts
+++ b/backend/src/spots/typeorm-spot.repository.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { Spot, SpotRepository } from '../common/interfaces/spot.repository';
+import { SpotEntity } from './spot.entity';
+
+/**
+ * PostGIS 반경 조회 — ST_MakePoint(경도, 위도) 순서 ($1=lng, $2=lat, $3=반경 m)
+ */
+@Injectable()
+export class TypeOrmSpotRepository implements SpotRepository {
+  constructor(
+    @InjectRepository(SpotEntity)
+    private readonly repo: Repository<SpotEntity>,
+  ) {}
+
+  async findById(id: string): Promise<Spot | null> {
+    const rows = (await this.repo.query(
+      `
+      SELECT
+        id,
+        name,
+        ST_Y(location::geometry) AS lat,
+        ST_X(location::geometry) AS lng,
+        bortle_class,
+        elevation_m,
+        has_parking,
+        has_toilet,
+        location_radius_m
+      FROM spots
+      WHERE id = $1::uuid
+      `,
+      [id],
+    )) as Record<string, unknown>[];
+
+    const row = rows[0];
+    return row ? this.mapRow(row) : null;
+  }
+
+  async findNearby(lat: number, lng: number, radiusM: number): Promise<Spot[]> {
+    const rows = (await this.repo.query(
+      `
+      SELECT
+        id,
+        name,
+        ST_Y(location::geometry) AS lat,
+        ST_X(location::geometry) AS lng,
+        bortle_class,
+        elevation_m,
+        has_parking,
+        has_toilet,
+        location_radius_m
+      FROM spots
+      WHERE ST_DWithin(
+        location::geography,
+        ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography,
+        $3
+      )
+      ORDER BY ST_Distance(
+        location::geography,
+        ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography
+      )
+      `,
+      [lng, lat, radiusM],
+    )) as Record<string, unknown>[];
+
+    return rows.map((r) => this.mapRow(r));
+  }
+
+  async findAll(): Promise<Spot[]> {
+    const rows = (await this.repo.query(
+      `
+      SELECT
+        id,
+        name,
+        ST_Y(location::geometry) AS lat,
+        ST_X(location::geometry) AS lng,
+        bortle_class,
+        elevation_m,
+        has_parking,
+        has_toilet,
+        location_radius_m
+      FROM spots
+      ORDER BY name
+      `,
+    )) as Record<string, unknown>[];
+
+    return rows.map((r) => this.mapRow(r));
+  }
+
+  private mapRow(row: Record<string, unknown>): Spot {
+    return {
+      id: String(row.id),
+      name: String(row.name),
+      lat: Number(row.lat),
+      lng: Number(row.lng),
+      bortleClass: Number(row.bortle_class ?? 0),
+      elevationM: Number(row.elevation_m),
+      hasParking: row.has_parking === true,
+      hasToilet: row.has_toilet === true,
+      locationRadiusM: Number(row.location_radius_m ?? 0),
+    };
+  }
+}

--- a/backend/src/star-index/star-index.controller.ts
+++ b/backend/src/star-index/star-index.controller.ts
@@ -1,15 +1,35 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  Inject,
+  NotFoundException,
+} from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { JwtValidatedUser } from '../auth/strategies/jwt.strategy';
+import {
+  SPOT_REPOSITORY,
+  type SpotRepository,
+} from '../common/interfaces/spot.repository';
 import { StarIndexService } from './star-index.service';
 
 @ApiTags('star-index')
 @Controller('star-index')
 export class StarIndexController {
-  constructor(private readonly starIndexService: StarIndexService) {}
+  constructor(
+    private readonly starIndexService: StarIndexService,
+    @Inject(SPOT_REPOSITORY)
+    private readonly spots: SpotRepository,
+  ) {}
 
   // 현재 위치 기반 Star-Index 조회 — 인증 필요 (JwtAuthGuard 샘플 적용)
   // 60초 내 10회 제한 (기상 API 비용 보호)
@@ -17,19 +37,29 @@ export class StarIndexController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @Get()
-  @ApiOperation({ summary: '현재 위치 Star-Index 조회 (0~100점) — Bearer access JWT' })
+  @ApiOperation({
+    summary:
+      '명소 기준 Star-Index 조회 (0~100점) — Bearer access JWT, spotId=spots.id UUID',
+  })
+  @ApiNotFoundResponse({ description: 'spotId에 해당하는 명소 없음' })
   async getStarIndex(
     @CurrentUser() user: JwtValidatedUser,
     @Query('spotId') spotId: string,
   ) {
-    // TODO: 장성재(A) 2~3주차 구현
-    // 1. CacheService에서 기상 데이터 조회
-    // 2. StarIndexService.calcStarIndex() 호출
-    // 3. 결과 반환
+    const spot = await this.spots.findById(spotId);
+    if (!spot) {
+      throw new NotFoundException('해당 spotId의 명소가 없습니다.');
+    }
+    // TODO: 캐시 기상·미세먼지·달 + StarIndexService.calcStarIndex() 연동
     return {
-      spotId,
+      spotId: spot.id,
+      name: spot.name,
+      lat: spot.lat,
+      lng: spot.lng,
+      elevationM: spot.elevationM,
+      bortleClass: spot.bortleClass,
       score: 0,
-      message: '구현 예정',
+      message: 'Star-Index 계산은 캐시·Cron 연동 후',
       requestedBy: user.email,
     };
   }

--- a/backend/src/star-index/star-index.module.ts
+++ b/backend/src/star-index/star-index.module.ts
@@ -5,11 +5,12 @@
 
 import { Module } from '@nestjs/common';
 import { AuthModule } from '../auth/auth.module';
+import { SpotsModule } from '../spots/spots.module';
 import { StarIndexController } from './star-index.controller';
 import { StarIndexService } from './star-index.service';
 
 @Module({
-  imports: [AuthModule],
+  imports: [AuthModule, SpotsModule],
   controllers: [StarIndexController],
   providers: [StarIndexService],
   exports: [StarIndexService],

--- a/backend/src/star-index/star-index.service.ts
+++ b/backend/src/star-index/star-index.service.ts
@@ -226,7 +226,8 @@ async testApiConnections(lat = 37.5665, lng = 126.9780): Promise<void> {
     this.logger.log(`에어코리아 API 응답: ${JSON.stringify(airData).slice(0, 200)}`);
 
   } catch (e) {
-    this.logger.error(`API 호출 실패: ${e.message}`);
+    const msg = e instanceof Error ? e.message : String(e);
+    this.logger.error(`API 호출 실패: ${msg}`);
   }
 }
 }


### PR DESCRIPTION
## 🔎 What

- TypeOrmSpotRepository: findById, findAll, findNearby(ST_DWithin + 거리 정렬).
- SpotEntity + SpotsModule에서 SPOT_REPOSITORY export.
- 검증용 SpotsController: GET /spots, GET /spots/nearby (Jwt).
- GET /star-index: spotId로 DB 조회 후 404/명소 메타 응답.
- sql/spots-gist-index.sql 추가.
- StarIndexService API 테스트 catch의 unknown 처리 보강.

## 🔗 Issue 

- Closes: #16 

## test result
<img width="1198" height="591" alt="화면 캡처 2026-04-05 235534" src="https://github.com/user-attachments/assets/6d2fd4f5-963a-4989-ad7b-b285f7e26117" />
<img width="1210" height="361" alt="화면 캡처 2026-04-05 235612" src="https://github.com/user-attachments/assets/f37dcadf-1d8b-439d-b60d-e3d6886fd6ea" />

- Swagger를 통한 DB조회 성공
- 해당하는 spotId에 따른 DB값 출력 성공

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
