### PR TITLE
chore(top5): weekly_top5 테이블/엔티티/마이그레이션 스켈레톤

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import { ObservationsModule } from './observations/observations.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { CorrectionsModule } from './corrections/corrections.module';
 import { ViirsModule } from './viirs/viirs.module';
+import { WeeklyTop5Module } from './weekly-top5/weekly-top5.module';
 import { KakaoPageController } from './kakao-page.controller';
 
 @Module({
@@ -60,6 +61,7 @@ import { KakaoPageController } from './kakao-page.controller';
     NotificationsModule,
     CorrectionsModule,
     ViirsModule,
+    WeeklyTop5Module,
   ],
   controllers: [AppController, KakaoPageController],
   providers: [AppService],

--- a/backend/src/common/interfaces/weekly-top5.repository.ts
+++ b/backend/src/common/interfaces/weekly-top5.repository.ts
@@ -1,0 +1,21 @@
+// ──────────────────────────────────────────────────────────────
+// Repository 패턴 — weekly_top5 조회·저장은 서비스가 이 인터페이스만 사용
+// ──────────────────────────────────────────────────────────────
+
+/** 도메인 단위 행 (spots 조인은 호출 측 또는 후속 메서드에서) */
+export interface WeeklyTop5Entry {
+  id: string;
+  /** YYYY-MM-DD */
+  weekStart: string;
+  rank: number;
+  spotId: string;
+  avgStarIndex: number;
+  createdAt: Date;
+}
+
+export interface WeeklyTop5Repository {
+  /** 해당 주 차 순위표를 rank 오름차순으로 조회 (동순위 시 spot_id 안정 정렬) */
+  findByWeekStart(weekStart: string): Promise<WeeklyTop5Entry[]>;
+}
+
+export const WEEKLY_TOP5_REPOSITORY = 'WEEKLY_TOP5_REPOSITORY';

--- a/backend/src/weekly-top5/typeorm-weekly-top5.repository.ts
+++ b/backend/src/weekly-top5/typeorm-weekly-top5.repository.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type {
+  WeeklyTop5Entry,
+  WeeklyTop5Repository,
+} from '../common/interfaces/weekly-top5.repository';
+import { WeeklyTop5Entity } from './weekly-top5.entity';
+
+@Injectable()
+export class TypeOrmWeeklyTop5Repository implements WeeklyTop5Repository {
+  constructor(
+    @InjectRepository(WeeklyTop5Entity)
+    private readonly repo: Repository<WeeklyTop5Entity>,
+  ) {}
+
+  async findByWeekStart(weekStart: string): Promise<WeeklyTop5Entry[]> {
+    const rows = await this.repo.find({
+      where: { weekStart },
+      order: { rank: 'ASC', spotId: 'ASC' },
+    });
+    return rows.map((e) => this.toEntry(e));
+  }
+
+  private toEntry(e: WeeklyTop5Entity): WeeklyTop5Entry {
+    return {
+      id: e.id,
+      weekStart: normalizeDateOnly(e.weekStart),
+      rank: e.rank,
+      spotId: e.spotId,
+      avgStarIndex: Number(e.avgStarIndex),
+      createdAt: e.createdAt,
+    };
+  }
+}
+
+function normalizeDateOnly(v: string | Date): string {
+  if (v instanceof Date) {
+    return v.toISOString().slice(0, 10);
+  }
+  const s = String(v);
+  return s.length >= 10 ? s.slice(0, 10) : s;
+}

--- a/backend/src/weekly-top5/weekly-top5.entity.ts
+++ b/backend/src/weekly-top5/weekly-top5.entity.ts
@@ -1,0 +1,32 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity('weekly_top5')
+export class WeeklyTop5Entity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'week_start', type: 'date' })
+  weekStart: string;
+
+  @Column({ type: 'smallint' })
+  rank: number;
+
+  @Column({ name: 'spot_id', type: 'uuid' })
+  spotId: string;
+
+  @Column({
+    name: 'avg_star_index',
+    type: 'numeric',
+    precision: 5,
+    scale: 2,
+  })
+  avgStarIndex: string;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/weekly-top5/weekly-top5.module.ts
+++ b/backend/src/weekly-top5/weekly-top5.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WEEKLY_TOP5_REPOSITORY } from '../common/interfaces/weekly-top5.repository';
+import { TypeOrmWeeklyTop5Repository } from './typeorm-weekly-top5.repository';
+import { WeeklyTop5Entity } from './weekly-top5.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WeeklyTop5Entity])],
+  providers: [
+    TypeOrmWeeklyTop5Repository,
+    {
+      provide: WEEKLY_TOP5_REPOSITORY,
+      useExisting: TypeOrmWeeklyTop5Repository,
+    },
+  ],
+  exports: [WEEKLY_TOP5_REPOSITORY],
+})
+export class WeeklyTop5Module {}


### PR DESCRIPTION
## 🔎 What

- supabase에 weekly_top5 테이블 생성, idx_weekly_top5 (week_start DESC, rank ASC) 인덱스, (week_start, spot_id) UNIQUE 및 FK(spots) 등 스키마 반영
- 백엔드: WeeklyTop5Entity, WeeklyTop5Module, WeeklyTop5Repository 인터페이스 + TypeOrmWeeklyTop5Repository 구현

## 🔗 Issue 

- Closes: #51 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
