### PR TITLE
fix: sky 모듈을 .cursorrules 규칙에 맞게 타입/에러 처리 정리

### DIFF
--- a/backend/src/sky/sky.service.ts
+++ b/backend/src/sky/sky.service.ts
@@ -4,11 +4,21 @@ import axios from 'axios';
 import { parseStringPromise } from 'xml2js';
 import { kasiToInternalMapper } from './kasi.mapper';
 
+type KasiApiEnvelope = {
+  response?: {
+    body?: {
+      items?: {
+        item?: Record<string, unknown> | Record<string, unknown>[];
+      };
+    };
+  };
+};
+
 @Injectable()
 export class SkyService {
   private readonly logger = new Logger(SkyService.name);
 
-  constructor(private configService: ConfigService) {}
+  constructor(private readonly configService: ConfigService) {}
 
   private async toKasiItem(data: unknown): Promise<Record<string, unknown> | null> {
     let normalized: unknown = data;
@@ -21,7 +31,8 @@ export class SkyService {
       normalized = parsed;
     }
 
-    const item = (normalized as any)?.response?.body?.items?.item;
+    const envelope = normalized as KasiApiEnvelope;
+    const item = envelope.response?.body?.items?.item;
     if (!item) {
       return null;
     }


### PR DESCRIPTION
## 🔎 What

- 2주차 가이드의 `KASI API 달 고도·위상 파싱` 구현을 진행하는 과정에서, sky 모듈은 동작하더라도 프로젝트 규칙(`.cursorrules`) 기준으로 타입 안정성 미흡 지점이 있어 보완했습니다.

## 무엇을 변경했나
- `backend/src/sky/sky.service.ts`
  - `as any` 캐스팅 제거
  - KASI 응답 구조 타입(`KasiApiEnvelope`) 명시
  - `ConfigService`를 `readonly`로 선언해 의존성 불변성 강화
- `backend/src/sky/kasi.mapper.ts`
  - KASI 필드명 → 내부 DTO(`moonAltitude`, `lunPhase`, `moonrise`, `moonset`, `lunAge`) 매핑 유지
  - 숫자 파싱/범위 보정 로직 유지(phase 0~1)
- 기존 sky 테스트/빌드 검증 재수행
- 
## 왜 문제가 발생했나 (원인)
- KASI 응답이 XML/JSON 혼합 가능성이 있어 빠르게 파싱 로직을 붙이는 과정에서, 응답 접근부에 `any` 캐스팅이 남아 타입 규칙 위반 소지가 생김
- 즉, 기능 구현은 되었지만 `.cursorrules`의 타입 엄격 기준(특히 `any` 금지)을 100% 충족하지 못한 상태였음
- 
## 규칙 기준과 적용 설명
`.cursorrules`의 아래 규칙을 기준으로 수정했습니다.
- `any 타입 사용 금지`  
  - 기존: `(normalized as any)?.response...`  
  - 변경: `KasiApiEnvelope` 타입 정의 후 안전 접근
- `TypeScript strict 모드 지향`  
  - 외부 응답 구조를 명시 타입으로 제한해 추론 불확실성 축소
- `에러 처리 및 안정성 유지`  
  - 기존 `try/catch` 구조 유지, 실패 시 fallback 반환 유지
- `NestJS 규칙 일관성`  
  - `ConfigService`를 `readonly`로 고정해 서비스 의존성 변경 위험 최소화
  - 
## 테스트/검증
- `npm test` ✅ 통과
- `npm run build` ✅ 통과
- 수정 파일 lint 진단 ✅ 문제 없음
- 
## 기대 효과
- 규칙 준수 상태에서 KASI 파싱 로직의 타입 안정성 향상
- 향후 KASI 응답 스키마 변화 대응 시 컴파일 단계에서 이상 탐지 용이
- 팀 내 `.cursorrules` 기준 일관성 강화

## 🔗 Issue 

- Closes: #11 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
