### PR TITLE
feat(seed): spots 시딩 스크립트 실행 구조 추가 및 고도 데이터 반영

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,8 @@
     "migration:run": "npm run typeorm -- migration:run",
     "migration:revert": "npm run typeorm -- migration:revert",
     "migration:create": "npm run typeorm -- migration:create src/migrations/manual-migration",
-    "migration:generate": "npm run typeorm -- migration:generate src/migrations/auto-migration"
+    "migration:generate": "npm run typeorm -- migration:generate src/migrations/auto-migration",
+    "seed": "ts-node src/seeds/spots.seed.ts"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^2.2.0",

--- a/backend/src/seeds/spots.seed.ts
+++ b/backend/src/seeds/spots.seed.ts
@@ -1,74 +1,133 @@
+import dataSource from '../database/data-source';
+import { Logger } from '@nestjs/common';
+
+type SpotSeedRow = {
+  name: string;
+  lng: number;
+  lat: number;
+  bortleClass: number;
+  elevationM: number;
+  hasParking: boolean;
+  hasToilet: boolean;
+  locationRadiusM: number;
+};
+
 // ──────────────────────────────────────────────────────────────
 // 명소 Seeding 스크립트 — 지영재(C) 담당
 // elevation_m 필수 입력! (Star-Index GPS 고도 변수 소스)
 // ──────────────────────────────────────────────────────────────
-
-export const spotsSeedData = [
+const spotsSeedData: SpotSeedRow[] = [
   // ⚠️ elevation_m 반드시 입력 — Google Maps 위성 뷰 또는 국토지리정보원 확인
   {
     name: '영월 별마로 천문대',
     // ST_MakePoint(경도, 위도) — 순서 주의!
-    lng: 128.4614,
-    lat: 37.1856,
+    lng: 128.4870,
+    lat: 37.1984,
     bortleClass: 2,
-    elevationM: 799,   // ⭐ 필수
+    elevationM: 769,   // ⭐ 필수
     hasParking: true,
     hasToilet: true,
     locationRadiusM: 200,
   },
   {
     name: '강원 인제 원대리',
-    lng: 128.2167,
-    lat: 38.0833,
+    lng: 128.2292,
+    lat: 37.9995,
     bortleClass: 2,
-    elevationM: 450,   // ⭐ 필수
+    elevationM: 336,   // ⭐ 필수
     hasParking: true,
-    hasToilet: false,
+    hasToilet: true,
     locationRadiusM: 300,
   },
   {
     name: '경북 영양 반딧불이공원',
-    lng: 129.1122,
-    lat: 36.6667,
+    lng: 129.2672,
+    lat: 36.8294,
     bortleClass: 1,
-    elevationM: 280,   // ⭐ 필수
+    elevationM: 318,   // ⭐ 필수
     hasParking: true,
     hasToilet: true,
     locationRadiusM: 200,
   },
   {
     name: '전남 신안 가거도',
-    lng: 125.1167,
-    lat: 34.0833,
+    lng: 125.1131,
+    lat: 34.0714,
     bortleClass: 1,
-    elevationM: 15,    // ⭐ 필수
-    hasParking: false,
+    elevationM: 427,    // ⭐ 필수
+    hasParking: true,
     hasToilet: true,
     locationRadiusM: 500,
   },
   {
     name: '강원 태백 매봉산 풍력단지',
-    lng: 128.9833,
-    lat: 37.1167,
+    lng: 128.9659,
+    lat: 37.2133,
     bortleClass: 2,
-    elevationM: 1303,  // ⭐ 필수
+    elevationM: 1252,  // ⭐ 필수
     hasParking: true,
-    hasToilet: false,
+    hasToilet: true,
     locationRadiusM: 200,
   },
 ];
 
-// ── Supabase SQL 편집기에서 직접 실행하는 INSERT 예시 ─────────
-/*
-INSERT INTO spots (name, location, bortle_class, elevation_m, has_parking, has_toilet, location_radius_m)
-VALUES
-  (
-    '영월 별마로 천문대',
-    ST_SetSRID(ST_MakePoint(128.4614, 37.1856), 4326),
-    2,
-    799,
-    true,
-    true,
-    200
-  );
-*/
+async function seedSpots(): Promise<void> {
+  const logger = new Logger('SpotsSeed');
+  await dataSource.initialize();
+
+  try {
+    for (const spot of spotsSeedData) {
+      await dataSource.query(
+        `
+        INSERT INTO spots (
+          name, location, bortle_class, elevation_m, has_parking, has_toilet, location_radius_m
+        )
+        SELECT
+          $1::varchar,
+          ST_SetSRID(ST_MakePoint($2::double precision, $3::double precision), 4326),
+          $4::smallint,
+          $5::int,
+          $6::boolean,
+          $7::boolean,
+          $8::int
+        WHERE NOT EXISTS (
+          SELECT 1 FROM spots WHERE name = $1::varchar
+        )
+        `,
+        [
+          spot.name,
+          spot.lng,
+          spot.lat,
+          spot.bortleClass,
+          spot.elevationM,
+          spot.hasParking,
+          spot.hasToilet,
+          spot.locationRadiusM,
+        ],
+      );
+    }
+
+    const countRows = (await dataSource.query(
+      `SELECT COUNT(*)::int AS count FROM spots`,
+    )) as Array<{ count: number }>;
+
+    const nullElevationRows = (await dataSource.query(
+      `SELECT COUNT(*)::int AS count FROM spots WHERE elevation_m IS NULL`,
+    )) as Array<{ count: number }>;
+
+    logger.log(
+      `spots 완료 - total: ${countRows[0]?.count ?? 0}, elevation_m null: ${
+        nullElevationRows[0]?.count ?? 0
+      }`,
+    );
+  } finally {
+    await dataSource.destroy();
+  }
+}
+
+seedSpots().catch((error: unknown) => {
+  const logger = new Logger('SpotsSeed');
+  const message = error instanceof Error ? error.message : String(error);
+  logger.error(`spots 실패 - ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## 🔎 What
- `Seeding 스크립트 (spots.seed.ts) 완성` 항목을 진행했습니다.
- TypeScript 기반 시드 실행 구조 추가
- elevation_m 포함 데이터로 실제 시딩 가능 상태 확인

## 주요 변경 사항
- `backend/src/seeds/spots.seed.ts`
  - seed 데이터 타입 정의(`SpotSeedRow`) 추가
  - DB 연결/실행 함수(`seedSpots`) 추가
  - 중복 방지 insert 로직 추가(`WHERE NOT EXISTS`)
  - 시딩 결과 로그 출력 추가(total, elevation_m null count)
  - SQL 파라미터 타입 캐스팅 보완
- `backend/package.json`
  - `seed` 스크립트 추가  
    - `npm run seed` → `ts-node src/seeds/spots.seed.ts`

## 검증
- `npm run build` 통과
- `npm run seed` 실행 성공
- 실행 로그:
  - `spots 완료 - total: 11, elevation_m null: 0`

## 2주차 가이드 반영 포인트
- `src/seeds/spots.seed.ts` TypeScript 작성
- `elevation_m` 필수 데이터 포함
- `package.json`에 seed 스크립트 추가 후 실행 가능한 구조 완료

## 변경 파일
- `backend/src/seeds/spots.seed.ts`
- `backend/package.json`

## 🔗 Issue 

- 없음

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
