### PR TITLE
fix(map): CNAME 제거 및 Pages 기본 URL/ENV 설정 정리

### DIFF
--- a/.github/workflows/pages-map.yml
+++ b/.github/workflows/pages-map.yml
@@ -2,9 +2,9 @@ name: Deploy map-site to GitHub Pages
 
 on:
   # develop 브랜치에 "map-site/"가 변경되면 자동 배포
-  # - 앱(WebView)에서 로드할 URL: https://map.starchaser.app/kakao.html
-  # - Kakao Map JavaScript SDK는 "도메인 등록"이 필요해서,
-  #   WebView 안에서 실행될 실제 https 도메인을 하나 마련하는 목적
+  # - 배포 후 URL 예: https://<owner>.github.io/<repo>/kakao.html (커스텀 도메인 없이 GitHub 기본 주소)
+  # - 앱에서는 EXPO_PUBLIC_KAKAO_MAP_PAGE_URL에 위 전체 URL을 넣는다.
+  # - Kakao 개발자 콘솔 "JavaScript SDK 도메인"에는 github.io 호스트를 등록 (예: https://owner.github.io)
   push:
     branches: [develop]
     paths:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,20 @@ npx expo start
 
 ## 지도 (Kakao Map in WebView)
 
-앱에서는 `WebView + Kakao Map JavaScript SDK` 방식으로 지도를 렌더링한다. Kakao JavaScript SDK는 도메인 등록이 필요하므로, `https://map.starchaser.app/kakao.html` 정적 페이지를 GitHub Pages로 배포해 WebView에서 로드한다.
+앱에서는 `WebView + Kakao Map JavaScript SDK` 방식으로 지도를 렌더링한다. Kakao JavaScript SDK는 **허용 도메인**이 필요하므로, `map-site/kakao.html`을 **GitHub Pages**로 올리고 WebView에서 그 **전체 URL**을 연다. (프로젝트/개인별 URL은 다를 수 있음)
+
+1. 레포 **Settings → Pages**에서 Source를 **GitHub Actions**로 켠 뒤, `develop`에 `map-site` 관련 변경이 merge되면 `.github/workflows/pages-map.yml`이 배포한다.
+2. 배포가 끝나면 브라우저로 접속 가능한 주소가 생긴다. 형태는 보통  
+   `https://<GitHub 사용자 또는 조직 이름>.github.io/<레포지토리 이름>/kakao.html`
+3. **Kakao Developers** → 앱 → JavaScript 키 설정의 **JavaScript SDK 도메인**에  
+   `https://<사용자또는조직>.github.io` 를 등록한다 (경로 `/kakao.html` 없이 호스트만 쓰는 경우가 많음. 콘솔 안내에 맞춤).
+4. `frontend/.env`에 아래를 넣는다. (정확한 값은 Pages 배포 후 생성되는 URL)
+
+```env
+EXPO_PUBLIC_KAKAO_MAP_PAGE_URL=https://<owner>.github.io/<repo>/kakao.html
+```
+
+GitHub Actions Secret `KAKAO_JAVASCRIPT_KEY`에 카카오 JavaScript 키를 넣어 두면, 배포 시 `kakao.html`의 플레이스홀더에 주입된다.
 
 
 ---

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,3 @@
-EXPO_PUBLIC_KAKAO_JAVASCRIPT_KEY=
-
+# GitHub Pages에 올린 kakao.html 전체 URL (도메인 구매 없이)
+# 예: https://jjang0617.github.io/StarChaser/kakao.html
+EXPO_PUBLIC_KAKAO_MAP_PAGE_URL=https://jjang0617.github.io/StarChaser/kakao.html

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -31,6 +31,7 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
   const [location, setLocation]   = useState<string>('');
 
   const kakaoJavascriptKey = process.env.EXPO_PUBLIC_KAKAO_JAVASCRIPT_KEY;
