### PR TITLE
feat: FCM 토큰/알림 설정 테이블·API·마이그레이션 추가

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { SpotsModule } from './spots/spots.module';
 import { StarIndexModule } from './star-index/star-index.module';
 import { SkyModule } from './sky/sky.module';
 import { ObservationsModule } from './observations/observations.module';
+import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
   imports: [
@@ -53,6 +54,7 @@ import { ObservationsModule } from './observations/observations.module';
     StarIndexModule,
     SkyModule,
     ObservationsModule,
+    NotificationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/common/interfaces/notification.repository.ts
+++ b/backend/src/common/interfaces/notification.repository.ts
@@ -1,0 +1,40 @@
+export type NotificationPlatform = 'ios' | 'android' | 'web';
+
+export interface NotificationToken {
+  id: string;
+  userId: string;
+  fcmToken: string;
+  platform: NotificationPlatform;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface NotificationPreference {
+  userId: string;
+  alertsEnabled: boolean;
+  starIndexAlertEnabled: boolean;
+  astronomyEventAlertEnabled: boolean;
+  top5AlertEnabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface NotificationRepository {
+  upsertToken(params: {
+    userId: string;
+    fcmToken: string;
+    platform: NotificationPlatform;
+  }): Promise<NotificationToken>;
+  deactivateToken(params: { userId: string; fcmToken: string }): Promise<void>;
+  getPreferenceByUserId(userId: string): Promise<NotificationPreference | null>;
+  upsertPreference(params: {
+    userId: string;
+    alertsEnabled: boolean;
+    starIndexAlertEnabled: boolean;
+    astronomyEventAlertEnabled: boolean;
+    top5AlertEnabled: boolean;
+  }): Promise<NotificationPreference>;
+}
+
+export const NOTIFICATION_REPOSITORY = 'NOTIFICATION_REPOSITORY';

--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -1,5 +1,7 @@
 import { DataSource } from 'typeorm';
 import { ObservationEntity } from '../observations/observation.entity';
+import { NotificationPreferenceEntity } from '../notifications/notification-preference.entity';
+import { NotificationTokenEntity } from '../notifications/notification-token.entity';
 import { PhotoEntity } from '../photos/photo.entity';
 import { SpotEntity } from '../spots/spot.entity';
 import { UserEntity } from '../users/user.entity';
@@ -18,7 +20,14 @@ export default new DataSource({
   type: 'postgres',
   url: databaseUrl,
   ssl: { rejectUnauthorized: false },
-  entities: [UserEntity, SpotEntity, ObservationEntity, PhotoEntity],
+  entities: [
+    UserEntity,
+    SpotEntity,
+    ObservationEntity,
+    PhotoEntity,
+    NotificationTokenEntity,
+    NotificationPreferenceEntity,
+  ],
   migrations: ['src/migrations/*.ts'],
   synchronize: false,
   logging: false,

--- a/backend/src/migrations/1714536000000-add-notification-tokens-and-preferences.ts
+++ b/backend/src/migrations/1714536000000-add-notification-tokens-and-preferences.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNotificationTokensAndPreferences1714536000000
+  implements MigrationInterface
+{
+  name = 'AddNotificationTokensAndPreferences1714536000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS notification_tokens (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        fcm_token text NOT NULL UNIQUE,
+        platform varchar(16) NOT NULL CHECK (platform IN ('ios', 'android', 'web')),
+        is_active boolean NOT NULL DEFAULT true,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_notification_tokens_user_id
+      ON notification_tokens(user_id)
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS notification_preferences (
+        user_id uuid PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+        alerts_enabled boolean NOT NULL DEFAULT true,
+        star_index_alert_enabled boolean NOT NULL DEFAULT true,
+        astronomy_event_alert_enabled boolean NOT NULL DEFAULT true,
+        top5_alert_enabled boolean NOT NULL DEFAULT true,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        updated_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS notification_preferences`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_notification_tokens_user_id`);
+    await queryRunner.query(`DROP TABLE IF EXISTS notification_tokens`);
+  }
+}

--- a/backend/src/notifications/dto/deactivate-notification-token.dto.ts
+++ b/backend/src/notifications/dto/deactivate-notification-token.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength } from 'class-validator';
+
+export class DeactivateNotificationTokenDto {
+  @ApiProperty({ example: 'fcm_device_token_value' })
+  @IsString()
+  @MinLength(10)
+  fcmToken: string;
+}

--- a/backend/src/notifications/dto/update-notification-preferences.dto.ts
+++ b/backend/src/notifications/dto/update-notification-preferences.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class UpdateNotificationPreferencesDto {
+  @ApiProperty({ required: false, example: true })
+  @IsOptional()
+  @IsBoolean()
+  alertsEnabled?: boolean;
+
+  @ApiProperty({ required: false, example: true })
+  @IsOptional()
+  @IsBoolean()
+  starIndexAlertEnabled?: boolean;
+
+  @ApiProperty({ required: false, example: true })
+  @IsOptional()
+  @IsBoolean()
+  astronomyEventAlertEnabled?: boolean;
+
+  @ApiProperty({ required: false, example: false })
+  @IsOptional()
+  @IsBoolean()
+  top5AlertEnabled?: boolean;
+}

--- a/backend/src/notifications/dto/upsert-notification-token.dto.ts
+++ b/backend/src/notifications/dto/upsert-notification-token.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsString, MinLength } from 'class-validator';
+
+export class UpsertNotificationTokenDto {
+  @ApiProperty({ example: 'fcm_device_token_value' })
+  @IsString()
+  @MinLength(10)
+  fcmToken: string;
+
+  @ApiProperty({ example: 'android', enum: ['ios', 'android', 'web'] })
+  @IsString()
+  @IsIn(['ios', 'android', 'web'])
+  platform: 'ios' | 'android' | 'web';
+}

--- a/backend/src/notifications/notification-preference.entity.ts
+++ b/backend/src/notifications/notification-preference.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { UserEntity } from '../users/user.entity';
+
+@Entity('notification_preferences')
+export class NotificationPreferenceEntity {
+  @PrimaryColumn({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @OneToOne(() => UserEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: UserEntity;
+
+  @Column({ name: 'alerts_enabled', type: 'boolean', default: true })
+  alertsEnabled: boolean;
+
+  @Column({ name: 'star_index_alert_enabled', type: 'boolean', default: true })
+  starIndexAlertEnabled: boolean;
+
+  @Column({ name: 'astronomy_event_alert_enabled', type: 'boolean', default: true })
+  astronomyEventAlertEnabled: boolean;
+
+  @Column({ name: 'top5_alert_enabled', type: 'boolean', default: true })
+  top5AlertEnabled: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/backend/src/notifications/notification-token.entity.ts
+++ b/backend/src/notifications/notification-token.entity.ts
@@ -1,0 +1,33 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('notification_tokens')
+@Index('idx_notification_tokens_user_id', ['userId'])
+export class NotificationTokenEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({ name: 'fcm_token', type: 'text', unique: true })
+  fcmToken: string;
+
+  @Column({ type: 'varchar', length: 16 })
+  platform: 'ios' | 'android' | 'web';
+
+  @Column({ name: 'is_active', type: 'boolean', default: true })
+  isActive: boolean;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at', type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, Delete, Get, Post, Put, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import type { JwtValidatedUser } from '../auth/strategies/jwt.strategy';
+import { DeactivateNotificationTokenDto } from './dto/deactivate-notification-token.dto';
+import { UpdateNotificationPreferencesDto } from './dto/update-notification-preferences.dto';
+import { UpsertNotificationTokenDto } from './dto/upsert-notification-token.dto';
+import { NotificationsService } from './notifications.service';
+
+@ApiTags('notifications')
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+export class NotificationsController {
+  constructor(private readonly notificationsService: NotificationsService) {}
+
+  @Post('token')
+  @ApiOperation({ summary: 'FCM 토큰 등록/갱신 (로그인 후 디바이스별 호출)' })
+  upsertToken(
+    @CurrentUser() user: JwtValidatedUser,
+    @Body() dto: UpsertNotificationTokenDto,
+  ) {
+    return this.notificationsService.upsertToken(user.userId, dto);
+  }
+
+  @Delete('token')
+  @ApiOperation({ summary: 'FCM 토큰 비활성화 (로그아웃/알림 해제)' })
+  async deactivateToken(
+    @CurrentUser() user: JwtValidatedUser,
+    @Body() dto: DeactivateNotificationTokenDto,
+  ) {
+    await this.notificationsService.deactivateToken(user.userId, dto.fcmToken);
+    return { message: '토큰 비활성화 완료' };
+  }
+
+  @Get('preferences')
+  @ApiOperation({ summary: '내 알림 설정 조회' })
+  getPreferences(@CurrentUser() user: JwtValidatedUser) {
+    return this.notificationsService.getPreference(user.userId);
+  }
+
+  @Put('preferences')
+  @ApiOperation({ summary: '내 알림 설정 저장/갱신 (온보딩 토글 연동)' })
+  updatePreferences(
+    @CurrentUser() user: JwtValidatedUser,
+    @Body() dto: UpdateNotificationPreferencesDto,
+  ) {
+    return this.notificationsService.upsertPreference(user.userId, dto);
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { NOTIFICATION_REPOSITORY } from '../common/interfaces/notification.repository';
+import { NotificationPreferenceEntity } from './notification-preference.entity';
+import { NotificationTokenEntity } from './notification-token.entity';
+import { NotificationsController } from './notifications.controller';
+import { NotificationsService } from './notifications.service';
+import { TypeOrmNotificationRepository } from './typeorm-notification.repository';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([NotificationTokenEntity, NotificationPreferenceEntity]),
+    AuthModule,
+  ],
+  controllers: [NotificationsController],
+  providers: [
+    NotificationsService,
+    TypeOrmNotificationRepository,
+    {
+      provide: NOTIFICATION_REPOSITORY,
+      useExisting: TypeOrmNotificationRepository,
+    },
+  ],
+  exports: [NotificationsService, NOTIFICATION_REPOSITORY],
+})
+export class NotificationsModule {}

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -1,0 +1,56 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  NOTIFICATION_REPOSITORY,
+  type NotificationPreference,
+  type NotificationRepository,
+} from '../common/interfaces/notification.repository';
+import { UpdateNotificationPreferencesDto } from './dto/update-notification-preferences.dto';
+import { UpsertNotificationTokenDto } from './dto/upsert-notification-token.dto';
+
+@Injectable()
+export class NotificationsService {
+  constructor(
+    @Inject(NOTIFICATION_REPOSITORY)
+    private readonly notifications: NotificationRepository,
+  ) {}
+
+  upsertToken(userId: string, dto: UpsertNotificationTokenDto) {
+    return this.notifications.upsertToken({
+      userId,
+      fcmToken: dto.fcmToken,
+      platform: dto.platform,
+    });
+  }
+
+  async deactivateToken(userId: string, fcmToken: string): Promise<void> {
+    await this.notifications.deactivateToken({ userId, fcmToken });
+  }
+
+  async getPreference(userId: string): Promise<NotificationPreference> {
+    const pref = await this.notifications.getPreferenceByUserId(userId);
+    if (pref) return pref;
+    return this.notifications.upsertPreference({
+      userId,
+      alertsEnabled: true,
+      starIndexAlertEnabled: true,
+      astronomyEventAlertEnabled: true,
+      top5AlertEnabled: true,
+    });
+  }
+
+  async upsertPreference(
+    userId: string,
+    dto: UpdateNotificationPreferencesDto,
+  ): Promise<NotificationPreference> {
+    const current = await this.getPreference(userId);
+    return this.notifications.upsertPreference({
+      userId,
+      alertsEnabled: dto.alertsEnabled ?? current.alertsEnabled,
+      starIndexAlertEnabled:
+        dto.starIndexAlertEnabled ?? current.starIndexAlertEnabled,
+      astronomyEventAlertEnabled:
+        dto.astronomyEventAlertEnabled ?? current.astronomyEventAlertEnabled,
+      top5AlertEnabled: dto.top5AlertEnabled ?? current.top5AlertEnabled,
+    });
+  }
+}

--- a/backend/src/notifications/typeorm-notification.repository.ts
+++ b/backend/src/notifications/typeorm-notification.repository.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type {
+  NotificationPreference,
+  NotificationRepository,
+  NotificationToken,
+} from '../common/interfaces/notification.repository';
+import { NotificationPreferenceEntity } from './notification-preference.entity';
+import { NotificationTokenEntity } from './notification-token.entity';
+
+@Injectable()
+export class TypeOrmNotificationRepository implements NotificationRepository {
+  constructor(
+    @InjectRepository(NotificationTokenEntity)
+    private readonly tokens: Repository<NotificationTokenEntity>,
+    @InjectRepository(NotificationPreferenceEntity)
+    private readonly prefs: Repository<NotificationPreferenceEntity>,
+  ) {}
+
+  async upsertToken(params: {
+    userId: string;
+    fcmToken: string;
+    platform: 'ios' | 'android' | 'web';
+  }): Promise<NotificationToken> {
+    const existing = await this.tokens.findOne({
+      where: { fcmToken: params.fcmToken },
+    });
+
+    if (!existing) {
+      const created = this.tokens.create({
+        userId: params.userId,
+        fcmToken: params.fcmToken,
+        platform: params.platform,
+        isActive: true,
+      });
+      const saved = await this.tokens.save(created);
+      return saved;
+    }
+
+    existing.userId = params.userId;
+    existing.platform = params.platform;
+    existing.isActive = true;
+    const saved = await this.tokens.save(existing);
+    return saved;
+  }
+
+  async deactivateToken(params: { userId: string; fcmToken: string }): Promise<void> {
+    await this.tokens
+      .createQueryBuilder()
+      .update(NotificationTokenEntity)
+      .set({ isActive: false })
+      .where('user_id = :userId', { userId: params.userId })
+      .andWhere('fcm_token = :fcmToken', { fcmToken: params.fcmToken })
+      .execute();
+  }
+
+  async getPreferenceByUserId(userId: string): Promise<NotificationPreference | null> {
+    const pref = await this.prefs.findOne({ where: { userId } });
+    return pref ?? null;
+  }
+
+  async upsertPreference(params: {
+    userId: string;
+    alertsEnabled: boolean;
+    starIndexAlertEnabled: boolean;
+    astronomyEventAlertEnabled: boolean;
+    top5AlertEnabled: boolean;
+  }): Promise<NotificationPreference> {
+    const existing = await this.prefs.findOne({ where: { userId: params.userId } });
+    if (!existing) {
+      const created = this.prefs.create({
+        userId: params.userId,
+        alertsEnabled: params.alertsEnabled,
+        starIndexAlertEnabled: params.starIndexAlertEnabled,
+        astronomyEventAlertEnabled: params.astronomyEventAlertEnabled,
+        top5AlertEnabled: params.top5AlertEnabled,
+      });
+      return this.prefs.save(created);
+    }
+
+    existing.alertsEnabled = params.alertsEnabled;
+    existing.starIndexAlertEnabled = params.starIndexAlertEnabled;
+    existing.astronomyEventAlertEnabled = params.astronomyEventAlertEnabled;
+    existing.top5AlertEnabled = params.top5AlertEnabled;
+    return this.prefs.save(existing);
+  }
+}


### PR DESCRIPTION
## 🔎 What
- 이벤트 기반 알림 구현을 위한 1주차 백엔드 기반을 추가했습니다.
- FCM 토큰 저장/비활성화와 사용자 알림 설정(preferences) 조회/수정 API를 구현했습니다.
- 알림 관련 테이블 마이그레이션을 추가해 팀원이 동일하게 재현 가능하도록 구성했습니다.

## Changes
- Notifications 모듈 추가
  - `POST /notifications/token` : FCM 토큰 등록/갱신
  - `DELETE /notifications/token` : FCM 토큰 비활성화
  - `GET /notifications/preferences` : 알림 설정 조회
  - `PUT /notifications/preferences` : 알림 설정 저장/갱신
- DB 엔티티 추가
  - `notification_tokens`
  - `notification_preferences`
- Repository 인터페이스/구현 추가
  - `NOTIFICATION_REPOSITORY`
  - TypeORM 기반 upsert/deactivate/get/update 처리
- 마이그레이션 추가
  - `1714536000000-add-notification-tokens-and-preferences.ts`
- 앱 모듈/데이터소스 연결
  - `NotificationsModule` 등록
  - 신규 엔티티 등록

## Why
- 고정 시각 일괄 발송이 아닌, 사용자 상태/조건 기반 알림으로 확장하기 위한 최소 데이터 기반이 필요했습니다.
- 온보딩 알림 토글과 실제 알림 발송 로직을 연결할 수 있는 중간 계층을 먼저 안정화했습니다.

## Test Plan
- [x] 마이그레이션 실행 확인
- [x] Swagger에서 인증 후 알림 API 동작 확인
  - [x] 토큰 등록/갱신 (`POST /notifications/token`)
  - [x] 토큰 비활성화 (`DELETE /notifications/token`)
  - [x] 설정 조회 (`GET /notifications/preferences`)
  - [x] 설정 저장 (`PUT /notifications/preferences`)
- [x] 응답 코드 200 기준 정상 동작 확인

## Out of Scope (이번 PR 제외)
- 실제 푸시 발송(FCM sender) 구현
- Star-Index 70+/유성우/TOP5 트리거 스케줄러 실발송
- FE 온보딩 UI 최종 연결

## 🔗 Issue 

- Closes: #44 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
