### PR TITLE
feat: Star-Index 캐시 계산·Cron 수집·Observation snapshot 검증 연동

### DIFF
--- a/backend/sql/observations-weather-snapshot-check.sql
+++ b/backend/sql/observations-weather-snapshot-check.sql
@@ -1,0 +1,25 @@
+-- observations.weather_snapshot JSONB — Star-Index 10점수 키 필수 (A/C 합의)
+-- TypeORM 마이그레이션을 쓰지 않는 Supabase에서만 수동 실행
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'CHK_observations_weather_snapshot_required_keys'
+  ) THEN
+    ALTER TABLE observations
+    ADD CONSTRAINT CHK_observations_weather_snapshot_required_keys
+    CHECK (
+      weather_snapshot ? 'cloud_score' AND
+      weather_snapshot ? 'pm25_score' AND
+      weather_snapshot ? 'light_pollution_score' AND
+      weather_snapshot ? 'moon_effect_score' AND
+      weather_snapshot ? 'humidity_score' AND
+      weather_snapshot ? 'elevation_score' AND
+      weather_snapshot ? 'wind_score' AND
+      weather_snapshot ? 'visibility_score' AND
+      weather_snapshot ? 'temperature_score' AND
+      weather_snapshot ? 'correction_score'
+    );
+  END IF;
+END
+$$;

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { CronModule } from './cron/cron.module';
 import { SpotsModule } from './spots/spots.module';
 import { StarIndexModule } from './star-index/star-index.module';
 import { SkyModule } from './sky/sky.module';