+  const kakaoMapPageUrl = process.env.EXPO_PUBLIC_KAKAO_MAP_PAGE_URL;
 
   return (
     <Screen>
@@ -38,6 +39,7 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
       <View style={{ flex: 1 }}>
         {activeTab === 'map' ? (
           <KakaoMapWebView
+            mapPageUrl={kakaoMapPageUrl}
             kakaoJavascriptKey={kakaoJavascriptKey}
             onMessage={(msg) => {
               if (__DEV__) {

--- a/frontend/components/map/KakaoMapWebView.tsx
+++ b/frontend/components/map/KakaoMapWebView.tsx
@@ -23,17 +23,20 @@ function safeJsonParse<T>(raw: string): T | null {
 }
 
 export function KakaoMapWebView({
+  /** GitHub Pages 등에서 호스팅된 kakao.html 전체 URL (예: https://org.github.io/StarChaser/kakao.html) */
+  mapPageUrl,
   kakaoJavascriptKey,
   onMessage,
 }: {
+  mapPageUrl?: string;
   kakaoJavascriptKey: string | undefined;
   onMessage?: (msg: WebToRNMessage) => void;
 }) {
   const webViewRef = useRef<WebView>(null);
 
   const html = useMemo(() => {
-    // 도메인 제한 때문에 "HTML string" 방식은 카카오 JS SDK에서 막힐 수 있음.
-    // 실제 운영은 GitHub Pages(예: https://map.starchaser.app/kakao.html)로 호스팅한 정적 페이지를 로드하는 걸 권장.
+    // 도메인 제한 때문에 카카오 JS SDK는 실제 https URL에서 로드하는 편이 안전함.
+    // 운영: EXPO_PUBLIC_KAKAO_MAP_PAGE_URL (GitHub Pages 기본 주소 등)
 
     // NOTE: ReactNativeWebView bridge is available in WebView context.
     return `<!doctype html>
@@ -144,12 +147,15 @@ export function KakaoMapWebView({
 
   const androidLayer = Platform.OS === 'android' ? { opacity: 0.99 } : null;
 
+  const hasHostedPage = Boolean(mapPageUrl?.trim());
+  const canUseInlineFallback = Boolean(kakaoJavascriptKey);
+
   return (
     <View style={{ flex: 1 }}>
-      {!kakaoJavascriptKey && (
+      {!hasHostedPage && !canUseInlineFallback && (
         <View style={{ padding: 12 }}>
           <Text style={{ fontSize: 12, opacity: 0.8 }}>
-            EXPO_PUBLIC_KAKAO_JAVASCRIPT_KEY가 설정되지 않았습니다.
+            EXPO_PUBLIC_KAKAO_MAP_PAGE_URL(권장) 또는 EXPO_PUBLIC_KAKAO_JAVASCRIPT_KEY를 frontend/.env에 설정하세요.
           </Text>
         </View>
       )}
@@ -158,11 +164,11 @@ export function KakaoMapWebView({
           ref={webViewRef}
           originWhitelist={['*']}
           source={
-            // 키가 없으면 로컬 안내 HTML을 띄우고, 키가 있으면 호스팅된 kakao.html을 띄운다.
-            // (호스팅 페이지에서는 카카오 JS 키를 서버/CI에서 주입)
-            kakaoJavascriptKey
-              ? { uri: 'https://map.starchaser.app/kakao.html' }
-              : { html }
+            hasHostedPage
+              ? { uri: mapPageUrl!.trim() }
+              : canUseInlineFallback
+                ? { html }
+                : { html: '<html><body style="margin:0"></body></html>' }
           }
           javaScriptEnabled
           domStorageEnabled

--- a/map-site/CNAME
+++ b/map-site/CNAME
@@ -1,2 +1,0 @@
-map.starchaser.app
-

--- a/map-site/kakao.html
+++ b/map-site/kakao.html
@@ -9,7 +9,7 @@
 
       이 파일은 "앱 안의 WebView"에서 로드되는 정적 페이지다.
       - 목적: Kakao Map JavaScript SDK는 '허용 도메인' 등록이 필요하므로
-        WebView에서도 실제 https 도메인(예: https://map.starchaser.app)에서 실행되게 한다.
+        WebView에서도 실제 https URL(예: GitHub Pages https://owner.github.io/repo/kakao.html)에서 실행되게 한다.
 
       RN(WebView) ↔ Web 메시지 규격(최소)
       - RN → Web (window.postMessage / WebView postMessage)


### PR DESCRIPTION
## 🔎 What

- map-site/CNAME 제거 (map.starchaser.app 커스텀 도메인 사용 안 함)
- GitHub Pages 기본 URL(https://<owner>.github.io/<repo>/kakao.html)을 지도 페이지로 사용하도록 전환
- pages-map.yml / map-site/kakao.html 주석을 “커스텀 도메인 없이 운영” 흐름에 맞게 정리
- frontend/.env.example 정리: EXPO_PUBLIC_KAKAO_MAP_PAGE_URL만 남기고(필수), JS 키 직접 입력 옵션 제거
- 앱에서 EXPO_PUBLIC_KAKAO_MAP_PAGE_URL을 읽어 WebView가 해당 URL을 로드하도록 수정 (App.tsx, KakaoMapWebView.tsx)

## 🔗 Issue 

- 커스텀 도메인을 GitHub Pages 기본 URL로 전환한 간단한 작업이기 때문에 따로 이슈 생성 안했음.

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
