### PR TITLE
fix: 광공해 오버레이 이미지 깨지는 오류 임시해결

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { ObservationsModule } from './observations/observations.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { CorrectionsModule } from './corrections/corrections.module';
 import { ViirsModule } from './viirs/viirs.module';
+import { KakaoPageController } from './kakao-page.controller';
 
 @Module({
   imports: [
@@ -60,7 +61,7 @@ import { ViirsModule } from './viirs/viirs.module';
     CorrectionsModule,
     ViirsModule,
   ],
-  controllers: [AppController],
+  controllers: [AppController, KakaoPageController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/kakao-page.controller.ts
+++ b/backend/src/kakao-page.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import * as fs from 'fs';
+import * as path from 'path';
+
+@Controller()
+export class KakaoPageController {
+  /**
+   * 로컬 개발에서 Kakao Developers의 "JavaScript SDK 도메인"을 단일 origin으로 유지하기 위해
+   * 백엔드 포트(:3333)에서 `map-site/kakao.html`을 그대로 서빙한다.
+   *
+   * 접근 예: http://<내PCIP>:3333/kakao.html
+   */
+  @Get('kakao.html')
+  kakaoHtml(@Res() res: Response) {
+    // dist 실행 환경에서도 동작하도록 프로젝트 루트 기준 상대경로로 계산
+    const filePath = path.resolve(process.cwd(), '..', 'map-site', 'kakao.html');
+
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const key = (process.env.KAKAO_JS_KEY ?? '').trim();
+    if (!key) {
+      res.status(500);
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      return res.end('Missing env: KAKAO_JS_KEY');
+    }
+
+    // 로컬 개발에서는 GitHub Actions 주입이 없으므로 서버가 직접 치환한다.
+    const html = raw.replace(/%KAKAO_JS_KEY%/g, key);
+    res.status(200);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    return res.end(html);
+  }
+}
+


### PR DESCRIPTION
## 🔎 What

- kakao.html을 백엔드가 직접 서빙해서 kakao.html도 http://<PCIP>:3333/kakao.html
- 오버레이도 http://<PCIP>:3333/viirs/wms
- 즉 같은 origin으로 통일 → 차단 회피
- backend/.env에 `KAKAO_JS_KEY=<카카오 JavaScript 키>` 설정
- frontend/.env에 `EXPO_PUBLIC_KAKAO_MAP_PAGE_URL=http://<내PC IP>:3333/kakao.html`, `EXPO_PUBLIC_KAKAO_JAVASCRIPT_KEY=<카카오 JavaScript 키>` 설정
- 백엔드에 `GET /kakao.html` 라우트 추가

.env는 직접 수정하셔야 합니다.

## 🔗 Issue 

- Closes: #61 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