+import { ObservationsModule } from './observations/observations.module';
 
 @Module({
   imports: [
@@ -50,7 +51,8 @@ import { SkyModule } from './sky/sky.module';
     CronModule,
     SpotsModule,
     StarIndexModule,
-    SkyModule, // 추가
+    SkyModule,
+    ObservationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/common/interfaces/observation.repository.ts
+++ b/backend/src/common/interfaces/observation.repository.ts
@@ -2,12 +2,14 @@
 // ObservationRepository 인터페이스
 // ──────────────────────────────────────────────────────────────
 
+import type { WeatherSnapshot } from './weather-snapshot';
+
 export interface Observation {
   id: string;
   userId: string;
   spotId: string | null;
   starIndexVal: number;
-  weatherSnapshot: Record<string, unknown>; // 9개 변수 스냅샷
+  weatherSnapshot: WeatherSnapshot;
   result: 'success' | 'partial' | 'fail';
   observedAt: Date;
 }

--- a/backend/src/common/interfaces/weather-snapshot.ts
+++ b/backend/src/common/interfaces/weather-snapshot.ts
@@ -1,7 +1,12 @@
 /**
- * observations.weather_snapshot JSONB 표준 구조 (Phase 1.5)
- * - Star-Index 10변수 점수 스냅샷을 누락 없이 보관한다.
- * - 점수 범위는 서비스 로직에서 0~100으로 정규화해 저장한다.
+ * observations.weather_snapshot JSONB 표준 구조 (Star-Index 10변수)
+ *
+ * [크로스체크] A(장성재) / C(지영재) 합의 — 기준 파일: 본 파일
+ * - 확정 키(필수, 10개): *_score 모두 0~100 정규화 점수
+ * - observations.weather_snapshot(JSONB)에 10개 키 필수
+ * - 누락 시 DB CHECK 제약으로 INSERT 실패 (마이그레이션 CHK_observations_weather_snapshot_required_keys)
+ *
+ * moon_effect_score: 달 위상·고도 반영 점수. 원시 moonAltitude(도)는 크로스체크용 선택 필드에만 저장.
  */
 export interface WeatherSnapshot {
   cloud_score: number;
@@ -15,11 +20,17 @@ export interface WeatherSnapshot {
   temperature_score: number;
   correction_score: number;
 
-  // 강수 확률은 10변수 가중치 항목은 아니지만 패널티 계산 추적용으로 보관한다.
+  /** 강수확률(%) — 가중치 항목은 아니나 패널티(60% 이상) 추적용 */
   precipitation_probability?: number;
+
+  /** C와 KASI 크로스체크용 — DB 필수 키 아님 */
+  moon_altitude_deg?: number;
+  /** 달 위상 0~1 — DB 필수 키 아님 */
+  lun_phase?: number;
 }
 
-export const WEATHER_SNAPSHOT_REQUIRED_KEYS: Array<keyof WeatherSnapshot> = [
+/** DB CHECK 및 Observation 저장 시 반드시 존재해야 하는 10개 점수 키 */
+export const WEATHER_SNAPSHOT_SCORE_KEYS = [
   'cloud_score',
   'pm25_score',
   'light_pollution_score',
@@ -30,4 +41,76 @@ export const WEATHER_SNAPSHOT_REQUIRED_KEYS: Array<keyof WeatherSnapshot> = [
   'visibility_score',
   'temperature_score',
   'correction_score',
+] as const satisfies ReadonlyArray<keyof WeatherSnapshot>;
+
+export type WeatherSnapshotScoreKey = (typeof WEATHER_SNAPSHOT_SCORE_KEYS)[number];
+
+/** @deprecated WEATHER_SNAPSHOT_SCORE_KEYS 사용 권장 */
+export const WEATHER_SNAPSHOT_REQUIRED_KEYS: WeatherSnapshotScoreKey[] = [
+  ...WEATHER_SNAPSHOT_SCORE_KEYS,
 ];
+
+export class WeatherSnapshotValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WeatherSnapshotValidationError';
+  }
+}
+
+function clampScore0to100(n: number): number {
+  return Math.min(100, Math.max(0, Math.round(n)));
+}
+
+/**
+ * Observation 저장 전 런타임 검증 — DB 제약 전에 앱에서 명확한 메시지 제공
+ */
+export function assertValidWeatherSnapshotScores(
+  value: unknown,
+): asserts value is WeatherSnapshot {
+  if (value === null || typeof value !== 'object') {
+    throw new WeatherSnapshotValidationError('weather_snapshot은 객체여야 합니다.');
+  }
+  const o = value as Record<string, unknown>;
+  for (const key of WEATHER_SNAPSHOT_SCORE_KEYS) {
+    if (!(key in o)) {
+      throw new WeatherSnapshotValidationError(`weather_snapshot 필수 키 누락: ${key}`);
+    }
+    const n = Number(o[key]);
+    if (!Number.isFinite(n)) {
+      throw new WeatherSnapshotValidationError(`weather_snapshot.${key}는 숫자여야 합니다.`);
+    }
+    if (n < 0 || n > 100) {
+      throw new WeatherSnapshotValidationError(
+        `weather_snapshot.${key}는 0~100 범위여야 합니다. (현재 ${n})`,
+      );
+    }
+  }
+}
+
+/** 저장용: 10개 점수만 추출(클램프) + 선택 필드 유지 */
+export function normalizeWeatherSnapshotForStorage(
+  raw: WeatherSnapshot,
+): WeatherSnapshot {
+  const base: WeatherSnapshot = {
+    cloud_score: clampScore0to100(raw.cloud_score),
+    pm25_score: clampScore0to100(raw.pm25_score),
+    light_pollution_score: clampScore0to100(raw.light_pollution_score),
+    moon_effect_score: clampScore0to100(raw.moon_effect_score),
+    humidity_score: clampScore0to100(raw.humidity_score),
+    elevation_score: clampScore0to100(raw.elevation_score),
+    wind_score: clampScore0to100(raw.wind_score),
+    visibility_score: clampScore0to100(raw.visibility_score),
+    temperature_score: clampScore0to100(raw.temperature_score),
+    correction_score: clampScore0to100(raw.correction_score),
+  };
+  if (raw.precipitation_probability !== undefined) {
+    base.precipitation_probability = raw.precipitation_probability;
+  }
+  if (raw.moon_altitude_deg !== undefined) {
+    base.moon_altitude_deg = raw.moon_altitude_deg;
+  }
+  if (raw.lun_phase !== undefined) {
+    base.lun_phase = raw.lun_phase;
+  }
+  return base;
+}

--- a/backend/src/observations/dto/create-observation.dto.ts
+++ b/backend/src/observations/dto/create-observation.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsIn,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsUUID,
+  Max,
+  Min,
+} from 'class-validator';
+
+export class CreateObservationDto {
+  @ApiPropertyOptional({ description: '명소 ID (없으면 null 저장)' })
+  @IsOptional()
+  @IsUUID()
+  spotId?: string;
+
+  @ApiProperty({ minimum: 0, maximum: 100 })
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  starIndexVal: number;
+
+  @ApiProperty({
+    description:
+      'A/C 합의 10개 score 키 필수 (cloud_score, pm25_score, … correction_score)',
+  })
+  @IsObject()
+  weatherSnapshot: Record<string, unknown>;
+
+  @ApiProperty({ enum: ['success', 'partial', 'fail'] })
+  @IsIn(['success', 'partial', 'fail'])
+  result: 'success' | 'partial' | 'fail';
+}

--- a/backend/src/observations/observation.service.ts
+++ b/backend/src/observations/observation.service.ts
@@ -1,0 +1,62 @@
+import {
+  BadRequestException,
+  Injectable,
+  Inject,
+  Logger,
+} from '@nestjs/common';
+import type { WeatherSnapshot } from '../common/interfaces/weather-snapshot';
+import {
+  assertValidWeatherSnapshotScores,
+  normalizeWeatherSnapshotForStorage,
+  WeatherSnapshotValidationError,
+} from '../common/interfaces/weather-snapshot';
+import {
+  OBSERVATION_REPOSITORY,
+  type ObservationRepository,
+} from '../common/interfaces/observation.repository';
+import type { CreateObservationDto } from './dto/create-observation.dto';
+
+@Injectable()
+export class ObservationService {
+  private readonly logger = new Logger(ObservationService.name);
+
+  constructor(
+    @Inject(OBSERVATION_REPOSITORY)
+    private readonly observations: ObservationRepository,
+  ) {}
+
+  /**
+   * Observation 저장 전 weather_snapshot 10키·0~100 검증 후 정규화 저장
+   * (DB CHECK와 이중 방어)
+   */
+  async create(userId: string, dto: CreateObservationDto) {
+    try {
+      assertValidWeatherSnapshotScores(dto.weatherSnapshot);
+    } catch (e) {
+      if (e instanceof WeatherSnapshotValidationError) {
+        throw new BadRequestException(e.message);
+      }
+      throw e;
+    }
+
+    const weatherSnapshot = normalizeWeatherSnapshotForStorage(
+      dto.weatherSnapshot as WeatherSnapshot,
+    );
+
+    const saved = await this.observations.save({
+      userId,
+      spotId: dto.spotId ?? null,
+      starIndexVal: dto.starIndexVal,
+      weatherSnapshot,
+      result: dto.result,
+      observedAt: new Date(),
+    });
+
+    this.logger.log(`Observation 저장 — id=${saved.id}, user=${userId}`);
+    return saved;
+  }
+
+  async findByUserId(userId: string) {
+    return this.observations.findByUserId(userId);
+  }
+}

--- a/backend/src/observations/observations.controller.ts
+++ b/backend/src/observations/observations.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { JwtValidatedUser } from '../auth/strategies/jwt.strategy';
+import { CreateObservationDto } from './dto/create-observation.dto';
+import { ObservationService } from './observation.service';
+
+@ApiTags('observations')
+@Controller('observations')
+export class ObservationsController {
+  constructor(private readonly observationService: ObservationService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Post()
+  @ApiOperation({
+    summary:
+      '관측 기록 저장 — weather_snapshot 10 score 키 검증 후 JSONB 저장',
+  })
+  create(
+    @CurrentUser() user: JwtValidatedUser,
+    @Body() dto: CreateObservationDto,
+  ) {
+    return this.observationService.create(user.userId, dto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Get('me')
+  @ApiOperation({ summary: '내 관측 기록 목록' })
+  findMine(@CurrentUser() user: JwtValidatedUser) {
+    return this.observationService.findByUserId(user.userId);
+  }
+}

--- a/backend/src/observations/observations.module.ts
+++ b/backend/src/observations/observations.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { OBSERVATION_REPOSITORY } from '../common/interfaces/observation.repository';
+import { ObservationEntity } from './observation.entity';
+import { ObservationService } from './observation.service';
+import { ObservationsController } from './observations.controller';
+import { TypeOrmObservationRepository } from './typeorm-observation.repository';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ObservationEntity]), AuthModule],
+  controllers: [ObservationsController],
+  providers: [
+    ObservationService,
+    TypeOrmObservationRepository,
+    {
+      provide: OBSERVATION_REPOSITORY,
+      useExisting: TypeOrmObservationRepository,
+    },
+  ],
+  exports: [ObservationService, OBSERVATION_REPOSITORY],
+})
+export class ObservationsModule {}

--- a/backend/src/observations/typeorm-observation.repository.ts
+++ b/backend/src/observations/typeorm-observation.repository.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { Observation, ObservationRepository } from '../common/interfaces/observation.repository';
+import { ObservationEntity } from './observation.entity';
+
+@Injectable()
+export class TypeOrmObservationRepository implements ObservationRepository {
+  constructor(
+    @InjectRepository(ObservationEntity)
+    private readonly repo: Repository<ObservationEntity>,
+  ) {}
+
+  async findById(id: string): Promise<Observation | null> {
+    const row = await this.repo.findOne({ where: { id } });
+    return row ? this.toObservation(row) : null;
+  }
+
+  async findByUserId(userId: string): Promise<Observation[]> {
+    const rows = await this.repo.find({
+      where: { userId },
+      order: { observedAt: 'DESC' },
+    });
+    return rows.map((r) => this.toObservation(r));
+  }
+
+  async save(data: Omit<Observation, 'id'>): Promise<Observation> {
+    const entity = this.repo.create({
+      userId: data.userId,
+      spotId: data.spotId,
+      starIndexVal: data.starIndexVal,
+      weatherSnapshot: data.weatherSnapshot,
+      result: data.result,
+      observedAt: data.observedAt ?? new Date(),
+    });
+    const row = await this.repo.save(entity);
+    return this.toObservation(row);
+  }
+
+  async deleteById(id: string): Promise<void> {
+    await this.repo.delete({ id });
+  }
+
+  private toObservation(row: ObservationEntity): Observation {
+    return {
+      id: row.id,
+      userId: row.userId,
+      spotId: row.spotId,
+      starIndexVal: row.starIndexVal,
+      weatherSnapshot: row.weatherSnapshot,
+      result: row.result,
+      observedAt: row.observedAt,
+    };
+  }
+}

--- a/backend/src/star-index/star-index.controller.ts
+++ b/backend/src/star-index/star-index.controller.ts
@@ -50,7 +50,7 @@ export class StarIndexController {
     if (!spot) {
       throw new NotFoundException('해당 spotId의 명소가 없습니다.');
     }
-    const { score, cacheKeys } =
+    const { score, weatherSnapshot, cacheKeys } =
       await this.starIndexService.calculateForSpotFromCache(spot);
     return {
       spotId: spot.id,
@@ -60,8 +60,10 @@ export class StarIndexController {
       elevationM: spot.elevationM,
       bortleClass: spot.bortleClass,
       score,
+      weatherSnapshot,
       cacheKeys,
-      message: '캐시(weather/dust/moon) 기반 Star-Index 계산 완료',
+      message:
+        '캐시(weather/dust/moon) 기반 Star-Index 계산 완료 — weather_snapshot 10키 합의 스키마',
       requestedBy: user.email,
     };
   }

--- a/backend/src/star-index/star-index.service.ts
+++ b/backend/src/star-index/star-index.service.ts
@@ -7,6 +7,8 @@ import {
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import type { Spot } from '../common/interfaces/spot.repository';
+import type { WeatherSnapshot } from '../common/interfaces/weather-snapshot';
+import { normalizeWeatherSnapshotForStorage } from '../common/interfaces/weather-snapshot';
 
 // ── 기상 데이터 타입 ─────────────────────────────────────────
 interface WeatherData {
@@ -24,7 +26,7 @@ interface DustData {
 
 interface MoonData {
   phase: number;       // 달 위상 (0~1, 0=삭, 1=보름)
-  altitude: number;    // 달 고도 (도, 음수=지평선 아래)
+  altitude: number;    // 달 고도 (도, 음수=지평선 아래) — moonAltitude
 }
 
 interface StarIndexInput {
@@ -35,6 +37,9 @@ interface StarIndexInput {
   elevationM: number;  // 해발고도 (m) — GPS 고도 변수
 }
 
+/** star_index:{spotId} 캐시 페이로드 — 레거시 number 캐시는 재계산 시 교체 */
+type StarIndexCachePayload = { score: number; weatherSnapshot: WeatherSnapshot };
+
 @Injectable()
 export class StarIndexService {
   private readonly logger = new Logger(StarIndexService.name);
@@ -43,6 +48,7 @@ export class StarIndexService {
 
   async calculateForSpotFromCache(spot: Spot): Promise<{
     score: number;
+    weatherSnapshot: WeatherSnapshot;
     cacheKeys: { weatherKey: string; dustKey: string; moonKey: string };
   }> {
     const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
@@ -68,7 +74,7 @@ export class StarIndexService {
       );
     }
 
-    const score = await this.getStarIndexBySpotId(spot.id, {
+    const { score, weatherSnapshot } = await this.getStarIndexBySpotId(spot.id, {
       weather,
       dust,
       moon,
@@ -76,59 +82,104 @@ export class StarIndexService {
       elevationM: spot.elevationM,
     });
 
-    return { score, cacheKeys: { weatherKey, dustKey, moonKey } };
+    return {
+      score,
+      weatherSnapshot,
+      cacheKeys: { weatherKey, dustKey, moonKey },
+    };
   }
 
-  // ── 캐시에서 Star-Index 조회 (없으면 계산 후 저장) ──────────
-  async getStarIndexBySpotId(spotId: string, input: StarIndexInput): Promise<number> {
+  /**
+   * 캐시에서 Star-Index 조회 — 없으면 계산 후 { score, weatherSnapshot } 저장
+   * weather_snapshot 10키는 observations 저장·C 크로스체크와 동일 스키마
+   */
+  async getStarIndexBySpotId(
+    spotId: string,
+    input: StarIndexInput,
+  ): Promise<{ score: number; weatherSnapshot: WeatherSnapshot }> {
     const cacheKey = `star_index:${spotId}`;
 
-    // 1. 캐시 히트 확인
-    const cached = await this.cache.get<number>(cacheKey);
+    const cached = await this.cache.get<number | StarIndexCachePayload>(cacheKey);
+
     if (cached !== undefined && cached !== null) {
-      return cached;
+      if (typeof cached === 'number') {
+        const fresh = this.calcStarIndexWithSnapshot(input);
+        await this.cache.set(cacheKey, fresh, 3600 * 1000);
+        this.logger.log(
+          `Star-Index 레거시 캐시 교체 — spot: ${spotId}, score: ${fresh.score}`,
+        );
+        return fresh;
+      }
+      return {
+        score: cached.score,
+        weatherSnapshot: cached.weatherSnapshot,
+      };
     }
 
-    // 2. 캐시 미스 → 계산
-    const score = this.calcStarIndex(input);
+    const payload = this.calcStarIndexWithSnapshot(input);
+    await this.cache.set(cacheKey, payload, 3600 * 1000);
+    this.logger.log(`Star-Index 계산 완료 — spot: ${spotId}, score: ${payload.score}`);
 
-    // 3. 캐시 저장 (TTL 1시간)
-    await this.cache.set(cacheKey, score, 3600 * 1000);
-    this.logger.log(`Star-Index 계산 완료 — spot: ${spotId}, score: ${score}`);
-
-    return score;
+    return payload;
   }
 
-  // ── Star-Index 10변수 계산 알고리즘 ─────────────────────────
+  /** 최종 점수만 필요할 때 */
   calcStarIndex(input: StarIndexInput): number {
+    return this.calcStarIndexWithSnapshot(input).score;
+  }
+
+  /**
+   * 10변수 점수 스냅샷 + 합산 점수
+   * - 보정: correction_score(0~100) × 0.01 가중 — 기본 100이면 기존 +1과 동일
+   * - moon_effect_score: altitude < 0 이면 100(지평선 아래, 달 영향 없음)
+   */
+  calcStarIndexWithSnapshot(input: StarIndexInput): StarIndexCachePayload {
+    const raw = this.buildRawWeatherSnapshot(input);
+    const weatherSnapshot = normalizeWeatherSnapshotForStorage(raw);
+    const score = this.aggregateScoreFromSnapshot(
+      weatherSnapshot,
+      input.weather.pop,
+    );
+    return { score, weatherSnapshot };
+  }
+
+  private buildRawWeatherSnapshot(input: StarIndexInput): WeatherSnapshot {
     const { weather, dust, moon, bortleClass, elevationM } = input;
 
-    // 각 변수를 0~100점으로 정규화
-    const cloudScore      = this.calcCloudScore(weather.cloud);
-    const pm25Score       = this.calcPm25Score(dust.pm25);
-    const lightPollScore  = this.calcLightPollutionScore(bortleClass);
-    const moonScore       = this.calcMoonScore(moon.phase, moon.altitude);
-    const humidityScore   = this.calcHumidityScore(weather.humidity);
-    const elevationScore  = this.calcElevationScore(elevationM);
-    const windScore       = this.calcWindScore(weather.windSpeed);
-    const visibilityScore = this.calcVisibilityScore(weather.visibility);
-    const tempScore       = this.calcTempScore(weather.temperature);
+    return {
+      cloud_score: this.calcCloudScore(weather.cloud),
+      pm25_score: this.calcPm25Score(dust.pm25),
+      light_pollution_score: this.calcLightPollutionScore(bortleClass),
+      moon_effect_score: this.calcMoonScore(moon.phase, moon.altitude),
+      humidity_score: this.calcHumidityScore(weather.humidity),
+      elevation_score: this.calcElevationScore(elevationM),
+      wind_score: this.calcWindScore(weather.windSpeed),
+      visibility_score: this.calcVisibilityScore(weather.visibility),
+      temperature_score: this.calcTempScore(weather.temperature),
+      correction_score: 100,
+      precipitation_probability: weather.pop,
+      moon_altitude_deg: moon.altitude,
+      lun_phase: moon.phase,
+    };
+  }
 
-    // 가중치 합산 (합계 = 100%)
+  private aggregateScoreFromSnapshot(
+    snap: WeatherSnapshot,
+    pop: number,
+  ): number {
     let score =
-      cloudScore      * 0.28 +  // 운량 28%
-      pm25Score       * 0.17 +  // PM2.5 17%
-      lightPollScore  * 0.17 +  // 광공해 17%
-      moonScore       * 0.12 +  // 달 위상×고도 12%
-      humidityScore   * 0.10 +  // 습도 10%
-      elevationScore  * 0.06 +  // GPS 고도 6% ⭐
-      windScore       * 0.04 +  // 풍속 4%
-      visibilityScore * 0.03 +  // 시정 3%
-      tempScore       * 0.02 +  // 기온 2%
-      1;                         // 보정 1% (추후 유저 제보 반영)
+      snap.cloud_score * 0.28 +
+      snap.pm25_score * 0.17 +
+      snap.light_pollution_score * 0.17 +
+      snap.moon_effect_score * 0.12 +
+      snap.humidity_score * 0.1 +
+      snap.elevation_score * 0.06 +
+      snap.wind_score * 0.04 +
+      snap.visibility_score * 0.03 +
+      snap.temperature_score * 0.02 +
+      snap.correction_score * 0.01;
 
-    // 강수 확률 패널티 (60% 이상이면 전체 × 0.4)
-    if (weather.pop >= 60) {
+    if (pop >= 60) {
       score *= 0.4;
     }
 
@@ -138,12 +189,10 @@ export class StarIndexService {
   // ── 각 변수 점수 계산 함수들 ─────────────────────────────────
 
   private calcCloudScore(cloud: number): number {
-    // 운량 0% = 100점, 100% = 0점 (선형)
     return Math.max(0, 100 - cloud);
   }
 
   private calcPm25Score(pm25: number): number {
-    // 좋음(0~15) = 100 / 보통(16~35) = 75 / 나쁨(36~75) = 40 / 매우나쁨(76+) = 0
     if (pm25 <= 15) return 100;
     if (pm25 <= 35) return 75;
     if (pm25 <= 75) return 40;
@@ -151,127 +200,116 @@ export class StarIndexService {
   }
 
   private calcLightPollutionScore(bortleClass: number): number {
-    // Bortle 1(완전 암흑) = 100점, Bortle 9(도심) = 0점
-    return Math.max(0, Math.round((9 - bortleClass) / 8 * 100));
+    return Math.max(0, Math.round(((9 - bortleClass) / 8) * 100));
   }
 
   private calcMoonScore(phase: number, altitudeDeg: number): number {
-    // 달이 지평선 아래면 영향 없음 (MoonEffect = 0)
     if (altitudeDeg < 0) return 100;
-    // 고도 비례 영향: 보름달 + 고도 90도 = 최대 감점
     const moonEffect = phase * (altitudeDeg / 90);
     return Math.round((1 - moonEffect) * 100);
   }
 
   private calcHumidityScore(humidity: number): number {
-    // 70% 이하 = 100점, 90% 이상 = 0점
     if (humidity <= 70) return 100;
     if (humidity >= 90) return 0;
-    return Math.round((90 - humidity) / 20 * 100);
+    return Math.round(((90 - humidity) / 20) * 100);
   }
 
   private calcElevationScore(elevationM: number): number {
-    // 해발 0m = 0점, 500m 이상 = 100점 (선형)
     return Math.min(100, Math.round(elevationM / 5));
   }
 
   private calcWindScore(windSpeed: number): number {
-    // 5m/s 이하 = 100점, 10m/s 이상 = 0점
     if (windSpeed <= 5) return 100;
     if (windSpeed >= 10) return 0;
-    return Math.round((10 - windSpeed) / 5 * 100);
+    return Math.round(((10 - windSpeed) / 5) * 100);
   }
 
   private calcVisibilityScore(visibilityKm: number): number {
-    // 10km 이상 = 100점, 5km 미만 = 0점
     if (visibilityKm >= 10) return 100;
     if (visibilityKm < 5) return 0;
-    return Math.round((visibilityKm - 5) / 5 * 100);
+    return Math.round(((visibilityKm - 5) / 5) * 100);
   }
 
   private calcTempScore(temp: number): number {
-    // 5~20℃ 최적 = 100점, 극단값 감점
     if (temp >= 5 && temp <= 20) return 100;
     if (temp < -10 || temp > 35) return 20;
     return 60;
-
-    
   }
 
-// ── 기상청 격자 좌표 변환 (위도·경도 → nx, ny) ───────────────
-private latLngToGrid(lat: number, lng: number): { nx: number; ny: number } {
-  const RE = 6371.00877;   // 지구 반경 (km)
-  const GRID = 5.0;        // 격자 간격 (km)
-  const SLAT1 = 30.0;      // 투영 위도 1 (도)
-  const SLAT2 = 60.0;      // 투영 위도 2 (도)
-  const OLON = 126.0;      // 기준점 경도 (도)
-  const OLAT = 38.0;       // 기준점 위도 (도)
-  const XO = 43;           // 기준점 X 좌표 (격자)
-  const YO = 136;          // 기준점 Y 좌표 (격자)
+  // ── 기상청 격자 좌표 변환 (위도·경도 → nx, ny) ───────────────
+  private latLngToGrid(lat: number, lng: number): { nx: number; ny: number } {
+    const RE = 6371.00877;
+    const GRID = 5.0;
+    const SLAT1 = 30.0;
+    const SLAT2 = 60.0;
+    const OLON = 126.0;
+    const OLAT = 38.0;
+    const XO = 43;
+    const YO = 136;
 
-  const DEGRAD = Math.PI / 180.0;
+    const DEGRAD = Math.PI / 180.0;
 
-  const re = RE / GRID;
-  const slat1 = SLAT1 * DEGRAD;
-  const slat2 = SLAT2 * DEGRAD;
-  const olon = OLON * DEGRAD;
-  const olat = OLAT * DEGRAD;
+    const re = RE / GRID;
+    const slat1 = SLAT1 * DEGRAD;
+    const slat2 = SLAT2 * DEGRAD;
+    const olon = OLON * DEGRAD;
+    const olat = OLAT * DEGRAD;
 
-  let sn = Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(Math.PI * 0.25 + slat1 * 0.5);
-  sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn);
+    let sn =
+      Math.tan(Math.PI * 0.25 + slat2 * 0.5) /
+      Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn);
 
-  let sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5);
-  sf = (Math.pow(sf, sn) * Math.cos(slat1)) / sn;
+    let sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+    sf = (Math.pow(sf, sn) * Math.cos(slat1)) / sn;
 
-  let ro = Math.tan(Math.PI * 0.25 + olat * 0.5);
-  ro = (re * sf) / Math.pow(ro, sn);
+    let ro = Math.tan(Math.PI * 0.25 + olat * 0.5);
+    ro = (re * sf) / Math.pow(ro, sn);
 
-  const ra = Math.tan(Math.PI * 0.25 + lat * DEGRAD * 0.5);
-  const raVal = (re * sf) / Math.pow(ra, sn);
+    const ra = Math.tan(Math.PI * 0.25 + lat * DEGRAD * 0.5);
+    const raVal = (re * sf) / Math.pow(ra, sn);
 
-  let theta = lng * DEGRAD - olon;
-  if (theta > Math.PI) theta -= 2.0 * Math.PI;
-  if (theta < -Math.PI) theta += 2.0 * Math.PI;
-  theta *= sn;
+    let theta = lng * DEGRAD - olon;
+    if (theta > Math.PI) theta -= 2.0 * Math.PI;
+    if (theta < -Math.PI) theta += 2.0 * Math.PI;
+    theta *= sn;
 
-  const nx = Math.floor(raVal * Math.sin(theta) + XO + 0.5);
-  const ny = Math.floor(ro - raVal * Math.cos(theta) + YO + 0.5);
+    const nx = Math.floor(raVal * Math.sin(theta) + XO + 0.5);
+    const ny = Math.floor(ro - raVal * Math.cos(theta) + YO + 0.5);
 
-  return { nx, ny };
-}
-
-
-async testApiConnections(lat = 37.5665, lng = 126.9780): Promise<void> {
-  const KMA_KEY = process.env.KMA_API_KEY;
-  const AIRKOREA_KEY = process.env.AIRKOREA_API_KEY;
-
-  // GPS → 기상청 격자 변환
-  const { nx, ny } = this.latLngToGrid(lat, lng);
-  this.logger.log(`격자 변환 결과 — lat: ${lat}, lng: ${lng} → nx: ${nx}, ny: ${ny}`);
-
-  const now = new Date();
-  const baseDate = now.toISOString().slice(0, 10).replace(/-/g, '');
-  const baseTime = '0500';
-
-  const kmaUrl = `https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=${KMA_KEY}&numOfRows=10&pageNo=1&dataType=JSON&base_date=${baseDate}&base_time=${baseTime}&nx=${nx}&ny=${ny}`;
-
-  const airUrl = `https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty?serviceKey=${AIRKOREA_KEY}&returnType=json&numOfRows=5&pageNo=1&sidoName=서울&ver=1.0`;
-
-  try {
-    const [kmaRes, airRes] = await Promise.all([
-      fetch(kmaUrl),
-      fetch(airUrl),
-    ]);
-
-    const kmaData = await kmaRes.json();
-    const airData = await airRes.json();
-
-    this.logger.log(`기상청 API 응답: ${JSON.stringify(kmaData).slice(0, 200)}`);
-    this.logger.log(`에어코리아 API 응답: ${JSON.stringify(airData).slice(0, 200)}`);
-
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    this.logger.error(`API 호출 실패: ${msg}`);
+    return { nx, ny };
   }
-}
+
+  async testApiConnections(lat = 37.5665, lng = 126.9780): Promise<void> {
+    const KMA_KEY = process.env.KMA_API_KEY;
+    const AIRKOREA_KEY = process.env.AIRKOREA_API_KEY;
+
+    const { nx, ny } = this.latLngToGrid(lat, lng);
+    this.logger.log(`격자 변환 결과 — lat: ${lat}, lng: ${lng} → nx: ${nx}, ny: ${ny}`);
+
+    const now = new Date();
+    const baseDate = now.toISOString().slice(0, 10).replace(/-/g, '');
+    const baseTime = '0500';
+
+    const kmaUrl = `https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=${KMA_KEY}&numOfRows=10&pageNo=1&dataType=JSON&base_date=${baseDate}&base_time=${baseTime}&nx=${nx}&ny=${ny}`;
+
+    const airUrl = `https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty?serviceKey=${AIRKOREA_KEY}&returnType=json&numOfRows=5&pageNo=1&sidoName=서울&ver=1.0`;
+
+    try {
+      const [kmaRes, airRes] = await Promise.all([
+        fetch(kmaUrl),
+        fetch(airUrl),
+      ]);
+
+      const kmaData = await kmaRes.json();
+      const airData = await airRes.json();
+
+      this.logger.log(`기상청 API 응답: ${JSON.stringify(kmaData).slice(0, 200)}`);
+      this.logger.log(`에어코리아 API 응답: ${JSON.stringify(airData).slice(0, 200)}`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.logger.error(`API 호출 실패: ${msg}`);
+    }
+  }
 }


### PR DESCRIPTION
## 🔎 What

- Star-Index API

GET /star-index?spotId=가 실제 캐시(weather/dust/moon)를 읽어 0~100 점수를 반환하도록 구현
weatherSnapshot(10개 score + 선택 필드) 응답 포함
캐시 누락 시 503 Service Unavailable + 누락 키 안내

- 검증용 엔드포인트 추가:
POST /cron/run-once
GET /cron/cache-status
SpotRepository

- weather-snapshot.ts에 확정 10개 키 명세
normalizeWeatherSnapshotForStorage, assertValidWeatherSnapshotScores 추가
Observation 저장 시 앱 레벨 선검증 + DB CHECK 이중 방어 적용
Observation API/모듈

- POST /observations (JWT) 저장 API 추가
GET /observations/me 조회 API 추가
ObservationsModule, TypeOrmObservationRepository, DTO/Service 구성

## 🔗 Issue 

- Closes: #31 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
