### PR TITLE
feat: 로그인/회원가입 UI 및 JWT 세션 연동

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,73 @@ cd backend
 npm install
 cp .env.example .env
 # .env 파일에 팀 공유 값 입력 (단톡 확인)
+```
+
+백엔드는 모바일(Expo Go)에서 접근 가능하게 실행해야 한다.
+
+- macOS/Linux
+```bash
+HOST=0.0.0.0 PORT=3333 npm run start:dev
+```
+
+- Windows cmd
+```bat
+set HOST=0.0.0.0
+set PORT=3333
 npm run start:dev
 ```
+
+정상 기준:
+- `http://localhost:3333/api-docs` 접속 가능
+- 같은 와이파이의 폰 브라우저에서 `http://<내PCIP>:3333/api-docs` 접속 가능
 
 ### 3. 프론트엔드 세팅
 ```bash
 cd frontend
 npm install
 cp .env.example .env
-npx expo start
-# 폰에 Expo Go 앱 설치 후 QR 스캔
 ```
+
+`frontend/.env` 예시:
+```env
+EXPO_PUBLIC_API_URL=http://<내PCIP>:3333
+EXPO_PUBLIC_DEFAULT_SPOT_ID=<spots.id UUID>
+```
+
+주의:
+- Expo Go(폰)에서 `127.0.0.1`은 폰 자기 자신을 의미하므로 사용 금지
+- 반드시 백엔드가 열려 있는 PC의 LAN IP 사용
+
+실행:
+- macOS/Linux
+```bash
+EXPO_PACKAGER_HOSTNAME=<내PCIP> npx expo start --host lan --clear
+```
+
+- Windows cmd
+```bat
+set EXPO_PACKAGER_HOSTNAME=<내PCIP>
+npm run start -- --host lan --clear
+```
+
+정상 기준:
+- 터미널에 `Metro waiting on exp://<내PCIP>:8081` 출력
+- 폰에서 QR 스캔 후 앱 하단 `API:` 문구가 `http://<내PCIP>:3333`로 표시
+
+### 4. 로그인/Star-Index 확인
+1. 앱에서 회원가입 또는 로그인
+2. Star-Index 카드에 캐시 부족 오류가 보이면 Swagger에서 `POST /cron/run-once` 1회 실행
+3. 앱에서 `다시 시도` 버튼으로 갱신
+
+---
+
+### 문제 해결 (자주 발생)
+- `ConfigError: .../starchaser/package.json does not exist`  
+  → `frontend` 또는 `backend` 폴더로 이동 후 실행
+- `listen EFAULT ... :::8081`  
+  → `--host lan --clear` + `EXPO_PACKAGER_HOSTNAME=<내PCIP>`로 재실행
+- 앱에서 `알 수 없는 오류` 또는 네트워크 오류  
+  → 앱 하단 `API:`가 `127.0.0.1`인지 먼저 확인 (PC IP로 교체 필요)
 
 ---
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,10 @@
-# GitHub Pages에 올린 kakao.html 전체 URL (도메인 구매 없이)
-# 예: https://jjang0617.github.io/StarChaser/kakao.html
-EXPO_PUBLIC_KAKAO_MAP_PAGE_URL=https://jjang0617.github.io/StarChaser/kakao.html
+# 백엔드 베이스 URL (끝에 / 붙이지 않음)
+# 에뮬레이터/실기기에서 PC의 Nest에 붙을 때는 127.0.0.1 대신 LAN IP 사용
+EXPO_PUBLIC_API_URL=http://127.0.0.1:3333
+
+# Star-Index 카드에 쓸 명소 UUID (spots.id) — 시드 후 DB/Swagger에서 복사
+EXPO_PUBLIC_DEFAULT_SPOT_ID=
+
+# (선택) 카카오맵
+# EXPO_PUBLIC_KAKAO_JAVASCRIPT_KEY=
+# EXPO_PUBLIC_KAKAO_MAP_PAGE_URL=

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,16 +1,22 @@
 /**
  * StarChaser — App.tsx
- * ThemeProvider로 전체 감싸기
- * 기존 App 구조 유지하면서 새 컴포넌트 적용
+ * AuthProvider → 온보딩 → 메인. Star-Index는 GET /star-index?spotId= 연동.
  */
 
 import { StatusBar } from 'expo-status-bar';
 import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, ScrollView, Text, StyleSheet, View } from 'react-native';
