### PR TITLE
feat: KakaoMapWebView 메시지 규격 문서화, 지도에 spots 마커, 온보딩 오류 해결

### DIFF
--- a/docs/kakao-map-webview-messages.md
+++ b/docs/kakao-map-webview-messages.md
@@ -1,0 +1,111 @@
+# Map 탭 — KakaoMapWebView 메시지 규격
+
+React Native(앱)와 WebView 안의 `kakao.html`(카카오맵 JS) 사이 데이터 교환 규격이다. **A(백엔드/데이터)·B(FE 지도)** 가 같은 타입 문자열을 쓰도록 맞춘다.
+
+## 구현 위치
+
+| 역할                | 파일                                                                                 |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| RN 타입·RN→Web 전송 | `frontend/components/map/KakaoMapWebView.tsx` (`RNToWebMessage`, `injectWebMessage`) |
+| spots 조회·DTO 매핑 | `frontend/lib/spots-api.ts` (`spotDtoToMapSpot`, `fetchSpotsAll` / `fetchSpotsNearby`) |
+| 지도 마커 좌표 타입 | `frontend/lib/types/map-spot.ts` (`MapSpot`, `LatLng`)                               |
+| Web 수신·지도 반영  | `map-site/kakao.html` (`handleMessage` 스위치)                                       |
+| Web→RN 전송         | `kakao.html` 내 `post()` → `window.ReactNativeWebView.postMessage`                   |
+
+## 공통 규칙
+
+- 한 메시지 = **JSON 문자열 한 덩어리** (객체 직렬화).
+- 필수 필드: **`type`** (대문자 스네이크/고정 문자열).
+- 페이로드는 가능하면 **`data`** 키 아래에만 둔다.
+
+---
+
+## Web → RN (지도 페이지 → 앱)
+
+Web에서 `JSON.stringify` 후 `ReactNativeWebView.postMessage`로 보낸다. RN은 `WebView`의 `onMessage`에서 `JSON.parse`한다.
+
+| `type`         | `data`               | 언제                                                                    |
+| -------------- | -------------------- | ----------------------------------------------------------------------- |
+| `MAP_READY`    | 없음                 | 카카오맵 생성 직후 1회. RN은 이 시점 이후 `SET_*` 전송을 시작해도 된다. |
+| `MARKER_CLICK` | `{ spotId: string }` | 명소 라벨(오버레이) 탭 시.                                              |
+
+### 예시
+
+```json
+{ "type": "MAP_READY" }
+```
+
+```json
+{ "type": "MARKER_CLICK", "data": { "spotId": "yeongwol-byeolmaro" } }
+```
+
+---
+
+## RN → Web (앱 → 지도 페이지)
+
+호스팅 URL을 쓸 때는 RN이 **`injectJavaScript`** 로 `MessageEvent('message', { data })`를 흘려 `kakao.html`의 `handleMessage`와 동일 경로로 태운다.
+
+| `type`                   | `data`                                             | 설명                                                          |
+| ------------------------ | -------------------------------------------------- | ------------------------------------------------------------- |
+| `INIT`                   | `{ center?: { lat, lng }, level?: number }` (선택) | 지도 중심·레벨 재설정. 현재 앱 플로우에서는 거의 안 씀.       |
+| `SET_CURRENT_LOCATION`   | `{ lat: number, lng: number }`                     | 내 위치 마커 + 지도 중심 이동. 갱신마다내도 된다.             |
+| `CLEAR_CURRENT_LOCATION` | 없음                                               | 내 위치 마커만 제거(언마운트 등).                             |
+| `SET_SPOTS`              | `Array<{ id, lat, lng, title? }>`                  | 명소 목록 **전체 교체**. 이전 오버레이는 비운 뒤 다시 그린다. |
+
+### `MapSpot` (SET_SPOTS 한 줄 요약)
+
+- `id`: 문자열, 고유 식별자 (API `spotId` 등과 매핑 예정).
+- `lat`, `lng`: WGS84 도 단위.
+- `title`: 선택. 라벨에 표시(HTML 이스케이프 처리됨).
+
+### 백엔드 `SpotDto` → `MapSpot` (앱 `spotDtoToMapSpot`)
+
+`GET /spots`, `GET /spots/nearby` 응답 한 건(`SpotDto`)을 지도로 보낼 때 아래처럼 맞춘다.
+
+| SpotDto (API) | MapSpot (SET_SPOTS) |
+| --------------- | --------------------- |
+| `id` | `id` |
+| `name` | `title` |
+| `lat` | `lat` |
+| `lng` | `lng` |
+
+나머지 필드(`bortleClass`, `elevationM`, `hasParking`, `hasToilet`, `locationRadiusM` 등)는 현재 Web 라벨에 쓰지 않아 `SET_SPOTS` 페이로드에 넣지 않는다. 필요 시 확장 시 문서·`kakao.html` 같이 갱신.
+
+### 앱에서 `SET_SPOTS`를 채우는 방식 (`KakaoMapWebView` `spotListMode`)
+
+| 모드 | 데이터 소스 |
+| ---- | ----------- |
+| `nearby` (기본) | 첫 GPS(또는 위치 권한 후 1회 좌표)로 `GET /spots/nearby` → `SET_SPOTS`. 10초 안에 좌표를 못 받으면 `GET /spots`로 폴백 후 `SET_SPOTS`. |
+| `all` | `GET /spots` → `SET_SPOTS`. |
+| `sample` | `spots` prop(기본 샘플 3곳)만 `SET_SPOTS`. |
+
+### 예시
+
+```json
+{ "type": "SET_CURRENT_LOCATION", "data": { "lat": 37.5665, "lng": 126.978 } }
+```
+
+```json
+{
+  "type": "SET_SPOTS",
+  "data": [
+    { "id": "1", "lat": 37.1865, "lng": 128.471, "title": "영월 별마로천문대" }
+  ]
+}
+```
+
+```json
+{ "type": "CLEAR_CURRENT_LOCATION" }
+```
+
+---
+
+## 확장 시 (팀 합의 후 추가)
+
+새 `type`을 넣을 때는 **양쪽**(TS 타입 + `kakao.html` 스위치)에 같이 반영하고, 이 문서에 한 줄 추가한다.
+
+---
+
+## 참고
+
+개발가이드에서는 **`MAP_READY`**, **`SET_CURRENT_LOCATION`**, **`SET_SPOTS`**, **`MARKER_CLICK`**만 언급했지만, 운영 편의를 위해 코드에 있는 **`CLEAR_CURRENT_LOCATION`**, **`INIT`** 도 같은 규격으로 문서화해 두었다.

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -127,6 +127,7 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
           <KakaoMapWebView
             mapPageUrl={kakaoMapPageUrl}
             kakaoJavascriptKey={kakaoJavascriptKey}
