### PR TITLE
feat(db): photos 마이그레이션 추가와 weather_snapshot 10변수 키 구조 확정

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,13 @@
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage"
+    "test:cov": "jest --coverage",
+    "typeorm": "node --require ts-node/register --require tsconfig-paths/register ./node_modules/typeorm/cli.js -d src/database/data-source.ts",
+    "migration:show": "npm run typeorm -- migration:show",
+    "migration:run": "npm run typeorm -- migration:run",
+    "migration:revert": "npm run typeorm -- migration:revert",
+    "migration:create": "npm run typeorm -- migration:create src/migrations/manual-migration",
+    "migration:generate": "npm run typeorm -- migration:generate src/migrations/auto-migration"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^2.2.0",

--- a/backend/src/common/interfaces/weather-snapshot.ts
+++ b/backend/src/common/interfaces/weather-snapshot.ts
@@ -1,0 +1,33 @@
+/**
+ * observations.weather_snapshot JSONB 표준 구조 (Phase 1.5)
+ * - Star-Index 10변수 점수 스냅샷을 누락 없이 보관한다.
+ * - 점수 범위는 서비스 로직에서 0~100으로 정규화해 저장한다.
+ */
+export interface WeatherSnapshot {
+  cloud_score: number;
+  pm25_score: number;
+  light_pollution_score: number;
+  moon_effect_score: number;
+  humidity_score: number;
+  elevation_score: number;
+  wind_score: number;
+  visibility_score: number;
+  temperature_score: number;
+  correction_score: number;
+
+  // 강수 확률은 10변수 가중치 항목은 아니지만 패널티 계산 추적용으로 보관한다.
+  precipitation_probability?: number;
+}
+
+export const WEATHER_SNAPSHOT_REQUIRED_KEYS: Array<keyof WeatherSnapshot> = [
+  'cloud_score',
+  'pm25_score',
+  'light_pollution_score',
+  'moon_effect_score',
+  'humidity_score',
+  'elevation_score',
+  'wind_score',
+  'visibility_score',
+  'temperature_score',
+  'correction_score',
+];

--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -1,0 +1,25 @@
+import { DataSource } from 'typeorm';
+import { ObservationEntity } from '../observations/observation.entity';
+import { PhotoEntity } from '../photos/photo.entity';
+import { SpotEntity } from '../spots/spot.entity';
+import { UserEntity } from '../users/user.entity';
+import { config } from 'dotenv';
+
+// TypeORM CLI 실행 시에도 backend/.env를 자동 로드한다.
+config({ path: '.env' });
+
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is required for TypeORM migrations.');
+}
+
+export default new DataSource({
+  type: 'postgres',
+  url: databaseUrl,
+  ssl: { rejectUnauthorized: false },
+  entities: [UserEntity, SpotEntity, ObservationEntity, PhotoEntity],
+  migrations: ['src/migrations/*.ts'],
+  synchronize: false,
+  logging: false,
+});