+import {
+  ActivityIndicator,
+  ScrollView,
+  Text,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { ThemeProvider, useTheme } from './themes/ThemeContext';
+import { AuthProvider, useAuth } from './contexts/auth-context';
 import {
   Badge,
   BottomTab,
@@ -23,15 +29,65 @@ import {
 } from './components/ui';
 import { OnboardingFlow } from './components/onboarding/OnboardingFlow';
 import { KakaoMapWebView } from './components/map/KakaoMapWebView';
+import { AuthScreen } from './components/auth/auth-screen';
+import { getDefaultSpotId } from './lib/config';
+import {
+  ApiRequestError,
+  fetchStarIndex,
+  SessionExpiredError,
+} from './lib/api-client';
+import { starIndexResponseToCardModel } from './lib/star-index-display';
+import type { StarIndexResponseDto } from './lib/types/api';
 
-// ── 실제 앱 내용 — ThemeProvider 안에서 useTheme() 사용 가능 ──
 function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
   const { theme, toggleRed, isRedMode } = useTheme();
+  const { user, logout, onSessionInvalidated } = useAuth();
   const [activeTab, setActiveTab] = useState<string>('home');
-  const [location, setLocation]   = useState<string>('');
+  const [location, setLocation] = useState<string>('');
+
+  const defaultSpotId = getDefaultSpotId();
+  const [siLoading, setSiLoading] = useState(false);
+  const [siError, setSiError] = useState<string | null>(null);
+  const [siData, setSiData] = useState<StarIndexResponseDto | null>(null);
+  const [siRefreshKey, setSiRefreshKey] = useState(0);
+
+  useEffect(() => {
+    if (!defaultSpotId) {
+      setSiData(null);
+      setSiError(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setSiLoading(true);
+      setSiError(null);
+      try {
+        const data = await fetchStarIndex(defaultSpotId);
+        if (!cancelled) setSiData(data);
+      } catch (e) {
+        if (e instanceof SessionExpiredError) {
+          await onSessionInvalidated();
+          return;
+        }
+        if (e instanceof ApiRequestError) {
+          if (!cancelled) setSiError(e.message);
+        } else if (!cancelled) {
+          setSiError('Star-Index를 불러오지 못했습니다.');
+        }
+        if (!cancelled) setSiData(null);
+      } finally {
+        if (!cancelled) setSiLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [defaultSpotId, siRefreshKey, onSessionInvalidated]);
 
   const kakaoJavascriptKey = process.env.EXPO_PUBLIC_KAKAO_JAVASCRIPT_KEY;
   const kakaoMapPageUrl = process.env.EXPO_PUBLIC_KAKAO_MAP_PAGE_URL;
+
+  const starProps = siData ? starIndexResponseToCardModel(siData) : null;
 
   return (
     <Screen>
@@ -54,13 +110,30 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
           >
-            {/* 헤더 */}
-            <Text style={[styles.appTitle, { color: theme.foreground, fontFamily: 'SpaceMono-Regular' }]}>
+            <Text
+              style={[
+                styles.appTitle,
+                { color: theme.foreground, fontFamily: 'SpaceMono-Regular' },
+              ]}
+            >
               StarChaser
             </Text>
-            <Text style={[styles.appSub, { color: theme.mutedForeground, fontFamily: 'SpaceMono-Regular' }]}>
-              Anti-AI Component v2.0
-            </Text>
+            <View style={styles.headerRow}>
+              <Text
+                style={[
+                  styles.appSub,
+                  { color: theme.mutedForeground, fontFamily: 'SpaceMono-Regular' },
+                ]}
+              >
+                {user?.email ?? ''}
+              </Text>
+              <Button
+                label="로그아웃"
+                variant="ghost"
+                size="sm"
+                onPress={() => void logout()}
+              />
+            </View>
             {__DEV__ && (
               <View style={styles.devRow}>
                 <Button
@@ -68,10 +141,15 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
                   variant="outline"
                   onPress={onResetOnboarding}
                 />
+                <Button
+                  label="DEV: 로그아웃"
+                  variant="ghost"
+                  size="sm"
+                  onPress={() => void logout()}
+                />
               </View>
             )}
 
-            {/* Badge 샘플 */}
             <View style={styles.row}>
               <Badge label="Bortle 3" variant="gold" mono />
               <Badge label="▲ 757m" variant="steel" mono />
@@ -79,27 +157,72 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
               <Badge label="Red Mode" variant="red" />
             </View>
 
-            {/* Star-Index 카드 */}
-            <StarIndexCard
-              score={78}
-              cloudCover={15}
-              pm25Level="보통"
-              moonAltitude={12}
-            />
+            {/* Star-Index — GET /star-index?spotId= */}
+            {!defaultSpotId ? (
+              <Card
+                title="Star-Index"
+                description="EXPO_PUBLIC_DEFAULT_SPOT_ID에 spots.id(UUID)를 넣으면 서버에서 점수를 불러옵니다."
+              >
+                <Text style={{ color: theme.mutedForeground, fontSize: 12 }}>
+                  예: 시드 영월 별마로 천문대 UUID를 .env에 설정하세요.
+                </Text>
+              </Card>
+            ) : siLoading ? (
+              <Card title="Star-Index" description="불러오는 중…">
+                <ActivityIndicator color={theme.starGold} />
+              </Card>
+            ) : siError ? (
+              <Card title="Star-Index" description="오류">
+                <Text style={{ color: theme.dimRedFg, fontSize: 12 }}>{siError}</Text>
+                <Button
+                  label="다시 시도"
+                  variant="outline"
+                  size="sm"
+                  style={{ marginTop: 10 }}
+                  onPress={() => setSiRefreshKey((k) => k + 1)}
+                />
+              </Card>
+            ) : starProps ? (
+              <View style={{ gap: 8 }}>
+                <StarIndexCard
+                  score={starProps.score}
+                  cloudCover={starProps.cloudCover}
+                  pm25Level={starProps.pm25Level}
+                  moonAltitude={starProps.moonAltitude}
+                  moonAltitudeKnown={starProps.moonAltitudeKnown}
+                />
+                <Button
+                  label="Star-Index 새로고침"
+                  variant="outline"
+                  size="sm"
+                  onPress={() => setSiRefreshKey((k) => k + 1)}
+                />
+              </View>
+            ) : null}
 
-            {/* 명소 카드 */}
-            <SpotCard
-              name="화왕산 억새평원"
-              region="창녕군"
-              elevation={757}
-              bortleClass={3}
-              starIndex={78}
-              hasParking
-              hasToilet
-              distanceKm={23}
-            />
+            {siData ? (
+              <SpotCard
+                name={siData.name}
+                region={`${siData.lat.toFixed(4)} · ${siData.lng.toFixed(4)}`}
+                elevation={siData.elevationM}
+                bortleClass={siData.bortleClass}
+                starIndex={siData.score}
+                hasParking={false}
+                hasToilet={false}
+              />
+            ) : (
+              <SpotCard
+                name="화왕산 억새평원"
+                region="창녕군"
+                elevation={757}
+                bortleClass={3}
+                starIndex={78}
+                hasParking
+                hasToilet
+                distanceKm={23}
+              />
+            )}
 
-            {/* 기본 Card */}
             <Card title="오늘의 관측 조건" description="기상/달/광공해 데이터 기반 실시간 계산">
               <View style={styles.cardInner}>
                 <Input
@@ -122,17 +245,16 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
           </ScrollView>
         )}
 
-        {/* BottomTab */}
         <View style={styles.tabWrap}>
           <BottomTab
             activeKey={activeTab}
             onChange={setActiveTab}
             items={[
-              { key: 'home',    label: 'Home',   icon: '⭐', redIcon: '★' },
-              { key: 'map',     label: 'Map',    icon: '🗺',  redIcon: '◈', hasDot: true },
-              { key: 'sky',     label: 'Sky',    icon: '🌌', redIcon: '◉' },
-              { key: 'records', label: 'Log',    icon: '📋', redIcon: '≡' },
-              { key: 'profile', label: 'Me',     icon: '👤', redIcon: '○' },
+              { key: 'home', label: 'Home', icon: '⭐', redIcon: '★' },
+              { key: 'map', label: 'Map', icon: '🗺', redIcon: '◈', hasDot: true },
+              { key: 'sky', label: 'Sky', icon: '🌌', redIcon: '◉' },
+              { key: 'records', label: 'Log', icon: '📋', redIcon: '≡' },
+              { key: 'profile', label: 'Me', icon: '👤', redIcon: '○' },
             ]}
           />
         </View>
@@ -147,7 +269,12 @@ function AppLoading() {
     <Screen>
       <View style={styles.loadingWrap}>
         <ActivityIndicator color={theme.starGold} />
-        <Text style={[styles.loadingText, { color: theme.mutedForeground, fontFamily: 'SpaceMono-Regular' }]}>
+        <Text
+          style={[
+            styles.loadingText,
+            { color: theme.mutedForeground, fontFamily: 'SpaceMono-Regular' },
+          ]}
+        >
           로딩 중...
         </Text>
       </View>
@@ -155,9 +282,12 @@ function AppLoading() {
   );
 }
 
-// ── 루트: ThemeProvider로 전체 감싸기 ──
-export default function App() {
-  const [status, setStatus] = useState<'loading' | 'onboarding' | 'ready'>('loading');
+/**
+ * 인증 후 온보딩 여부만 분기 — 로그아웃 시 AuthScreen
+ */
+function AppGate() {
+  const { isHydrated, isAuthenticated } = useAuth();
+  const [route, setRoute] = useState<'boot' | 'onboarding' | 'ready'>('boot');
 
   const resetOnboarding = useCallback(async () => {
     await Promise.all([
@@ -166,36 +296,43 @@ export default function App() {
       AsyncStorage.removeItem('starChaser:notificationPrefs'),
       AsyncStorage.removeItem('starChaser:onboardInterests'),
     ]);
-    setStatus('onboarding');
+    setRoute('onboarding');
   }, []);
 
   useEffect(() => {
+    if (!isHydrated || !isAuthenticated) return;
     let mounted = true;
     (async () => {
       try {
         const completed = await AsyncStorage.getItem('starChaser:onboardingCompleted');
         if (!mounted) return;
-        setStatus(completed === 'true' ? 'ready' : 'onboarding');
+        setRoute(completed === 'true' ? 'ready' : 'onboarding');
       } catch {
         if (!mounted) return;
-        setStatus('onboarding');
+        setRoute('onboarding');
       }
     })();
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [isHydrated, isAuthenticated]);
 
+  if (!isHydrated) return <AppLoading />;
+  if (!isAuthenticated) return <AuthScreen />;
+  if (route === 'boot') return <AppLoading />;
+  if (route === 'onboarding') {
+    return <OnboardingFlow onDone={() => setRoute('ready')} />;
+  }
+  return <AppContent onResetOnboarding={resetOnboarding} />;
+}
+
+export default function App() {
   return (
     <SafeAreaProvider>
       <ThemeProvider>
-        {status === 'loading' ? (
-          <AppLoading />
-        ) : status === 'onboarding' ? (
-          <OnboardingFlow onDone={() => setStatus('ready')} />
-        ) : (
-          <AppContent onResetOnboarding={resetOnboarding} />
-        )}
+        <AuthProvider>
+          <AppGate />
+        </AuthProvider>
       </ThemeProvider>
     </SafeAreaProvider>
   );
@@ -203,22 +340,30 @@ export default function App() {
 
 const styles = StyleSheet.create({
   scrollContent: {
-    gap:         12,
+    gap: 12,
     paddingBottom: 20,
   },
   appTitle: {
-    fontSize:      22,
-    fontWeight:    '700',
+    fontSize: 22,
+    fontWeight: '700',
     letterSpacing: -0.5,
   },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
   appSub: {
-    fontSize:      10,
-    letterSpacing:  1,
+    fontSize: 10,
+    letterSpacing: 1,
+    flex: 1,
   },
   row: {
     flexDirection: 'row',
-    flexWrap:      'wrap',
-    gap:            6,
+    flexWrap: 'wrap',
+    gap: 6,
   },
   cardInner: {
     gap: 8,
@@ -229,6 +374,7 @@ const styles = StyleSheet.create({
   devRow: {
     marginTop: 8,
     alignItems: 'flex-start',
+    gap: 8,
   },
   loadingWrap: {
     flex: 1,

--- a/frontend/components/auth/auth-screen.tsx
+++ b/frontend/components/auth/auth-screen.tsx
@@ -1,0 +1,180 @@
+import React, { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useTheme } from '../../themes/ThemeContext';
+import { useAuth } from '../../contexts/auth-context';
+import { Button, Input, Screen } from '../ui';
+import { ApiRequestError } from '../../lib/api-client';
+
+type Mode = 'login' | 'register';
+
+/**
+ * 로그인 / 회원가입 — POST /auth/login · /auth/register
+ */
+export function AuthScreen() {
+  const { theme } = useTheme();
+  const { login, register } = useAuth();
+  const [mode, setMode] = useState<Mode>('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async () => {
+    setError(null);
+    const apiUrl = process.env.EXPO_PUBLIC_API_URL?.trim() || 'http://127.0.0.1:3333';
+    const trimmed = email.trim().toLowerCase();
+    if (!trimmed || !password) {
+      setError('이메일과 비밀번호를 입력해 주세요.');
+      return;
+    }
+    if (password.length < 6) {
+      setError('비밀번호는 6자 이상이어야 합니다.');
+      return;
+    }
+    setLoading(true);
+    try {
+      if (mode === 'login') {
+        await login(trimmed, password);
+      } else {
+        await register(trimmed, password);
+      }
+    } catch (e) {
+      if (e instanceof ApiRequestError) {
+        setError(e.message);
+      } else {
+        // fetch 네트워크 에러는 대부분 TypeError로 떨어짐 (Expo Go에서 127.0.0.1 등)
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.toLowerCase().includes('network') || msg.toLowerCase().includes('failed')) {
+          setError(
+            `네트워크 오류로 서버에 연결할 수 없습니다.\nAPI URL을 확인해 주세요: ${apiUrl}`,
+          );
+        } else {
+          setError('알 수 없는 오류가 발생했습니다.');
+        }
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Screen>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scroll}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          <Text style={[styles.title, { color: theme.foreground }]}>
+            StarChaser
+          </Text>
+          <Text style={[styles.sub, { color: theme.mutedForeground }]}>
+            {mode === 'login' ? '로그인' : '회원가입'}
+          </Text>
+
+          <View style={styles.tabRow}>
+            <Button
+              label="로그인"
+              variant={mode === 'login' ? 'primary' : 'outline'}
+              size="sm"
+              onPress={() => {
+                setMode('login');
+                setError(null);
+              }}
+            />
+            <Button
+              label="회원가입"
+              variant={mode === 'register' ? 'primary' : 'outline'}
+              size="sm"
+              onPress={() => {
+                setMode('register');
+                setError(null);
+              }}
+            />
+          </View>
+
+          <View style={styles.form}>
+            <Input
+              label="이메일"
+              monoLabel
+              value={email}
+              onChangeText={setEmail}
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="email-address"
+              placeholder="you@example.com"
+            />
+            <Input
+              label="비밀번호"
+              monoLabel
+              value={password}
+              onChangeText={setPassword}
+              secureTextEntry
+              placeholder="6자 이상"
+            />
+            {error && (
+              <Text style={[styles.err, { color: theme.dimRedFg }]}>
+                {error}
+              </Text>
+            )}
+            <Button
+              label={mode === 'login' ? '로그인' : '가입하기'}
+              fullWidth
+              loading={loading}
+              onPress={() => void onSubmit()}
+            />
+          </View>
+
+          <Text style={[styles.hint, { color: theme.mutedForeground }]}>
+            API: {process.env.EXPO_PUBLIC_API_URL?.trim() || 'http://127.0.0.1:3333 (기본)'}
+          </Text>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  scroll: {
+    flexGrow: 1,
+    paddingBottom: 32,
+    gap: 14,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    letterSpacing: -0.5,
+    marginTop: 8,
+  },
+  sub: {
+    fontSize: 13,
+    marginBottom: 4,
+  },
+  tabRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  form: {
+    gap: 12,
+    marginTop: 8,
+  },
+  err: {
+    fontSize: 12,
+  },
+  hint: {
+    fontSize: 10,
+    marginTop: 16,
+    fontFamily: 'SpaceMono-Regular',
+  },
+});

--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -67,7 +67,9 @@ interface StarIndexCardProps {
   score:        number;
   cloudCover:   number;   // % 운량
   pm25Level:    string;   // '좋음' | '보통' | '나쁨'
-  moonAltitude: number;   // 달 고도 (도)
+  moonAltitude: number;   // 달 고도 (도) — unknown이면 표시만 생략
+  /** false면 KASI 고도 미수신 등 — MOON 칸에 미상 */
+  moonAltitudeKnown?: boolean;
   onPress?:     () => void;
 }
 
@@ -76,6 +78,7 @@ export function StarIndexCard({
   cloudCover,
   pm25Level,
   moonAltitude,
+  moonAltitudeKnown = true,
   onPress,
 }: StarIndexCardProps) {
   const { theme } = useTheme();
@@ -88,10 +91,13 @@ export function StarIndexCard({
     score >= 75 ? theme.starGold :
     score >= 50 ? theme.moonlight : theme.mutedForeground;
 
+  const moonLabel =
+    moonAltitudeKnown ? `${moonAltitude}°` : '미상';
+
   const dataItems = [
     { key: 'CLOUD', value: `${cloudCover}%` },
     { key: 'PM2.5', value: pm25Level },
-    { key: 'MOON',  value: `${moonAltitude}°` },
+    { key: 'MOON',  value: moonLabel },
   ];
 
   return (

--- a/frontend/contexts/auth-context.tsx
+++ b/frontend/contexts/auth-context.tsx
@@ -1,0 +1,142 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  clearSession,
+  loadUser,
+  saveSession,
+  type StoredUser,
+} from '../lib/auth-storage';
+import { ensureFreshAccessToken, postAuthJson } from '../lib/api-client';
+import { getJwtPayload } from '../lib/jwt-utils';
+
+interface AuthContextValue {
+  /** AsyncStorage + 선택적 선제 갱신 완료 */
+  isHydrated: boolean;
+  /** refresh 토큰이 있고 세션 유효(또는 갱신 성공) */
+  isAuthenticated: boolean;
+  user: StoredUser | null;
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  /** refresh 실패 등 — 저장소 비우고 로그인 화면으로 */
+  onSessionInvalidated: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+function userFromAccessToken(accessToken: string): StoredUser | null {
+  const p = getJwtPayload(accessToken);
+  if (!p?.sub) return null;
+  return {
+    id: p.sub,
+    email: typeof p.email === 'string' ? p.email : '',
+  };
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [isHydrated, setIsHydrated] = useState(false);
+  const [hasValidSession, setHasValidSession] = useState(false);
+  const [user, setUser] = useState<StoredUser | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const session = await ensureFreshAccessToken();
+        if (cancelled) return;
+        if (!session) {
+          setHasValidSession(false);
+          setUser(null);
+          return;
+        }
+        setHasValidSession(true);
+        const u =
+          session.user ??
+          userFromAccessToken(session.accessToken) ??
+          null;
+        setUser(
+          u
+            ? { id: u.id, email: u.email || '(이메일 없음)' }
+            : null,
+        );
+      } finally {
+        if (!cancelled) setIsHydrated(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const login = useCallback(async (email: string, password: string) => {
+    const data = await postAuthJson('/auth/login', { email, password });
+    await saveSession({
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+      user: data.user,
+    });
+    setHasValidSession(true);
+    setUser(data.user);
+  }, []);
+
+  const register = useCallback(async (email: string, password: string) => {
+    const data = await postAuthJson('/auth/register', { email, password });
+    await saveSession({
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+      user: data.user,
+    });
+    setHasValidSession(true);
+    setUser(data.user);
+  }, []);
+
+  const logout = useCallback(async () => {
+    await clearSession();
+    setHasValidSession(false);
+    setUser(null);
+  }, []);
+
+  const onSessionInvalidated = useCallback(async () => {
+    await clearSession();
+    setHasValidSession(false);
+    setUser(null);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      isHydrated,
+      isAuthenticated: hasValidSession,
+      user,
+      login,
+      register,
+      logout,
+      onSessionInvalidated,
+    }),
+    [
+      isHydrated,
+      hasValidSession,
+      user,
+      login,
+      register,
+      logout,
+      onSessionInvalidated,
+    ],
+  );
+
+  return (
+    <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth는 AuthProvider 안에서만 사용하세요.');
+  return ctx;
+}

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -1,0 +1,176 @@
+import { getApiBaseUrl } from './config';
+import {
+  clearSession,
+  loadTokens,
+  loadUser,
+  setAccessToken,
+  type StoredUser,
+} from './auth-storage';
+import type {
+  AuthTokensResponseDto,
+  RefreshAccessResponseDto,
+  StarIndexResponseDto,
+} from './types/api';
+import { isAccessTokenExpired } from './jwt-utils';
+
+export class SessionExpiredError extends Error {
+  constructor(message = '세션이 만료되었습니다. 다시 로그인해 주세요.') {
+    super(message);
+    this.name = 'SessionExpiredError';
+  }
+}
+
+export class ApiRequestError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly body: unknown,
+  ) {
+    super(message);
+    this.name = 'ApiRequestError';
+  }
+}
+
+async function parseJsonSafe(res: Response): Promise<unknown> {
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+/** Nest validation pipe — message가 string | string[] */
+function messageFromErrorBody(body: unknown, fallback: string): string {
+  if (typeof body !== 'object' || body === null || !('message' in body)) {
+    return fallback;
+  }
+  const m = (body as { message: unknown }).message;
+  if (typeof m === 'string') return m;
+  if (Array.isArray(m)) return m.map(String).join(' ');
+  return fallback;
+}
+
+/** refresh로 access만 재발급 */
+export async function requestAccessRefresh(
+  refreshToken: string,
+): Promise<string> {
+  const res = await fetch(`${getApiBaseUrl()}/auth/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken }),
+  });
+  const body = await parseJsonSafe(res);
+  if (!res.ok) {
+    throw new ApiRequestError(
+      messageFromErrorBody(body, '토큰 갱신 실패'),
+      res.status,
+      body,
+    );
+  }
+  const data = body as RefreshAccessResponseDto;
+  if (!data?.accessToken) {
+    throw new ApiRequestError('응답에 accessToken이 없습니다.', res.status, body);
+  }
+  return data.accessToken;
+}
+
+/**
+ * Bearer가 필요한 GET — 401 시 refresh 1회 후 재시도, 실패 시 세션 삭제
+ */
+export async function authorizedGetJson<T>(path: string): Promise<T> {
+  const { accessToken, refreshToken } = await loadTokens();
+  if (!accessToken || !refreshToken) {
+    throw new SessionExpiredError();
+  }
+
+  const doFetch = (token: string) =>
+    fetch(`${getApiBaseUrl()}${path}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+  let res = await doFetch(accessToken);
+  if (res.status === 401) {
+    try {
+      const next = await requestAccessRefresh(refreshToken);
+      await setAccessToken(next);
+      res = await doFetch(next);
+    } catch {
+      await clearSession();
+      throw new SessionExpiredError();
+    }
+  }
+
+  const body = await parseJsonSafe(res);
+  if (!res.ok) {
+    throw new ApiRequestError(
+      messageFromErrorBody(body, `요청 실패 (${res.status})`),
+      res.status,
+      body,
+    );
+  }
+  return body as T;
+}
+
+export async function postAuthJson(
+  path: '/auth/login' | '/auth/register',
+  payload: { email: string; password: string },
+): Promise<AuthTokensResponseDto> {
+  const res = await fetch(`${getApiBaseUrl()}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  const body = await parseJsonSafe(res);
+  if (!res.ok) {
+    const fallback =
+      path === '/auth/register'
+        ? '회원가입에 실패했습니다.'
+        : '로그인에 실패했습니다.';
+    throw new ApiRequestError(
+      messageFromErrorBody(body, fallback),
+      res.status,
+      body,
+    );
+  }
+  const data = body as AuthTokensResponseDto;
+  if (!data.accessToken || !data.refreshToken || !data.user) {
+    throw new ApiRequestError('인증 응답 형식이 올바르지 않습니다.', res.status, body);
+  }
+  return data;
+}
+
+/** 앱 기동 시 access 만료면 선제 갱신 */
+export async function ensureFreshAccessToken(): Promise<{
+  accessToken: string;
+  refreshToken: string;
+  user: StoredUser | null;
+} | null> {
+  const { accessToken, refreshToken } = await loadTokens();
+  if (!refreshToken) return null;
+
+  const user = await loadUser();
+
+  let access = accessToken;
+  if (!access || isAccessTokenExpired(access)) {
+    try {
+      access = await requestAccessRefresh(refreshToken);
+      await setAccessToken(access);
+    } catch {
+      await clearSession();
+      return null;
+    }
+  }
+
+  return { accessToken: access, refreshToken, user };
+}
+
+export function fetchStarIndex(spotId: string): Promise<StarIndexResponseDto> {
+  const q = encodeURIComponent(spotId);
+  return authorizedGetJson<StarIndexResponseDto>(`/star-index?spotId=${q}`);
+}

--- a/frontend/lib/auth-storage.ts
+++ b/frontend/lib/auth-storage.ts
@@ -1,0 +1,53 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const KEY_ACCESS = 'starChaser:accessToken';
+const KEY_REFRESH = 'starChaser:refreshToken';
+const KEY_USER = 'starChaser:userJson';
+
+export interface StoredUser {
+  id: string;
+  email: string;
+}
+
+export async function saveSession(params: {
+  accessToken: string;
+  refreshToken: string;
+  user: StoredUser;
+}): Promise<void> {
+  await AsyncStorage.multiSet([
+    [KEY_ACCESS, params.accessToken],
+    [KEY_REFRESH, params.refreshToken],
+    [KEY_USER, JSON.stringify(params.user)],
+  ]);
+}
+
+export async function setAccessToken(token: string): Promise<void> {
+  await AsyncStorage.setItem(KEY_ACCESS, token);
+}
+
+export async function loadTokens(): Promise<{
+  accessToken: string | null;
+  refreshToken: string | null;
+}> {
+  const [[, access], [, refresh]] = await AsyncStorage.multiGet([
+    KEY_ACCESS,
+    KEY_REFRESH,
+  ]);
+  return { accessToken: access, refreshToken: refresh };
+}
+
+export async function loadUser(): Promise<StoredUser | null> {
+  const raw = await AsyncStorage.getItem(KEY_USER);
+  if (!raw) return null;
+  try {
+    const u = JSON.parse(raw) as StoredUser;
+    if (u && typeof u.id === 'string' && typeof u.email === 'string') return u;
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+export async function clearSession(): Promise<void> {
+  await AsyncStorage.multiRemove([KEY_ACCESS, KEY_REFRESH, KEY_USER]);
+}

--- a/frontend/lib/config.ts
+++ b/frontend/lib/config.ts
@@ -1,0 +1,16 @@
+/**
+ * API 베이스 URL — 코드에 시크릿 금지, Expo public env만 사용 (.cursorrules)
+ */
+export function getApiBaseUrl(): string {
+  const url = process.env.EXPO_PUBLIC_API_URL?.trim();
+  if (!url) {
+    return 'http://127.0.0.1:3333';
+  }
+  return url.replace(/\/$/, '');
+}
+
+/** Star-Index 데모용 명소 UUID — 없으면 카드에 설정 안내 */
+export function getDefaultSpotId(): string | undefined {
+  const id = process.env.EXPO_PUBLIC_DEFAULT_SPOT_ID?.trim();
+  return id || undefined;
+}

--- a/frontend/lib/jwt-utils.ts
+++ b/frontend/lib/jwt-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * JWT payload 파싱 — exp·email 등 (서명 검증 없음, 만료 판단·표시용)
+ */
+export function getJwtPayload(jwt: string): {
+  sub?: string;
+  email?: string;
+  exp?: number;
+} | null {
+  const parts = jwt.split('.');
+  if (parts.length < 2) return null;
+  try {
+    const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const pad = (4 - (b64.length % 4)) % 4;
+    const padded = b64 + '='.repeat(pad);
+    if (typeof atob !== 'function') return null;
+    const binary = atob(padded);
+    const json = decodeURIComponent(
+      Array.from(binary, (c) => {
+        const code = c.charCodeAt(0);
+        return `%${code < 16 ? '0' : ''}${code.toString(16)}`;
+      }).join(''),
+    );
+    const payload = JSON.parse(json) as {
+      sub?: string;
+      email?: string;
+      exp?: number;
+    };
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+export function getJwtExpSeconds(jwt: string): number | null {
+  const p = getJwtPayload(jwt);
+  return typeof p?.exp === 'number' ? p.exp : null;
+}
+
+/** true면 곧 만료 또는 이미 만료 — skew 초 만큼 여유 */
+export function isAccessTokenExpired(jwt: string, skewSeconds = 60): boolean {
+  const exp = getJwtExpSeconds(jwt);
+  if (exp === null) return true;
+  const now = Math.floor(Date.now() / 1000);
+  return exp <= now + skewSeconds;
+}

--- a/frontend/lib/star-index-display.ts
+++ b/frontend/lib/star-index-display.ts
@@ -1,0 +1,23 @@
+import type { StarIndexResponseDto } from './types/api';
+
+/** cloud_score = max(0, 100 - cloud%) 역산 (표시용 근사) */
+export function approximateCloudCoverPercent(cloudScore: number): number {
+  return Math.min(100, Math.max(0, 100 - Math.round(cloudScore)));
+}
+
+export function pm25LevelFromScore(pm25Score: number): string {
+  if (pm25Score >= 75) return '좋음';
+  if (pm25Score >= 45) return '보통';
+  return '나쁨';
+}
+
+export function starIndexResponseToCardModel(d: StarIndexResponseDto) {
+  const snap = d.weatherSnapshot;
+  return {
+    score: d.score,
+    cloudCover: approximateCloudCoverPercent(snap.cloud_score),
+    pm25Level: pm25LevelFromScore(snap.pm25_score),
+    moonAltitude: snap.moon_altitude_deg ?? 0,
+    moonAltitudeKnown: snap.moon_altitude_known !== false,
+  };
+}

--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -1,0 +1,41 @@
+/** 백엔드 WeatherSnapshot(표시용 일부 필드) */
+export interface WeatherSnapshotDto {
+  cloud_score: number;
+  pm25_score: number;
+  light_pollution_score: number;
+  moon_effect_score: number;
+  humidity_score: number;
+  elevation_score: number;
+  wind_score: number;
+  visibility_score: number;
+  temperature_score: number;
+  correction_score: number;
+  precipitation_probability?: number;
+  moon_altitude_deg?: number;
+  moon_altitude_known?: boolean;
+  lun_phase?: number;
+}
+
+export interface StarIndexResponseDto {
+  spotId: string;
+  name: string;
+  lat: number;
+  lng: number;
+  elevationM: number;
+  bortleClass: number;
+  score: number;
+  weatherSnapshot: WeatherSnapshotDto;
+  cacheKeys: { weatherKey: string; dustKey: string; moonKey: string };
+  message: string;
+  requestedBy: string;
+}
+
+export interface AuthTokensResponseDto {
+  user: { id: string; email: string };
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface RefreshAccessResponseDto {
+  accessToken: string;
+}


### PR DESCRIPTION
## 🔎 What

- 로그인/회원가입 화면 추가 및 AuthContext로 세션 관리
- AsyncStorage 기반 토큰 저장 + 401 시 refresh로 access 재발급 후 재요청
- 홈 화면 StarIndexCard를 GET /star-index?spotId= 응답 기반으로 표시

## 🔗 Issue 

- Closes: #34 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