+            spotListMode="all"
             onSessionExpired={onSessionInvalidated}
             onMessage={(msg) => {
               if (__DEV__) {

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -127,6 +127,7 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
           <KakaoMapWebView
             mapPageUrl={kakaoMapPageUrl}
             kakaoJavascriptKey={kakaoJavascriptKey}
+            onSessionExpired={onSessionInvalidated}
             onMessage={(msg) => {
               if (__DEV__) {
                 // eslint-disable-next-line no-console

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -172,12 +172,6 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
                   variant="outline"
                   onPress={onResetOnboarding}
                 />
-                <Button
-                  label="DEV: 로그아웃"
-                  variant="ghost"
-                  size="sm"
-                  onPress={() => void logout()}
-                />
               </View>
             )}
 
@@ -330,27 +324,69 @@ function AppLoading() {
  * 인증 후 온보딩 여부만 분기 — 로그아웃 시 AuthScreen
  */
 function AppGate() {
-  const { isHydrated, isAuthenticated } = useAuth();
+  const { isHydrated, isAuthenticated, user } = useAuth();
   const [route, setRoute] = useState<'boot' | 'onboarding' | 'ready'>('boot');
 
   const resetOnboarding = useCallback(async () => {
-    await Promise.all([
-      AsyncStorage.removeItem('starChaser:onboardingCompleted'),
-      AsyncStorage.removeItem('starChaser:onboardingRegion'),
-      AsyncStorage.removeItem('starChaser:notificationPrefs'),
-      AsyncStorage.removeItem('starChaser:onboardInterests'),
-    ]);
+    const userId = user?.id;
+    const keys: string[] = [
+      // legacy (앱 전체 1회)
+      'starChaser:onboardingCompleted',
+      'starChaser:onboardingRegion',
+      'starChaser:notificationPrefs',
+      'starChaser:onboardInterests',
+    ];
+    if (userId) {
+      // user-scoped (user별 1회)
+      keys.push(
+        `starChaser:onboardingCompleted:${userId}`,
+        `starChaser:onboardingRegion:${userId}`,
+        `starChaser:notificationPrefs:${userId}`,
+        `starChaser:onboardInterests:${userId}`,
+      );
+    }
+    await AsyncStorage.multiRemove(keys);
     setRoute('onboarding');
-  }, []);
+  }, [user?.id]);
 
   useEffect(() => {
     if (!isHydrated || !isAuthenticated) return;
+    // 인증 직후 user가 아직 세팅 전이면 잠깐 대기
+    if (!user?.id) return;
     let mounted = true;
     (async () => {
       try {
-        const completed = await AsyncStorage.getItem('starChaser:onboardingCompleted');
+        const completedKey = `starChaser:onboardingCompleted:${user.id}`;
+        const regionKey = `starChaser:onboardingRegion:${user.id}`;
+        const notifKey = `starChaser:notificationPrefs:${user.id}`;
+        const interestsKey = `starChaser:onboardInterests:${user.id}`;
+        const legacyKeys = [
+          'starChaser:onboardingCompleted',
+          'starChaser:onboardingRegion',
+          'starChaser:notificationPrefs',
+          'starChaser:onboardInterests',
+        ];
+
+        // 유저별 키만 신뢰 (legacy는 새 계정에 잘못 적용될 수 있어 정리만 수행)
+        const [completed, region, notif, interests] = await AsyncStorage.multiGet([
+          completedKey,
+          regionKey,
+          notifKey,
+          interestsKey,
+        ]).then((rows) => rows.map(([, v]) => v));
         if (!mounted) return;
-        setRoute(completed === 'true' ? 'ready' : 'onboarding');
+
+        // 안전장치: 과거 마이그레이션/테스트로 completedKey만 잘못 남은 경우 → 온보딩으로 복구
+        if (completed === 'true' && (region || notif || interests)) {
+          setRoute('ready');
+          return;
+        }
+        if (completed === 'true' && !region && !notif && !interests) {
+          void AsyncStorage.removeItem(completedKey);
+        }
+        // legacy 키가 남아있으면 1회 정리
+        void AsyncStorage.multiRemove(legacyKeys);
+        setRoute('onboarding');
       } catch {
         if (!mounted) return;
         setRoute('onboarding');
@@ -359,13 +395,15 @@ function AppGate() {
     return () => {
       mounted = false;
     };
-  }, [isHydrated, isAuthenticated]);
+  }, [isHydrated, isAuthenticated, user?.id]);
 
   if (!isHydrated) return <AppLoading />;
   if (!isAuthenticated) return <AuthScreen />;
   if (route === 'boot') return <AppLoading />;
   if (route === 'onboarding') {
-    return <OnboardingFlow onDone={() => setRoute('ready')} />;
+    // userId가 없으면 (드물게) 로딩 유지
+    if (!user?.id) return <AppLoading />;
+    return <OnboardingFlow userId={user.id} onDone={() => setRoute('ready')} />;
   }
   return <AppContent onResetOnboarding={resetOnboarding} />;
 }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -71,6 +71,12 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
   const [activeTab, setActiveTab] = useState<string>('home');
   const [location, setLocation] = useState<string>('');
 
+  // Map: 마커 클릭 → 해당 spotId의 Star-Index 오버레이
+  const [mapSpotId, setMapSpotId] = useState<string | null>(null);
+  const [mapSiLoading, setMapSiLoading] = useState(false);
+  const [mapSiError, setMapSiError] = useState<StarIndexUiError | null>(null);
+  const [mapSiData, setMapSiData] = useState<StarIndexResponseDto | null>(null);
+
   const defaultSpotId = getDefaultSpotId();
   const [siLoading, setSiLoading] = useState(false);
   const [siError, setSiError] = useState<StarIndexUiError | null>(null);
@@ -118,24 +124,151 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
   const kakaoMapPageUrl = process.env.EXPO_PUBLIC_KAKAO_MAP_PAGE_URL;
 
   const starProps = siData ? starIndexResponseToCardModel(siData) : null;
+  const mapStarProps = mapSiData ? starIndexResponseToCardModel(mapSiData) : null;
 
   return (
     <Screen>
       <StatusBar style="light" />
       <View style={{ flex: 1 }}>
         {activeTab === 'map' ? (
-          <KakaoMapWebView
-            mapPageUrl={kakaoMapPageUrl}
-            kakaoJavascriptKey={kakaoJavascriptKey}
-            spotListMode="all"
-            onSessionExpired={onSessionInvalidated}
-            onMessage={(msg) => {
-              if (__DEV__) {
-                // eslint-disable-next-line no-console
-                console.log('[KakaoMap]', msg);
-              }
-            }}
-          />
+          <View style={{ flex: 1 }}>
+            <KakaoMapWebView
+              mapPageUrl={kakaoMapPageUrl}
+              kakaoJavascriptKey={kakaoJavascriptKey}
+              spotListMode="all"
+              onSessionExpired={onSessionInvalidated}
+              onMessage={(msg) => {
+                if (__DEV__) {
+                  // eslint-disable-next-line no-console
+                  console.log('[KakaoMap]', msg);
+                }
+                if (msg.type === 'MARKER_CLICK') {
+                  const spotId = msg.data.spotId;
+                  setMapSpotId(spotId);
+                  setMapSiLoading(true);
+                  setMapSiError(null);
+                  setMapSiData(null);
+                  void (async () => {
+                    try {
+                      const data = await fetchStarIndex(spotId);
+                      setMapSiData(data);
+                    } catch (e) {
+                      if (e instanceof SessionExpiredError) {
+                        await onSessionInvalidated();
+                        return;
+                      }
+                      if (e instanceof ApiRequestError) {
+                        setMapSiError(starIndexErrorFromApi(e));
+                      } else {
+                        setMapSiError({
+                          cardDescription: '오류',
+                          isTransient: false,
+                          lines: ['Star-Index를 불러오지 못했습니다.'],
+                        });
+                      }
+                    } finally {
+                      setMapSiLoading(false);
+                    }
+                  })();
+                }
+              }}
+            />
+
+            {(mapSiLoading || mapSiError || mapStarProps) && (
+              <View style={styles.mapOverlay}>
+                <Card
+                  title="Star-Index"
+                  description={
+                    mapSiLoading
+                      ? '불러오는 중…'
+                      : mapSiError
+                        ? mapSiError.cardDescription
+                        : mapSiData?.name
+                          ? mapSiData.name
+                          : '명소'
+                  }
+                >
+                  <View style={{ gap: 10 }}>
+                    {mapSiLoading ? (
+                      <ActivityIndicator color={theme.starGold} />
+                    ) : mapSiError ? (
+                      mapSiError.lines.map((line, i) => (
+                        <Text
+                          key={i}
+                          style={{
+                            color: mapSiError.isTransient
+                              ? theme.mutedForeground
+                              : theme.dimRedFg,
+                            fontSize: 12,
+                            marginBottom: i < mapSiError.lines.length - 1 ? 8 : 0,
+                          }}
+                        >
+                          {line}
+                        </Text>
+                      ))
+                    ) : mapStarProps ? (
+                      <StarIndexCard
+                        score={mapStarProps.score}
+                        cloudCover={mapStarProps.cloudCover}
+                        pm25Level={mapStarProps.pm25Level}
+                        moonAltitude={mapStarProps.moonAltitude}
+                        moonAltitudeKnown={mapStarProps.moonAltitudeKnown}
+                      />
+                    ) : null}
+
+                    <View style={{ flexDirection: 'row', gap: 8 }}>
+                      {mapSpotId && !mapSiLoading && (
+                        <Button
+                          label="새로고침"
+                          variant="outline"
+                          size="sm"
+                          onPress={() => {
+                            // 동일 spotId로 다시 fetch
+                            setMapSiLoading(true);
+                            setMapSiError(null);
+                            setMapSiData(null);
+                            void (async () => {
+                              try {
+                                const data = await fetchStarIndex(mapSpotId);
+                                setMapSiData(data);
+                              } catch (e) {
+                                if (e instanceof SessionExpiredError) {
+                                  await onSessionInvalidated();
+                                  return;
+                                }
+                                if (e instanceof ApiRequestError) {
+                                  setMapSiError(starIndexErrorFromApi(e));
+                                } else {
+                                  setMapSiError({
+                                    cardDescription: '오류',
+                                    isTransient: false,
+                                    lines: ['Star-Index를 불러오지 못했습니다.'],
+                                  });
+                                }
+                              } finally {
+                                setMapSiLoading(false);
+                              }
+                            })();
+                          }}
+                        />
+                      )}
+                      <Button
+                        label="닫기"
+                        variant="ghost"
+                        size="sm"
+                        onPress={() => {
+                          setMapSpotId(null);
+                          setMapSiLoading(false);
+                          setMapSiError(null);
+                          setMapSiData(null);
+                        }}
+                      />
+                    </View>
+                  </View>
+                </Card>
+              </View>
+            )}
+          </View>
         ) : (
           <ScrollView
             style={{ flex: 1 }}
@@ -425,6 +558,12 @@ const styles = StyleSheet.create({
   scrollContent: {
     gap: 12,
     paddingBottom: 20,
+  },
+  mapOverlay: {
+    position: 'absolute',
+    left: 12,
+    right: 12,
+    top: 12,
   },
   appTitle: {
     fontSize: 22,

--- a/frontend/components/map/KakaoMapWebView.tsx
+++ b/frontend/components/map/KakaoMapWebView.tsx
@@ -158,9 +158,13 @@ export function KakaoMapWebView({
         function setSpots(spots) {
           if (!map || !Array.isArray(spots)) return;
           clearSpots();
+          var bounds = new kakao.maps.LatLngBounds();
+          var hasAny = false;
           spots.forEach(function (s) {
             if (!s || !s.id) return;
             var pos = new kakao.maps.LatLng(s.lat, s.lng);
+            bounds.extend(pos);
+            hasAny = true;
             var label = escapeHtml(s.title || '명소');
             var el = document.createElement('div');
             el.style.cssText =
@@ -182,6 +186,13 @@ export function KakaoMapWebView({
             });
             spotMarkers.set(String(s.id), overlay);
           });
+
+          // 마커가 여러 개면 화면에 모두 보이게 이동/줌 (1개면 과도한 줌 변화 방지)
+          if (hasAny && spots.length >= 2) {
+            try {
+              map.setBounds(bounds, 60, 60, 60, 60);
+            } catch (e) {}
+          }
         }
 
         function handleMessage(raw) {

--- a/frontend/components/map/KakaoMapWebView.tsx
+++ b/frontend/components/map/KakaoMapWebView.tsx
@@ -3,8 +3,17 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Platform, Text, View } from 'react-native';
 import WebView, { WebViewMessageEvent } from 'react-native-webview';
 
-export type LatLng = { lat: number; lng: number };
-export type MapSpot = { id: string; lat: number; lng: number; title?: string };
+import {
+  fetchSpotsAll,
+  fetchSpotsNearby,
+  SessionExpiredError,
+  spotDtoToMapSpot,
+} from '../../lib/spots-api';
+import type { LatLng, MapSpot } from '../../lib/types/map-spot';
+
+export type { LatLng, MapSpot } from '../../lib/types/map-spot';
+
+export type SpotListMode = 'sample' | 'nearby' | 'all';
 
 type RNToWebMessage =
   | { type: 'INIT'; data?: { center?: LatLng; level?: number } }
@@ -54,17 +63,28 @@ export function KakaoMapWebView({
   onMessage,
   /** MAP_READY 이후 expo-location으로 내 위치 마커 (기본 true) */
   showUserLocation = true,
-  /** 하드코딩 명소 마커 (기본 SAMPLE_MAP_SPOTS, 빈 배열이면 전송 안 함) */
+  /** `sample`: spots prop만 사용 · `nearby`: GET /spots/nearby(위치 확보 후) · `all`: GET /spots */
+  spotListMode = 'nearby' as SpotListMode,
+  /** nearby 반경(미터) */
+  spotsNearbyRadiusM = 50000,
+  /** spotListMode === `sample` 일 때만 사용 (기본 샘플 3곳) */
   spots = SAMPLE_MAP_SPOTS,
+  /** spots API에서 401/세션 만료 시 */
+  onSessionExpired,
 }: {
   mapPageUrl?: string;
   kakaoJavascriptKey: string | undefined;
   onMessage?: (msg: WebToRNMessage) => void;
   showUserLocation?: boolean;
+  spotListMode?: SpotListMode;
+  spotsNearbyRadiusM?: number;
   spots?: MapSpot[];
+  onSessionExpired?: () => void | Promise<void>;
 }) {
   const webViewRef = useRef<WebView>(null);
   const [mapReady, setMapReady] = useState(false);
+  /** nearby: 첫 GPS 좌표(주변 spots API 트리거) */
+  const [coordsForSpots, setCoordsForSpots] = useState<LatLng | null>(null);
 
   const html = useMemo(() => {
     return `<!doctype html>
@@ -241,6 +261,9 @@ export function KakaoMapWebView({
           type: 'SET_CURRENT_LOCATION',
           data: { lat: coords.latitude, lng: coords.longitude },
         });
+        if (spotListMode === 'nearby') {
+          setCoordsForSpots((prev) => prev ?? { lat: coords.latitude, lng: coords.longitude });
+        }
       };
 
       try {
@@ -282,14 +305,127 @@ export function KakaoMapWebView({
       sub?.remove();
       sendToWeb({ type: 'CLEAR_CURRENT_LOCATION' });
     };
-  }, [mapReady, showUserLocation, sendToWeb]);
+  }, [mapReady, showUserLocation, spotListMode, sendToWeb]);
 
-  // Step 3: MAP_READY 직후 샘플 명소 (호스팅/인라인 공통)
+  // nearby + 내 위치 끔: 좌표만 한 번 받아 spots API에 사용
   useEffect(() => {
-    if (!mapReady) return;
+    if (!mapReady || spotListMode !== 'nearby' || showUserLocation) return;
+
+    let cancelled = false;
+    (async () => {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (cancelled || status !== 'granted') return;
+      try {
+        const pos = await Location.getCurrentPositionAsync({
+          accuracy: Location.Accuracy.Balanced,
+        });
+        if (cancelled) return;
+        setCoordsForSpots((prev) => prev ?? { lat: pos.coords.latitude, lng: pos.coords.longitude });
+      } catch {
+        if (__DEV__) {
+          // eslint-disable-next-line no-console
+          console.warn('[KakaoMap] spots용 현재 위치 조회 실패');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mapReady, spotListMode, showUserLocation]);
+
+  // sample: prop만 지도에 반영
+  useEffect(() => {
+    if (!mapReady || spotListMode !== 'sample') return;
     if (!spots.length) return;
     sendToWeb({ type: 'SET_SPOTS', data: spots });
-  }, [mapReady, spots, sendToWeb]);
+  }, [mapReady, spotListMode, spots, sendToWeb]);
+
+  // all: GET /spots
+  useEffect(() => {
+    if (!mapReady || spotListMode !== 'all') return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const dtos = await fetchSpotsAll();
+        if (cancelled) return;
+        sendToWeb({ type: 'SET_SPOTS', data: dtos.map(spotDtoToMapSpot) });
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof SessionExpiredError) {
+          await onSessionExpired?.();
+          return;
+        }
+        if (__DEV__) {
+          // eslint-disable-next-line no-console
+          console.warn('[KakaoMap] fetchSpotsAll', e);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mapReady, spotListMode, sendToWeb, onSessionExpired]);
+
+  // nearby: 좌표 있으면 GET /spots/nearby
+  useEffect(() => {
+    if (!mapReady || spotListMode !== 'nearby') return;
+    if (!coordsForSpots) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const dtos = await fetchSpotsNearby(
+          coordsForSpots.lat,
+          coordsForSpots.lng,
+          spotsNearbyRadiusM,
+        );
+        if (cancelled) return;
+        sendToWeb({ type: 'SET_SPOTS', data: dtos.map(spotDtoToMapSpot) });
+      } catch (e) {
+        if (cancelled) return;
+        if (e instanceof SessionExpiredError) {
+          await onSessionExpired?.();
+          return;
+        }
+        if (__DEV__) {
+          // eslint-disable-next-line no-console
+          console.warn('[KakaoMap] fetchSpotsNearby', e);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [mapReady, spotListMode, coordsForSpots, spotsNearbyRadiusM, sendToWeb, onSessionExpired]);
+
+  // nearby: 좌표가 오래 없으면 GET /spots 로 폴백
+  useEffect(() => {
+    if (!mapReady || spotListMode !== 'nearby') return;
+    if (coordsForSpots) return;
+    let cancelled = false;
+    const t = setTimeout(() => {
+      void (async () => {
+        try {
+          const dtos = await fetchSpotsAll();
+          if (cancelled) return;
+          sendToWeb({ type: 'SET_SPOTS', data: dtos.map(spotDtoToMapSpot) });
+        } catch (e) {
+          if (cancelled) return;
+          if (e instanceof SessionExpiredError) {
+            await onSessionExpired?.();
+            return;
+          }
+          if (__DEV__) {
+            // eslint-disable-next-line no-console
+            console.warn('[KakaoMap] fetchSpotsAll (nearby fallback)', e);
+          }
+        }
+      })();
+    }, 10_000);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [mapReady, spotListMode, coordsForSpots, sendToWeb, onSessionExpired]);
 
   const androidLayer = Platform.OS === 'android' ? { opacity: 0.99 } : null;
 

--- a/frontend/components/onboarding/OnboardingFlow.tsx
+++ b/frontend/components/onboarding/OnboardingFlow.tsx
@@ -32,11 +32,15 @@ type NotificationPrefs = {
   weeklyTop5: boolean;
 };
 
-// AsyncStorage 키 (App.tsx reset과 동일하게 유지)
-const KEY_COMPLETED = 'starChaser:onboardingCompleted';
-const KEY_REGION = 'starChaser:onboardingRegion';
-const KEY_NOTIF_PREFS = 'starChaser:notificationPrefs';
-const KEY_INTERESTS = 'starChaser:onboardInterests';
+// AsyncStorage 키 베이스 (userId suffix로 스코프)
+const KEY_COMPLETED_BASE = 'starChaser:onboardingCompleted';
+const KEY_REGION_BASE = 'starChaser:onboardingRegion';
+const KEY_NOTIF_PREFS_BASE = 'starChaser:notificationPrefs';
+const KEY_INTERESTS_BASE = 'starChaser:onboardInterests';
+
+function onboardingKey(base: string, userId: string) {
+  return `${base}:${userId}`;
+}
 
 // Step3 칩 목록 (표시 순서 고정)
 const STAR_CONSTELLATIONS = [
@@ -91,7 +95,13 @@ function districtFromGeocode(addr: Record<string, unknown> | undefined): string 
   );
 }
 
-export function OnboardingFlow({ onDone }: { onDone: () => void }) {
+export function OnboardingFlow({
+  onDone,
+  userId,
+}: {
+  onDone: () => void;
+  userId: string;
+}) {
   const { theme } = useTheme();
   const [step, setStep] = useState<Step>(1);
   /** 저장/완료·위치 요청 중 버튼 비활성 등 */
@@ -194,10 +204,16 @@ export function OnboardingFlow({ onDone }: { onDone: () => void }) {
         };
 
         await Promise.all([
-          AsyncStorage.setItem(KEY_COMPLETED, 'true'),
-          AsyncStorage.setItem(KEY_REGION, JSON.stringify(region)),
-          AsyncStorage.setItem(KEY_NOTIF_PREFS, JSON.stringify(notifPrefs)),
-          AsyncStorage.setItem(KEY_INTERESTS, JSON.stringify(interests)),
+          AsyncStorage.setItem(onboardingKey(KEY_COMPLETED_BASE, userId), 'true'),
+          AsyncStorage.setItem(onboardingKey(KEY_REGION_BASE, userId), JSON.stringify(region)),
+          AsyncStorage.setItem(
+            onboardingKey(KEY_NOTIF_PREFS_BASE, userId),
+            JSON.stringify(notifPrefs),
+          ),
+          AsyncStorage.setItem(
+            onboardingKey(KEY_INTERESTS_BASE, userId),
+            JSON.stringify(interests),
+          ),
         ]);
 
         onDone();
@@ -205,7 +221,7 @@ export function OnboardingFlow({ onDone }: { onDone: () => void }) {
         setBusy(false);
       }
     },
-    [notifPrefs, onDone, regionDo, regionName, selectedInterests],
+    [notifPrefs, onDone, regionDo, regionName, selectedInterests, userId],
   );
 
   return (

--- a/frontend/lib/spots-api.ts
+++ b/frontend/lib/spots-api.ts
@@ -1,0 +1,26 @@
+import { authorizedGetJson, SessionExpiredError } from './api-client';
+import type { MapSpot } from './types/map-spot';
+import type { SpotDto } from './types/api';
+
+export function spotDtoToMapSpot(s: SpotDto): MapSpot {
+  return { id: s.id, title: s.name, lat: s.lat, lng: s.lng };
+}
+
+export async function fetchSpotsAll(): Promise<SpotDto[]> {
+  return authorizedGetJson<SpotDto[]>('/spots');
+}
+
+export async function fetchSpotsNearby(
+  lat: number,
+  lng: number,
+  radiusM: number,
+): Promise<SpotDto[]> {
+  const q = new URLSearchParams({
+    lat: String(lat),
+    lng: String(lng),
+    radiusM: String(radiusM),
+  });
+  return authorizedGetJson<SpotDto[]>(`/spots/nearby?${q.toString()}`);
+}
+
+export { SessionExpiredError };

--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -39,3 +39,16 @@ export interface AuthTokensResponseDto {
 export interface RefreshAccessResponseDto {
   accessToken: string;
 }
+
+/** GET /spots · /spots/nearby 응답 한 줄 (Nest SpotRepository → JSON) */
+export interface SpotDto {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+  bortleClass: number;
+  elevationM: number;
+  hasParking: boolean;
+  hasToilet: boolean;
+  locationRadiusM: number;
+}

--- a/frontend/lib/types/map-spot.ts
+++ b/frontend/lib/types/map-spot.ts
@@ -1,0 +1,3 @@
+export type LatLng = { lat: number; lng: number };
+
+export type MapSpot = { id: string; lat: number; lng: number; title?: string };


### PR DESCRIPTION
## 🔎 What

- 문서화: docs/kakao-map-webview-messages.md에 메시지 규격 + SpotDto → MapSpot 매핑 + spotListMode 동작 정리
- Map 탭 마커 표시: /spots(또는 /spots/nearby) 결과를 SET_SPOTS로 주입해서 DB spots 마커 표시
- 전체 마커 보이기(bounds): spots가 여러 개면 bounds 맞춰 화면에 보이게 처리 완료 (kakao.html/WebView 쪽 반영)
- 세션 만료 처리: 401/만료 시 onSessionInvalidated로 연결
- 온보딩 1회 표시: 유저별 완료 키로 분리해서 미온보딩 계정은 로그인 후 1회 표시

## 🔗 Issue 

- Closes: #40 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
