### PR TITLE
feat(backend): Star-Index 캐시 계산·Cron 수집기·SpotRepository 연동

### DIFF
--- a/backend/src/cron/cron.controller.ts
+++ b/backend/src/cron/cron.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CronService } from './cron.service';
+
+@ApiTags('cron')
+@Controller('cron')
+export class CronController {
+  constructor(private readonly cronService: CronService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Post('run-once')
+  @ApiOperation({ summary: '기상/미세먼지/달 캐시 수집 즉시 실행 (개발 검증용)' })
+  async runOnce() {
+    await this.cronService.runCollectionOnce();
+    return { message: 'Cron 수집 실행 완료' };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Get('cache-status')
+  @ApiOperation({ summary: 'Star-Index용 캐시 키 존재 여부 확인' })
+  cacheStatus(
+    @Query('lat') lat = '37.5665',
+    @Query('lng') lng = '126.978',
+  ) {
+    return this.cronService.getCacheStatus(Number(lat), Number(lng));
+  }
+}

--- a/backend/src/cron/cron.module.ts
+++ b/backend/src/cron/cron.module.ts
@@ -1,4 +1,13 @@
 import { Module } from '@nestjs/common';
+import { CronService } from './cron.service';
+import { SkyModule } from '../sky/sky.module';
+import { CronController } from './cron.controller';
+import { SpotsModule } from '../spots/spots.module';
 
-@Module({})
+@Module({
+  imports: [SkyModule, SpotsModule],
+  controllers: [CronController],
+  providers: [CronService],
+  exports: [CronService],
+})
 export class CronModule {}

--- a/backend/src/cron/cron.service.ts
+++ b/backend/src/cron/cron.service.ts
@@ -3,6 +3,12 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { Inject } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
+import { ConfigService } from '@nestjs/config';
+import { SkyService } from '../sky/sky.service';
+import {
+  SPOT_REPOSITORY,
+  type SpotRepository,
+} from '../common/interfaces/spot.repository';
 
 // ──────────────────────────────────────────────────────────────
 // Cron 수집기 — 장성재(A) 담당
@@ -13,32 +19,206 @@ import { Cache } from 'cache-manager';
 export class CronService {
   private readonly logger = new Logger(CronService.name);
 
-  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
+  constructor(
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
+    private readonly config: ConfigService,
+    private readonly skyService: SkyService,
+    @Inject(SPOT_REPOSITORY) private readonly spots: SpotRepository,
+  ) {}
+
+  private latLngToGrid(lat: number, lng: number): { nx: number; ny: number } {
+    const RE = 6371.00877;
+    const GRID = 5.0;
+    const SLAT1 = 30.0;
+    const SLAT2 = 60.0;
+    const OLON = 126.0;
+    const OLAT = 38.0;
+    const XO = 43;
+    const YO = 136;
+
+    const DEGRAD = Math.PI / 180.0;
+
+    const re = RE / GRID;
+    const slat1 = SLAT1 * DEGRAD;
+    const slat2 = SLAT2 * DEGRAD;
+    const olon = OLON * DEGRAD;
+    const olat = OLAT * DEGRAD;
+
+    let sn =
+      Math.tan(Math.PI * 0.25 + slat2 * 0.5) /
+      Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn);
+
+    let sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sf = (Math.pow(sf, sn) * Math.cos(slat1)) / sn;
+
+    let ro = Math.tan(Math.PI * 0.25 + olat * 0.5);
+    ro = (re * sf) / Math.pow(ro, sn);
+
+    const ra = Math.tan(Math.PI * 0.25 + lat * DEGRAD * 0.5);
+    const raVal = (re * sf) / Math.pow(ra, sn);
+
+    let theta = lng * DEGRAD - olon;
+    if (theta > Math.PI) theta -= 2.0 * Math.PI;
+    if (theta < -Math.PI) theta += 2.0 * Math.PI;
+    theta *= sn;
+
+    const nx = Math.floor(raVal * Math.sin(theta) + XO + 0.5);
+    const ny = Math.floor(ro - raVal * Math.cos(theta) + YO + 0.5);
+
+    return { nx, ny };
+  }
+
+  private pickForecast(
+    items: Array<{ category?: string; fcstValue?: string }>,
+  ): {
+    cloud: number;
+    humidity: number;
+    windSpeed: number;
+    visibility: number;
+    temperature: number;
+    pop: number;
+  } {
+    const findValue = (category: string, fallback: number): number => {
+      const raw = items.find((v) => v.category === category)?.fcstValue;
+      const parsed = raw ? Number(raw) : NaN;
+      return Number.isFinite(parsed) ? parsed : fallback;
+    };
+
+    return {
+      cloud: findValue('SKY', 5) * 25,
+      humidity: findValue('REH', 70),
+      windSpeed: findValue('WSD', 2),
+      visibility: findValue('VVV', 10),
+      temperature: findValue('TMP', 12),
+      pop: findValue('POP', 0),
+    };
+  }
 
   // ── 기상청 단기예보 — 매 1시간마다 수집 ─────────────────────
   @Cron(CronExpression.EVERY_HOUR)
   async collectWeatherData() {
-    this.logger.log('기상청 API 수집 시작...');
-    // TODO: 장성재(A) 3주차 구현
-    // 1. 전국 주요 격자 목록 조회
-    // 2. 기상청 단기예보 API 호출 (KMA_API_KEY)
-    // 3. cache.set(`weather:${gridX}:${gridY}`, data, 3600)
+    const serviceKey = this.config.get<string>('KMA_API_KEY');
+
+    if (!serviceKey) {
+      this.logger.warn('KMA_API_KEY가 없어 weather 수집을 건너뜁니다.');
+      return;
+    }
+
+    try {
+      const spots = await this.spots.findAll();
+      if (!spots.length) {
+        this.logger.warn('spots 데이터가 없어 weather 수집을 건너뜁니다.');
+        return;
+      }
+
+      const grids = new Map<string, { nx: number; ny: number }>();
+      for (const spot of spots) {
+        const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
+        grids.set(`${nx}:${ny}`, { nx, ny });
+      }
+
+      const now = new Date();
+      const baseDate = now.toISOString().slice(0, 10).replace(/-/g, '');
+      for (const { nx, ny } of grids.values()) {
+        const cacheKey = `weather:${nx}:${ny}`;
+        try {
+          const url =
+            'https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst' +
+            `?serviceKey=${serviceKey}&numOfRows=200&pageNo=1&dataType=JSON` +
+            `&base_date=${baseDate}&base_time=0500&nx=${nx}&ny=${ny}`;
+
+          const response = await fetch(url);
+          const data = (await response.json()) as {
+            response?: { body?: { items?: { item?: Array<{ category?: string; fcstValue?: string }> } } };
+          };
+          const items = data.response?.body?.items?.item ?? [];
+          if (!items.length) {
+            throw new Error('기상청 응답 item이 비어 있습니다.');
+          }
+
+          const payload = {
+            ...this.pickForecast(items),
+            collectedAt: new Date().toISOString(),
+          };
+          await this.cache.set(cacheKey, payload, 3600 * 1000);
+          this.logger.log(`weather 캐시 저장 완료: ${cacheKey}`);
+        } catch (error) {
+          const msg = error instanceof Error ? error.message : String(error);
+          this.logger.warn(`weather 수집 실패(기존 캐시 유지): ${cacheKey} - ${msg}`);
+        }
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`weather 수집 실패(기존 캐시 유지): ${msg}`);
+    }
   }
 
   // ── 에어코리아 PM2.5 — 매 1시간마다 수집 ─────────────────────
   @Cron(CronExpression.EVERY_HOUR)
   async collectDustData() {
-    this.logger.log('에어코리아 API 수집 시작...');
-    // TODO: 장성재(A) 3주차 구현
-    // cache.set(`dust:${sido}`, data, 3600)
+    const sido = '서울';
+    const cacheKey = `dust:${sido}`;
+    const serviceKey = this.config.get<string>('AIRKOREA_API_KEY');
+
+    if (!serviceKey) {
+      this.logger.warn('AIRKOREA_API_KEY가 없어 dust 수집을 건너뜁니다.');
+      return;
+    }
+
+    try {
+      const url =
+        'https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty' +
+        `?serviceKey=${serviceKey}&returnType=json&numOfRows=10&pageNo=1&sidoName=${encodeURIComponent(
+          sido,
+        )}&ver=1.0`;
+
+      const response = await fetch(url);
+      const data = (await response.json()) as {
+        response?: { body?: { items?: Array<{ pm25Value?: string }> } };
+      };
+
+      const items = data.response?.body?.items ?? [];
+      const pm25 =
+        items
+          .map((v) => Number(v.pm25Value))
+          .find((v) => Number.isFinite(v) && v >= 0) ?? 20;
+
+      await this.cache.set(
+        cacheKey,
+        { pm25, collectedAt: new Date().toISOString() },
+        3600 * 1000,
+      );
+      this.logger.log(`dust 캐시 저장 완료: ${cacheKey}`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`dust 수집 실패(기존 캐시 유지): ${msg}`);
+    }
   }
 
   // ── KASI 달 데이터 — 매일 자정 수집 ─────────────────────────
   @Cron('0 0 * * *')
   async collectMoonData() {
-    this.logger.log('KASI 달 고도·위상 수집 시작...');
-    // TODO: 지영재(C)와 협력 — 달 고도(moonAltitude) 필드 확인 필수
-    // cache.set(`moon:${date}`, data, 86400)
+    const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+    const cacheKey = `moon:${date}`;
+    try {
+      const moon = await this.skyService.getMoonData(date);
+      await this.cache.set(
+        cacheKey,
+        {
+          phase: moon.lunPhase,
+          altitude: moon.moonAltitude,
+          moonrise: moon.moonrise,
+          moonset: moon.moonset,
+          collectedAt: new Date().toISOString(),
+        },
+        86400 * 1000,
+      );
+      this.logger.log(`moon 캐시 저장 완료: ${cacheKey}`);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`moon 수집 실패(기존 캐시 유지): ${msg}`);
+    }
   }
 
   // ── 주간 TOP5 — 매주 월요일 오전 7시 갱신 ────────────────────
@@ -47,5 +227,40 @@ export class CronService {
     this.logger.log('주간 TOP5 산출 시작...');
     // TODO: 김세희(B) — 5주차 구현
     // cache.set(`top5:weekly:${week}`, data, 86400)
+  }
+
+  async runCollectionOnce(): Promise<void> {
+    await this.collectWeatherData();
+    await this.collectDustData();
+    await this.collectMoonData();
+  }
+
+  async getCacheStatus(lat = 37.5665, lng = 126.978): Promise<{
+    weatherKey: string;
+    dustKey: string;
+    moonKey: string;
+    weatherExists: boolean;
+    dustExists: boolean;
+    moonExists: boolean;
+  }> {
+    const { nx, ny } = this.latLngToGrid(lat, lng);
+    const weatherKey = `weather:${nx}:${ny}`;
+    const dustKey = 'dust:서울';
+    const moonKey = `moon:${new Date().toISOString().slice(0, 10).replace(/-/g, '')}`;
+
+    const [weather, dust, moon] = await Promise.all([
+      this.cache.get(weatherKey),
+      this.cache.get(dustKey),
+      this.cache.get(moonKey),
+    ]);
+
+    return {
+      weatherKey,
+      dustKey,
+      moonKey,
+      weatherExists: weather !== undefined && weather !== null,
+      dustExists: dust !== undefined && dust !== null,
+      moonExists: moon !== undefined && moon !== null,
+    };
   }
 }

