### PR TITLE
feat(search): pg_trgm 기반 Full-text 검색(tsvector + trigram) 적용

### DIFF
--- a/backend/src/common/interfaces/spot.repository.ts
+++ b/backend/src/common/interfaces/spot.repository.ts
@@ -20,6 +20,7 @@ export interface SpotRepository {
   findById(id: string): Promise<Spot | null>;
   findNearby(lat: number, lng: number, radiusM: number): Promise<Spot[]>;
   findAll(): Promise<Spot[]>;
+  search(keyword: string, limit?: number): Promise<Spot[]>;
 }
 
 // ── 주입 토큰 (NestJS DI용) ──────────────────────────────────

--- a/backend/src/migrations/1712223000000-add-spots-search-vector-with-pgtrgm.ts
+++ b/backend/src/migrations/1712223000000-add-spots-search-vector-with-pgtrgm.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSpotsSearchVectorWithPgtrgm1712223000000 implements MigrationInterface {
+  name = 'AddSpotsSearchVectorWithPgtrgm1712223000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+
+    await queryRunner.query(`
+      ALTER TABLE spots
+      ADD COLUMN IF NOT EXISTS search_vector tsvector
+    `);
+
+    await queryRunner.query(`
+      CREATE OR REPLACE FUNCTION spots_search_vector_update()
+      RETURNS trigger AS $$
+      BEGIN
+        NEW.search_vector :=
+          setweight(to_tsvector('simple', COALESCE(NEW.name, '')), 'A');
+        RETURN NEW;
+      END
+      $$ LANGUAGE plpgsql;
+    `);
+
+    await queryRunner.query(`
+      DROP TRIGGER IF EXISTS trg_spots_search_vector_update ON spots
+    `);
+
+    await queryRunner.query(`
+      CREATE TRIGGER trg_spots_search_vector_update
+      BEFORE INSERT OR UPDATE ON spots
+      FOR EACH ROW EXECUTE FUNCTION spots_search_vector_update()
+    `);
+
+    await queryRunner.query(`
+      UPDATE spots
+      SET search_vector = setweight(to_tsvector('simple', COALESCE(name, '')), 'A')
+      WHERE search_vector IS NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_spots_search_vector
+      ON spots USING gin (search_vector)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_spots_name_trgm
+      ON spots USING gin (name gin_trgm_ops)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_spots_name_trgm`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_spots_search_vector`);
+    await queryRunner.query(`DROP TRIGGER IF EXISTS trg_spots_search_vector_update ON spots`);
+    await queryRunner.query(`DROP FUNCTION IF EXISTS spots_search_vector_update`);
+    await queryRunner.query(`ALTER TABLE spots DROP COLUMN IF EXISTS search_vector`);
+  }
+}

--- a/backend/src/spots/spot.entity.ts
+++ b/backend/src/spots/spot.entity.ts
@@ -32,6 +32,9 @@ export class SpotEntity {
   @Column({ name: 'location_radius_m', type: 'int', nullable: true })
   locationRadiusM: number | null;
 
+  @Column({ name: 'search_vector', type: 'tsvector', nullable: true, select: false })
+  searchVector: string | null;
+
   @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
   createdAt: Date;
 }

--- a/backend/src/spots/spots.controller.ts
+++ b/backend/src/spots/spots.controller.ts
@@ -41,4 +41,15 @@ export class SpotsController {
       Number(radiusM) || 30000,
     );
   }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Get('search')
+  @ApiOperation({ summary: '명소 검색 (tsvector + pg_trgm + ILIKE 하이브리드)' })
+  search(
+    @Query('q') q: string,
+    @Query('limit') limit = '20',
+  ) {
+    return this.spots.search(q ?? '', Number(limit) || 20);
+  }
 }

--- a/backend/src/spots/typeorm-spot.repository.ts
+++ b/backend/src/spots/typeorm-spot.repository.ts
@@ -88,6 +88,43 @@ export class TypeOrmSpotRepository implements SpotRepository {
     return rows.map((r) => this.mapRow(r));
   }
 
+  async search(keyword: string, limit = 20): Promise<Spot[]> {
+    const normalizedKeyword = keyword.trim();
+    if (!normalizedKeyword) {
+      return [];
+    }
+
+    const rows = (await this.repo.query(
+      `
+      SELECT
+        id,
+        name,
+        ST_Y(location::geometry) AS lat,
+        ST_X(location::geometry) AS lng,
+        bortle_class,
+        elevation_m,
+        has_parking,
+        has_toilet,
+        location_radius_m
+      FROM spots
+      WHERE
+        search_vector @@ plainto_tsquery('simple', $1)
+        OR name % $1
+        OR name ILIKE '%' || $1 || '%'
+      ORDER BY
+        GREATEST(
+          ts_rank_cd(search_vector, plainto_tsquery('simple', $1)),
+          similarity(name, $1)
+        ) DESC,
+        name ASC
+      LIMIT $2
+      `,
+      [normalizedKeyword, Math.max(1, Math.min(limit, 50))],
+    )) as Record<string, unknown>[];
+
+    return rows.map((r) => this.mapRow(r));
+  }
+
   private mapRow(row: Record<string, unknown>): Spot {
     return {
       id: String(row.id),


### PR DESCRIPTION
## 🔎 What

- 기존 pg_bigm 계획을 pg_trgm 기반으로 전환하여, 한글 명소 검색(부분 검색 포함) 성능과 유지보수성을 개선했습니다.

## 주요 변경 사항
- `spots` 검색 기능 추가 (`GET /spots/search`)
- 검색 전략: `tsvector + pg_trgm + ILIKE` 하이브리드
- TypeORM migration 추가:
  - `pg_trgm` extension 활성화
  - `spots.search_vector (tsvector)` 컬럼 추가
  - `search_vector` 업데이트 트리거 함수/트리거 생성
  - 기존 데이터 backfill
  - GIN 인덱스 생성
    - `idx_spots_search_vector`
    - `idx_spots_name_trgm`
- `SpotEntity`에 `search_vector` 매핑 추가

## 변경 파일
- `backend/src/migrations/1712223000000-add-spots-search-vector-with-pgtrgm.ts`
- `backend/src/common/interfaces/spot.repository.ts`
- `backend/src/spots/typeorm-spot.repository.ts`
- `backend/src/spots/spots.controller.ts`
- `backend/src/spots/spot.entity.ts`

## 검증
- `npm run build` 통과
- `npm test` 통과
- `npm run migration:show`에서 신규 migration 적용 확인
- 한국어 검색 테스트:
  - `별마로` 검색 결과 정상 조회
<img width="956" height="110" alt="image" src="https://github.com/user-attachments/assets/2d401345-bf20-4e12-b780-83db98ef52af" />
  - `인제`는 현재 데이터셋 기준 매칭 row 0건 확인(쿼리 정상 실행)
<img width="118" height="90" alt="image" src="https://github.com/user-attachments/assets/1a52d2e8-5481-443d-a3fc-4f86773bbe55" />


## 참고
- `.env` 자동 로드 기반 migration 실행 체계 유지
- snake_case(DB) ↔ camelCase(Entity) 매핑 규칙 준수

## 🔗 Issue 

- 없음

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
