### PR TITLE
feat(ui): Star-Index/명소 카드 로딩·에러·정상 UI를 StatefulCard로 통일

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -24,8 +24,10 @@ import {
   Card,
   StarIndexCard,
   SpotCard,
+  StatefulCard,
   Input,
   Screen,
+  type StatefulCardError,
 } from './components/ui';
 import { OnboardingFlow } from './components/onboarding/OnboardingFlow';
 import { KakaoMapWebView } from './components/map/KakaoMapWebView';
@@ -39,15 +41,7 @@ import {
 import { starIndexResponseToCardModel } from './lib/star-index-display';
 import type { StarIndexResponseDto } from './lib/types/api';
 
-/** Star-Index 카드에 표시할 오류(503 캐시 부족 vs 일반) */
-type StarIndexUiError = {
-  cardDescription: string;
-  lines: string[];
-  /** true면 안내 톤(빨간 에러색 대신 muted) */
-  isTransient: boolean;
-};
-
-function starIndexErrorFromApi(e: ApiRequestError): StarIndexUiError {
+function starIndexErrorFromApi(e: ApiRequestError): StatefulCardError {
   if (e.status === 503) {
     return {
       cardDescription: '캐시 준비 중',
@@ -74,12 +68,12 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
   // Map: 마커 클릭 → 해당 spotId의 Star-Index 오버레이
   const [mapSpotId, setMapSpotId] = useState<string | null>(null);
   const [mapSiLoading, setMapSiLoading] = useState(false);
-  const [mapSiError, setMapSiError] = useState<StarIndexUiError | null>(null);
+  const [mapSiError, setMapSiError] = useState<StatefulCardError | null>(null);
   const [mapSiData, setMapSiData] = useState<StarIndexResponseDto | null>(null);
 
   const defaultSpotId = getDefaultSpotId();
   const [siLoading, setSiLoading] = useState(false);
-  const [siError, setSiError] = useState<StarIndexUiError | null>(null);
+  const [siError, setSiError] = useState<StatefulCardError | null>(null);
   const [siData, setSiData] = useState<StarIndexResponseDto | null>(null);
   const [siRefreshKey, setSiRefreshKey] = useState(0);
 
@@ -176,54 +170,52 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
 
             {(mapSiLoading || mapSiError || mapStarProps) && (
               <View style={styles.mapOverlay}>
-                <Card
+                <StatefulCard
                   title="Star-Index"
-                  description={
-                    mapSiLoading
-                      ? '불러오는 중…'
-                      : mapSiError
-                        ? mapSiError.cardDescription
-                        : mapSiData?.name
-                          ? mapSiData.name
-                          : '명소'
+                  description={mapSiData?.name}
+                  loading={mapSiLoading}
+                  error={mapSiError}
+                  onRetry={
+                    mapSpotId
+                      ? () => {
+                          setMapSiLoading(true);
+                          setMapSiError(null);
+                          setMapSiData(null);
+                          void (async () => {
+                            try {
+                              const data = await fetchStarIndex(mapSpotId);
+                              setMapSiData(data);
+                            } catch (e) {
+                              if (e instanceof SessionExpiredError) {
+                                await onSessionInvalidated();
+                                return;
+                              }
+                              if (e instanceof ApiRequestError) {
+                                setMapSiError(starIndexErrorFromApi(e));
+                              } else {
+                                setMapSiError({
+                                  cardDescription: '오류',
+                                  isTransient: false,
+                                  lines: ['Star-Index를 불러오지 못했습니다.'],
+                                });
+                              }
+                            } finally {
+                              setMapSiLoading(false);
+                            }
+                          })();
+                        }
+                      : undefined
                   }
-                >
-                  <View style={{ gap: 10 }}>
-                    {mapSiLoading ? (
-                      <ActivityIndicator color={theme.starGold} />
-                    ) : mapSiError ? (
-                      mapSiError.lines.map((line, i) => (
-                        <Text
-                          key={i}
-                          style={{
-                            color: mapSiError.isTransient
-                              ? theme.mutedForeground
-                              : theme.dimRedFg,
-                            fontSize: 12,
-                            marginBottom: i < mapSiError.lines.length - 1 ? 8 : 0,
-                          }}
-                        >
-                          {line}
-                        </Text>
-                      ))
-                    ) : mapStarProps ? (
-                      <StarIndexCard
-                        score={mapStarProps.score}
-                        cloudCover={mapStarProps.cloudCover}
-                        pm25Level={mapStarProps.pm25Level}
-                        moonAltitude={mapStarProps.moonAltitude}
-                        moonAltitudeKnown={mapStarProps.moonAltitudeKnown}
-                      />
-                    ) : null}
-
+                  retryLabel="새로고침"
+                  footer={
                     <View style={{ flexDirection: 'row', gap: 8 }}>
-                      {mapSpotId && !mapSiLoading && (
+                      {mapSpotId && (
                         <Button
                           label="새로고침"
                           variant="outline"
                           size="sm"
+                          disabled={mapSiLoading}
                           onPress={() => {
-                            // 동일 spotId로 다시 fetch
                             setMapSiLoading(true);
                             setMapSiError(null);
                             setMapSiData(null);
@@ -264,8 +256,19 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
                         }}
                       />
                     </View>
-                  </View>
-                </Card>
+                  }
+                >
+                  {mapStarProps ? (
+                    <StarIndexCard
+                      bare
+                      score={mapStarProps.score}
+                      cloudCover={mapStarProps.cloudCover}
+                      pm25Level={mapStarProps.pm25Level}
+                      moonAltitude={mapStarProps.moonAltitude}
+                      moonAltitudeKnown={mapStarProps.moonAltitudeKnown}
+                    />
+                  ) : null}
+                </StatefulCard>
               </View>
             )}
           </View>
@@ -326,62 +329,56 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
                   예: 시드 영월 별마로 천문대 UUID를 .env에 설정하세요.
                 </Text>
               </Card>
-            ) : siLoading ? (
-              <Card title="Star-Index" description="불러오는 중…">
-                <ActivityIndicator color={theme.starGold} />
-              </Card>
-            ) : siError ? (
-              <Card title="Star-Index" description={siError.cardDescription}>
-                {siError.lines.map((line, i) => (
-                  <Text
-                    key={i}
-                    style={{
-                      color: siError.isTransient
-                        ? theme.mutedForeground
-                        : theme.dimRedFg,
-                      fontSize: 12,
-                      marginBottom: i < siError.lines.length - 1 ? 8 : 0,
-                    }}
-                  >
-                    {line}
-                  </Text>
-                ))}
-                <Button
-                  label="다시 시도"
-                  variant="outline"
-                  size="sm"
-                  style={{ marginTop: 10 }}
-                  onPress={() => setSiRefreshKey((k) => k + 1)}
-                />
-              </Card>
-            ) : starProps ? (
-              <View style={{ gap: 8 }}>
-                <StarIndexCard
-                  score={starProps.score}
-                  cloudCover={starProps.cloudCover}
-                  pm25Level={starProps.pm25Level}
-                  moonAltitude={starProps.moonAltitude}
-                  moonAltitudeKnown={starProps.moonAltitudeKnown}
-                />
-                <Button
-                  label="Star-Index 새로고침"
-                  variant="outline"
-                  size="sm"
-                  onPress={() => setSiRefreshKey((k) => k + 1)}
-                />
-              </View>
-            ) : null}
+            ) : (
+              <StatefulCard
+                title="Star-Index"
+                loading={siLoading}
+                error={siError}
+                onRetry={() => setSiRefreshKey((k) => k + 1)}
+                footer={
+                  starProps && !siLoading && !siError ? (
+                    <Button
+                      label="Star-Index 새로고침"
+                      variant="outline"
+                      size="sm"
+                      onPress={() => setSiRefreshKey((k) => k + 1)}
+                    />
+                  ) : null
+                }
+              >
+                {starProps ? (
+                  <StarIndexCard
+                    bare
+                    score={starProps.score}
+                    cloudCover={starProps.cloudCover}
+                    pm25Level={starProps.pm25Level}
+                    moonAltitude={starProps.moonAltitude}
+                    moonAltitudeKnown={starProps.moonAltitudeKnown}
+                  />
+                ) : null}
+              </StatefulCard>
+            )}
 
-            {siData ? (
-              <SpotCard
-                name={siData.name}
-                region={`${siData.lat.toFixed(4)} · ${siData.lng.toFixed(4)}`}
-                elevation={siData.elevationM}
-                bortleClass={siData.bortleClass}
-                starIndex={siData.score}
-                hasParking={false}
-                hasToilet={false}
-              />
+            {defaultSpotId ? (
+              <StatefulCard
+                title="명소"
+                loading={siLoading}
+                error={siError}
+                onRetry={() => setSiRefreshKey((k) => k + 1)}
+              >
+                {siData ? (
+                  <SpotCard
+                    bare
+                    name={siData.name}
+                    region={`${siData.lat.toFixed(4)} · ${siData.lng.toFixed(4)}`}
+                    elevation={siData.elevationM}
+                    bortleClass={siData.bortleClass}
+                    starIndex={siData.score}
+                    hasParking={false}
+                    hasToilet={false}
+                  />
+                ) : null}
+              </StatefulCard>
             ) : (
               <SpotCard
                 name="화왕산 억새평원"

--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -6,6 +6,7 @@
 
 import React, { type ReactNode } from 'react';
 import {
+  ActivityIndicator,
   Pressable,
   StyleSheet,
   Text,
@@ -14,6 +15,7 @@ import {
 } from 'react-native';
 import { useTheme } from '../../themes/ThemeContext';
 import { Badge } from './Badge';
+import { Button } from './Button';
 
 // ── 기본 Card 래퍼 ──
 interface CardProps {
@@ -62,6 +64,98 @@ export function Card({ children, onPress, style, title, description }: CardProps
   );
 }
 
+/** 로딩/에러/정상 UI를 Card 안에서 일관되게 보여줄 때 사용 */
+export type StatefulCardError = {
+  cardDescription: string;
+  lines: string[];
+  /** true면 안내 톤(빨간 에러색 대신 muted) */
+  isTransient?: boolean;
+};
+
+interface StatefulCardProps {
+  title: string;
+  /** 로딩/에러 시 카드 상단 설명(선택). 없으면 기본 문구 사용 */
+  description?: string;
+  loading: boolean;
+  error?: StatefulCardError | null;
+  onRetry?: () => void;
+  retryLabel?: string;
+  /** 성공 상태 본문 */
+  children?: ReactNode;
+  /** 성공/에러 하단 액션(닫기 등) */
+  footer?: ReactNode;
+  style?: ViewStyle;
+}
+
+export function StatefulCard({
+  title,
+  description,
+  loading,
+  error,
+  onRetry,
+  retryLabel = '다시 시도',
+  children,
+  footer,
+  style,
+}: StatefulCardProps) {
+  const { theme } = useTheme();
+
+  const desc =
+    description ??
+    (loading ? '불러오는 중…' : error ? error.cardDescription : undefined);
+
+  return (
+    <View
+      style={[
+        styles.card,
+        {
+          backgroundColor: theme.card,
+          borderColor: theme.border,
+          borderRadius: theme.radius,
+        },
+        style,
+      ]}
+    >
+      {title ? <Text style={[styles.title, { color: theme.foreground }]}>{title}</Text> : null}
+      {desc ? <Text style={[styles.desc, { color: theme.mutedForeground }]}>{desc}</Text> : null}
+
+      <View style={[styles.stateBody, (title || desc) && styles.stateBodyAfterHeader]}>
+        {loading ? (
+          <ActivityIndicator color={theme.starGold} />
+        ) : error ? (
+          <>
+            {error.lines.map((line, i) => (
+              <Text
+                key={i}
+                style={{
+                  color: error.isTransient ? theme.mutedForeground : theme.dimRedFg,
+                  fontSize: 12,
+                  lineHeight: 16,
+                  marginBottom: i < error.lines.length - 1 ? 8 : 0,
+                }}
+              >
+                {line}
+              </Text>
+            ))}
+            {onRetry ? (
+              <Button
+                label={retryLabel}
+                variant="outline"
+                size="sm"
+                style={{ marginTop: 6, alignSelf: 'flex-start' }}
+                onPress={onRetry}
+              />
+            ) : null}
+          </>
+        ) : (
+          children
+        )}
+        {footer ? <View style={styles.stateFooter}>{footer}</View> : null}
+      </View>
+    </View>
+  );
+}
+
 // ── Star-Index 숫자 카드 ──
 interface StarIndexCardProps {
   score:        number;
@@ -71,6 +165,8 @@ interface StarIndexCardProps {
   /** false면 KASI 고도 미수신 등 — MOON 칸에 미상 */
   moonAltitudeKnown?: boolean;
   onPress?:     () => void;
+  /** true면 바깥 Card 래퍼 없이 내용만 렌더(StatefulCard 등 중첩 방지) */
+  bare?: boolean;
 }
 
 export function StarIndexCard({
@@ -80,6 +176,7 @@ export function StarIndexCard({
   moonAltitude,
   moonAltitudeKnown = true,
   onPress,
+  bare = false,
 }: StarIndexCardProps) {
   const { theme } = useTheme();
 
@@ -100,8 +197,8 @@ export function StarIndexCard({
     { key: 'MOON',  value: moonLabel },
   ];
 
-  return (
-    <Card onPress={onPress}>
+  const inner = (
+    <>
       {/* 헤더 행 */}
       <View style={styles.siTop}>
         <View>
@@ -145,8 +242,19 @@ export function StarIndexCard({
           </View>
         ))}
       </View>
-    </Card>
+    </>
   );
+
+  if (bare) {
+    if (!onPress) return inner;
+    return (
+      <Pressable onPress={onPress} style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}>
+        {inner}
+      </Pressable>
+    );
+  }
+
+  return <Card onPress={onPress}>{inner}</Card>;
 }
 
 // ── 명소 카드 ──
@@ -160,11 +268,14 @@ interface SpotCardProps {
   hasToilet:   boolean;
   distanceKm?: number;
   onPress?:    () => void;
+  /** true면 바깥 Card 래퍼 없이 내용만 렌더(StatefulCard 등 중첩 방지) */
+  bare?: boolean;
 }
 
 export function SpotCard({
   name, region, elevation, bortleClass,
   starIndex, hasParking, hasToilet, distanceKm, onPress,
+  bare = false,
 }: SpotCardProps) {
   const { theme } = useTheme();
 
@@ -172,8 +283,8 @@ export function SpotCard({
     bortleClass <= 3 ? 'gold' :
     bortleClass <= 5 ? 'steel' : 'muted';
 
-  return (
-    <Card onPress={onPress}>
+  const inner = (
+    <>
       <View style={styles.spotTop}>
         <View style={{ flex: 1, marginRight: 8 }}>
           <Text style={[styles.spotName, { color: theme.foreground }]}>{name}</Text>
@@ -199,8 +310,19 @@ export function SpotCard({
         {hasParking && <Badge label="주차" variant="muted" />}
         {hasToilet  && <Badge label="화장실" variant="muted" />}
       </View>
-    </Card>
+    </>
   );
+
+  if (bare) {
+    if (!onPress) return inner;
+    return (
+      <Pressable onPress={onPress} style={({ pressed }) => ({ opacity: pressed ? 0.9 : 1 })}>
+        {inner}
+      </Pressable>
+    );
+  }
+
+  return <Card onPress={onPress}>{inner}</Card>;
 }
 
 const styles = StyleSheet.create({
@@ -220,6 +342,16 @@ const styles = StyleSheet.create({
   },
   childrenWrap: {
     marginTop: 10,
+  },
+
+  stateBody: {
+    gap: 10,
+  },
+  stateBodyAfterHeader: {
+    marginTop: 10,
+  },
+  stateFooter: {
+    marginTop: 4,
   },
 
   // Star-Index Card

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -1,6 +1,12 @@
 export { Badge,     type BadgeVariant }    from './Badge';
 export { BottomTab, type BottomTabItem }   from './BottomTab';
 export { Button,    type ButtonVariant, type ButtonSize } from './Button';
-export { Card, StarIndexCard, SpotCard }   from './Card';
+export {
+  Card,
+  StarIndexCard,
+  SpotCard,
+  StatefulCard,
+  type StatefulCardError,
+} from './Card';
 export { Input }                           from './Input';
 export { Screen }                          from './Screen';


### PR DESCRIPTION
## 🔎 What

- **공통 “상태 카드” 컴포넌트 추가**: 로딩/에러/정상 UI를 `StatefulCard`로 묶어서 재사용 가능하게 적용
- **에러 포맷 공통화**: `StatefulCardError`로 에러 제목 + 본문 줄 + transient(안내 톤)까지 같은 규칙으로 통일
- **카드 중첩 방지**: `StarIndexCard`, `SpotCard`에 `bare` 옵션 추가해서 외부 `StatefulCard`랑 겹치지 않게 적용
- **Home 적용**
    - Star-Index 영역: 기존 분기 로직을 `StatefulCard`로 통일 + `StarIndexCard bare` 적용
    - 명소 영역(`defaultSpotId` 있을 때): `StatefulCard`로 통일 + `SpotCard bare` 적용
- **Map 오버레이 적용**
    - Star-Index 오버레이: `StatefulCard`로 통일 + `StarIndexCard bare` 적용
    - `footer`에 정상 상태에서도 동작하는 `새로고침` 추가 + 로딩 중 `disabled` 적용
- **export 정리**: `components/ui/index.ts`에서 `StatefulCard`, `StatefulCardError` export 추가

앞으로 API 결과 카드 만들 때는 StatefulCard로 틀 잡고, 내용은 **StarIndexCard bare / SpotCard bare**로 넣으면 로딩/에러/정상 UI 톤이 자동으로 맞춰집니다.

## 🔗 Issue 

- Closes: #42 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] 최소 1명의 리뷰를 받았나요?