--- a/backend/src/sky/sky.module.ts
+++ b/backend/src/sky/sky.module.ts
@@ -4,6 +4,7 @@ import { SkyController } from './sky.controller';
 
 @Module({
   providers: [SkyService],
-  controllers: [SkyController]
+  controllers: [SkyController],
+  exports: [SkyService],
 })
 export class SkyModule {}

--- a/backend/src/sky/sky.service.ts
+++ b/backend/src/sky/sky.service.ts
@@ -47,8 +47,12 @@ export class SkyService {
     moonset: string | null;
     lunAge: number;
   }> {
-    const moonApiKey = this.configService.get<string>('KASI_MOON_API_KEY');
-    const riseSetApiKey = this.configService.get<string>('KASI_RISE_SET_API_KEY');
+    const moonApiKey =
+      this.configService.get<string>('KASI_MOON_API_KEY') ??
+      this.configService.get<string>('KASI_API_KEY');
+    const riseSetApiKey =
+      this.configService.get<string>('KASI_RISE_SET_API_KEY') ??
+      this.configService.get<string>('KASI_API_KEY');
 
     // 날짜 형식 변환 (20250324 → year=2025, month=03, day=24)
     const solYear = date.slice(0, 4);
@@ -95,7 +99,8 @@ export class SkyService {
       return result;
 
     } catch (error) {
-      this.logger.error('KASI API 호출 실패', error);
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`KASI API 호출 실패: ${message}`);
       // 실패 시 기본값 반환 (달이 없는 것으로 처리)
       return {
         moonAltitude: -10,

--- a/backend/src/star-index/star-index.controller.ts
+++ b/backend/src/star-index/star-index.controller.ts
@@ -50,7 +50,8 @@ export class StarIndexController {
     if (!spot) {
       throw new NotFoundException('해당 spotId의 명소가 없습니다.');
     }
-    // TODO: 캐시 기상·미세먼지·달 + StarIndexService.calcStarIndex() 연동
+    const { score, cacheKeys } =
+      await this.starIndexService.calculateForSpotFromCache(spot);
     return {
       spotId: spot.id,
       name: spot.name,
@@ -58,8 +59,9 @@ export class StarIndexController {
       lng: spot.lng,
       elevationM: spot.elevationM,
       bortleClass: spot.bortleClass,
-      score: 0,
-      message: 'Star-Index 계산은 캐시·Cron 연동 후',
+      score,
+      cacheKeys,
+      message: '캐시(weather/dust/moon) 기반 Star-Index 계산 완료',
       requestedBy: user.email,
     };
   }

--- a/backend/src/star-index/star-index.service.ts
+++ b/backend/src/star-index/star-index.service.ts
@@ -1,6 +1,12 @@
-import { Injectable, Inject, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Inject,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
+import type { Spot } from '../common/interfaces/spot.repository';
 
 // ── 기상 데이터 타입 ─────────────────────────────────────────
 interface WeatherData {
@@ -34,6 +40,44 @@ export class StarIndexService {
   private readonly logger = new Logger(StarIndexService.name);
 
   constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
+
+  async calculateForSpotFromCache(spot: Spot): Promise<{
+    score: number;
+    cacheKeys: { weatherKey: string; dustKey: string; moonKey: string };
+  }> {
+    const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
+    const weatherKey = `weather:${nx}:${ny}`;
+    const dustKey = 'dust:서울';
+    const moonKey = `moon:${new Date().toISOString().slice(0, 10).replace(/-/g, '')}`;
+
+    const weather = await this.cache.get<WeatherData>(weatherKey);
+    const dust = await this.cache.get<DustData>(dustKey);
+    const moon = await this.cache.get<MoonData>(moonKey);
+
+    if (!weather || !dust || !moon) {
+      const missing = [
+        !weather ? weatherKey : null,
+        !dust ? dustKey : null,
+        !moon ? moonKey : null,
+      ]
+        .filter(Boolean)
+        .join(', ');
+
+      throw new ServiceUnavailableException(
+        `캐시 데이터가 부족합니다. 누락 키: ${missing}. Cron 수집기를 먼저 실행하세요.`,
+      );
+    }
+
+    const score = await this.getStarIndexBySpotId(spot.id, {
+      weather,
+      dust,
+      moon,
+      bortleClass: spot.bortleClass,
+      elevationM: spot.elevationM,
+    });
+
+    return { score, cacheKeys: { weatherKey, dustKey, moonKey } };
+  }
 
   // ── 캐시에서 Star-Index 조회 (없으면 계산 후 저장) ──────────
   async getStarIndexBySpotId(spotId: string, input: StarIndexInput): Promise<number> {


### PR DESCRIPTION
## 🔎 What

- TypeOrmSpotRepository를 추가해 spots 테이블(PostGIS) 기반 findById/findNearby/findAll를 구현했습니다.
- GET /star-index?spotId=...를 명소 조회 + 캐시(weather/dust/moon) 기반 계산으로 연결해 0~100 점수를 반환하도록 변경했습니다.
- 캐시가 비어 있으면 503과 함께 누락된 캐시 키를 응답하도록 처리했습니다.
- Cron 수집기를 구현해 기상청·에어코리아·KASI 데이터를 각각 캐시에 저장하도록 했고, API 장애 시 기존 캐시 유지(실패 시 덮어쓰기 없음) 로직을 넣었습니다.
- 검증 편의를 위해 POST /cron/run-once, GET /cron/cache-status 엔드포인트를 추가했습니다.
- SkyModule에서 SkyService를 export하여 CronService DI 오류를 해결했습니다.
- spots GIST 인덱스 SQL(backend/sql/spots-gist-index.sql)을 추가했습니다.

## 🔗 Issue 

- Closes: #20 

## 테스트 결과
<img width="1203" height="471" alt="test1" src="https://github.com/user-attachments/assets/19ea1343-e3dd-4243-98ba-b819266b856b" />
<img width="1202" height="321" alt="test2" src="https://github.com/user-attachments/assets/2ea68e7b-cdef-4417-be36-9cc2614d1ba0" />
<img width="1187" height="433" alt="test3" src="https://github.com/user-attachments/assets/fe441af2-4b46-416c-bdec-6e6d004c026f" />
Swagger를 통해 검증 완료

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