--- a/backend/src/migrations/1712214000000-add-observations-and-photos.ts
+++ b/backend/src/migrations/1712214000000-add-observations-and-photos.ts
@@ -1,0 +1,100 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddObservationsAndPhotos1712214000000 implements MigrationInterface {
+  name = 'AddObservationsAndPhotos1712214000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pgcrypto`);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS observations (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        spot_id uuid NULL REFERENCES spots(id) ON DELETE SET NULL,
+        star_index_val smallint NOT NULL CHECK (star_index_val BETWEEN 0 AND 100),
+        weather_snapshot jsonb NOT NULL,
+        result varchar(16) NOT NULL CHECK (result IN ('success', 'partial', 'fail')),
+        observed_at timestamptz NOT NULL DEFAULT now(),
+        created_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE observations
+      ALTER COLUMN weather_snapshot SET NOT NULL
+    `);
+
+    // Star-Index 10변수 누락 방지: 점수 변수 10개를 weather_snapshot JSONB에 필수 보관
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_constraint
+          WHERE conname = 'CHK_observations_weather_snapshot_required_keys'
+        ) THEN
+          ALTER TABLE observations
+          ADD CONSTRAINT CHK_observations_weather_snapshot_required_keys
+          CHECK (
+            weather_snapshot ? 'cloud_score' AND
+            weather_snapshot ? 'pm25_score' AND
+            weather_snapshot ? 'light_pollution_score' AND
+            weather_snapshot ? 'moon_effect_score' AND
+            weather_snapshot ? 'humidity_score' AND
+            weather_snapshot ? 'elevation_score' AND
+            weather_snapshot ? 'wind_score' AND
+            weather_snapshot ? 'visibility_score' AND
+            weather_snapshot ? 'temperature_score' AND
+            weather_snapshot ? 'correction_score'
+          );
+        END IF;
+      END
+      $$;
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_observations_user_observed_at
+      ON observations(user_id, observed_at DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_observations_spot_observed_at
+      ON observations(spot_id, observed_at DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS photos (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        observation_id uuid NOT NULL REFERENCES observations(id) ON DELETE CASCADE,
+        image_url text NOT NULL,
+        caption varchar(255),
+        taken_at timestamptz,
+        created_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_photos_observation_id
+      ON photos(observation_id)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_photos_created_at
+      ON photos(created_at DESC)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_photos_created_at`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_photos_observation_id`);
+    await queryRunner.query(`DROP TABLE IF EXISTS photos`);
+
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_observations_spot_observed_at`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_observations_user_observed_at`);
+    await queryRunner.query(`
+      ALTER TABLE observations
+      DROP CONSTRAINT IF EXISTS CHK_observations_weather_snapshot_required_keys
+    `);
+    await queryRunner.query(`DROP TABLE IF EXISTS observations`);
+  }
+}

--- a/backend/src/observations/observation.entity.ts
+++ b/backend/src/observations/observation.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { WeatherSnapshot } from '../common/interfaces/weather-snapshot';
+
+@Entity('observations')
+export class ObservationEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({ name: 'spot_id', type: 'uuid', nullable: true })
+  spotId: string | null;
+
+  @Column({ name: 'star_index_val', type: 'smallint' })
+  starIndexVal: number;
+
+  @Column({ name: 'weather_snapshot', type: 'jsonb' })
+  weatherSnapshot: WeatherSnapshot;
+
+  @Column({ type: 'varchar', length: 16 })
+  result: 'success' | 'partial' | 'fail';
+
+  @Column({ name: 'observed_at', type: 'timestamptz', default: () => 'now()' })
+  observedAt: Date;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/photos/photo.entity.ts
+++ b/backend/src/photos/photo.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('photos')
+export class PhotoEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'observation_id', type: 'uuid' })
+  observationId: string;
+
+  @Column({ name: 'image_url', type: 'text' })
+  imageUrl: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  caption: string | null;
+
+  @Column({ name: 'taken_at', type: 'timestamptz', nullable: true })
+  takenAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}


### PR DESCRIPTION
## 🔎 What

2주차 개발 가이드의 C 담당 항목인 `DB 마이그레이션 2차 보완`을 진행했습니다.
- photos 테이블 추가 (Phase 1.5 대비)
- observations 테이블 컬럼 검토 및 weather_snapshot JSONB 구조 확정
- Star-Index 10변수 키 누락 방지 기준 반영

## 주요 변경 사항
### 1) photos 테이블 추가
- `photos` 테이블 마이그레이션 추가
- observations와 FK 연결 (`observation_id`)
- 인덱스 추가
  - `idx_photos_observation_id`
  - `idx_photos_created_at`
### 2) observations 구조 확정
- `observations` 테이블 마이그레이션 포함
- `weather_snapshot`를 `JSONB NOT NULL`로 명시
- `star_index_val` 범위 체크(0~100)
- `result` 값 제한(`success | partial | fail`)
- 인덱스 추가
  - `idx_observations_user_observed_at`
  - `idx_observations_spot_observed_at`
### 3) Star-Index 10변수 키 누락 방지
- `weather_snapshot` 필수 키 체크 제약 추가
  - cloud_score
  - pm25_score
  - light_pollution_score
  - moon_effect_score
  - humidity_score
  - elevation_score
  - wind_score
  - visibility_score
  - temperature_score
  - correction_score
- 코드 레벨에서도 동일 스키마를 사용하도록 `WeatherSnapshot` 인터페이스 추가
### 4) 마이그레이션 실행 체계 보완
- TypeORM migration 스크립트 추가 (`migration:show/run/revert/...`)
- `data-source.ts` 추가
- migration 실행 시 `.env` 자동 로드되도록 설정 (DATABASE_URL 인식 문제 해결)
## 왜 문제가 발생했는가
초기에는 migration CLI 실행 시 `.env`가 자동 로드되지 않아 `DATABASE_URL is required` 에러가 발생했습니다.
Nest 실행 경로와 TypeORM CLI 실행 경로가 다르기 때문에 생긴 문제였고, `data-source.ts`에서 dotenv 로딩을 명시해 해결했습니다.
## .cursorrules 기준 반영
- 환경변수 하드코딩 금지 원칙 준수 (`DATABASE_URL` 기반)
- TypeScript 타입 명시 원칙 반영 (`WeatherSnapshot` 인터페이스)
- DB snake_case 규칙 유지 (`weather_snapshot`, `star_index_val`, `observation_id` 등)
## 변경 파일
- `backend/src/migrations/1712214000000-add-observations-and-photos.ts`
- `backend/src/common/interfaces/weather-snapshot.ts`
- `backend/src/observations/observation.entity.ts`
- `backend/src/photos/photo.entity.ts`
- `backend/src/database/data-source.ts`
- `backend/package.json`
## 검증
- `npm run build` 통과
- `npm test` 통과
- `npm run migration:show` 정상 동작 확인
- `npm run migration:run`로 대상 DB 반영 확인
## 후속 작업
- observations 저장 로직에서 10변수 키를 실제로 weather_snapshot에 저장하는 서비스 연동
- photos CRUD/API는 Phase 1.5 범위에서 별도 진행 

## 🔗 Issue 

- 없음

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
