### PR TITLE
feat(top5): TOP5 조회 API 스켈레톤

### DIFF
--- a/backend/src/common/interfaces/weekly-top5.repository.ts
+++ b/backend/src/common/interfaces/weekly-top5.repository.ts
@@ -16,6 +16,9 @@ export interface WeeklyTop5Entry {
 export interface WeeklyTop5Repository {
   /** 해당 주 차 순위표를 rank 오름차순으로 조회 (동순위 시 spot_id 안정 정렬) */
   findByWeekStart(weekStart: string): Promise<WeeklyTop5Entry[]>;
+
+  /** 집계된 행이 있을 때 가장 최근 `week_start`(DATE). 없으면 null */
+  findLatestWeekStart(): Promise<string | null>;
 }
 
 export const WEEKLY_TOP5_REPOSITORY = 'WEEKLY_TOP5_REPOSITORY';

--- a/backend/src/weekly-top5/dto/weekly-top5-item.dto.ts
+++ b/backend/src/weekly-top5/dto/weekly-top5-item.dto.ts
@@ -8,7 +8,7 @@ export class WeeklyTop5ItemDto {
   @ApiProperty({
     description:
       '집계 구간이 시작된 월요일 (지난주 월~일 TOP5의 week_start, YYYY-MM-DD)',
-    example: '2026-04-28',
+    example: '2026-05-04',
   })
   weekStart: string;
 

--- a/backend/src/weekly-top5/dto/weekly-top5-item.dto.ts
+++ b/backend/src/weekly-top5/dto/weekly-top5-item.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/** GET /top5/weekly 한 행 — spots 조인으로 채운 노출용 DTO */
+export class WeeklyTop5ItemDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({
+    description:
+      '집계 구간이 시작된 월요일 (지난주 월~일 TOP5의 week_start, YYYY-MM-DD)',
+    example: '2026-04-28',
+  })
+  weekStart: string;
+
+  @ApiProperty({ description: 'TOP5 카드에 표시할 순위', minimum: 1, maximum: 5 })
+  rank: number;
+
+  @ApiProperty({ format: 'uuid' })
+  spotId: string;
+
+  @ApiProperty({ description: 'spots.name 조인' })
+  spotName: string;
+
+  @ApiProperty({ description: '해당 주 평균 Star-Index (스냅샷)', example: 82.5 })
+  avgStarIndex: number;
+}

--- a/backend/src/weekly-top5/typeorm-weekly-top5.repository.ts
+++ b/backend/src/weekly-top5/typeorm-weekly-top5.repository.ts
@@ -22,6 +22,15 @@ export class TypeOrmWeeklyTop5Repository implements WeeklyTop5Repository {
     return rows.map((e) => this.toEntry(e));
   }
 
+  async findLatestWeekStart(): Promise<string | null> {
+    const row = await this.repo
+      .createQueryBuilder('w')
+      .select('MAX(w.week_start)', 'max')
+      .getRawOne<{ max: string | Date | null }>();
+    if (row?.max == null) return null;
+    return normalizeDateOnly(row.max);
+  }
+
   private toEntry(e: WeeklyTop5Entity): WeeklyTop5Entry {
     return {
       id: e.id,

--- a/backend/src/weekly-top5/weekly-top5.controller.ts
+++ b/backend/src/weekly-top5/weekly-top5.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { WeeklyTop5Service } from './weekly-top5.service';
+import { WeeklyTop5ItemDto } from './dto/weekly-top5-item.dto';
+
+@ApiTags('top5')
+@Controller('top5')
+export class WeeklyTop5Controller {
+  constructor(private readonly weeklyTop5Service: WeeklyTop5Service) {}
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Get('weekly')
+  @ApiOperation({
+    summary: '주간 TOP5 조회 (지난주 월~일 집계, week_start = 그 주의 월요일)',
+    description:
+      '`weekStart` 생략 시 DB에 존재하는 가장 최근 `week_start`로 조회합니다. ' +
+      '해당 주 데이터가 없으면 빈 배열 `[]`을 반환합니다.',
+  })
+  @ApiQuery({
+    name: 'weekStart',
+    required: false,
+    description: '조회할 week_start (YYYY-MM-DD, 집계 구간의 월요일)',
+    example: '2026-04-28',
+  })
+  @ApiOkResponse({ type: WeeklyTop5ItemDto, isArray: true })
+  async getWeekly(
+    @Query('weekStart') weekStart?: string,
+  ): Promise<WeeklyTop5ItemDto[]> {
+    return this.weeklyTop5Service.getWeekly(weekStart);
+  }
+}

--- a/backend/src/weekly-top5/weekly-top5.controller.ts
+++ b/backend/src/weekly-top5/weekly-top5.controller.ts
@@ -28,7 +28,7 @@ export class WeeklyTop5Controller {
     name: 'weekStart',
     required: false,
     description: '조회할 week_start (YYYY-MM-DD, 집계 구간의 월요일)',
-    example: '2026-04-28',
+    example: '2026-05-04',
   })
   @ApiOkResponse({ type: WeeklyTop5ItemDto, isArray: true })
   async getWeekly(

--- a/backend/src/weekly-top5/weekly-top5.module.ts
+++ b/backend/src/weekly-top5/weekly-top5.module.ts
@@ -1,17 +1,27 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { SpotsModule } from '../spots/spots.module';
 import { WEEKLY_TOP5_REPOSITORY } from '../common/interfaces/weekly-top5.repository';
 import { TypeOrmWeeklyTop5Repository } from './typeorm-weekly-top5.repository';
 import { WeeklyTop5Entity } from './weekly-top5.entity';
+import { WeeklyTop5Controller } from './weekly-top5.controller';
+import { WeeklyTop5Service } from './weekly-top5.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([WeeklyTop5Entity])],
+  imports: [
+    TypeOrmModule.forFeature([WeeklyTop5Entity]),
+    SpotsModule,
+    AuthModule,
+  ],
+  controllers: [WeeklyTop5Controller],
   providers: [
     TypeOrmWeeklyTop5Repository,
     {
       provide: WEEKLY_TOP5_REPOSITORY,
       useExisting: TypeOrmWeeklyTop5Repository,
     },
+    WeeklyTop5Service,
   ],
   exports: [WEEKLY_TOP5_REPOSITORY],
 })

--- a/backend/src/weekly-top5/weekly-top5.service.ts
+++ b/backend/src/weekly-top5/weekly-top5.service.ts
@@ -1,0 +1,71 @@
+import {
+  BadRequestException,
+  Injectable,
+  Inject,
+} from '@nestjs/common';
+import {
+  WEEKLY_TOP5_REPOSITORY,
+  type WeeklyTop5Entry,
+  type WeeklyTop5Repository,
+} from '../common/interfaces/weekly-top5.repository';
+import {
+  SPOT_REPOSITORY,
+  type SpotRepository,
+} from '../common/interfaces/spot.repository';
+import { WeeklyTop5ItemDto } from './dto/weekly-top5-item.dto';
+
+const WEEK_START_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+@Injectable()
+export class WeeklyTop5Service {
+  constructor(
+    @Inject(WEEKLY_TOP5_REPOSITORY)
+    private readonly weeklyTop5Repo: WeeklyTop5Repository,
+    @Inject(SPOT_REPOSITORY)
+    private readonly spots: SpotRepository,
+  ) {}
+
+  /**
+   * @param weekStart YYYY-MM-DD 생략 시 DB의 MAX(week_start)
+   */
+  async getWeekly(weekStart?: string): Promise<WeeklyTop5ItemDto[]> {
+    const resolved =
+      weekStart != null && weekStart.trim() !== ''
+        ? parseWeekStartQuery(weekStart.trim())
+        : await this.weeklyTop5Repo.findLatestWeekStart();
+
+    if (resolved == null) {
+      return [];
+    }
+
+    const rows = await this.weeklyTop5Repo.findByWeekStart(resolved);
+    if (rows.length === 0) {
+      return [];
+    }
+
+    return Promise.all(rows.map((r) => this.toDto(r)));
+  }
+
+  private async toDto(row: WeeklyTop5Entry): Promise<WeeklyTop5ItemDto> {
+    const spot = await this.spots.findById(row.spotId);
+    return {
+      id: row.id,
+      weekStart: row.weekStart,
+      rank: row.rank,
+      spotId: row.spotId,
+      spotName: spot?.name ?? '(명소 없음)',
+      avgStarIndex: row.avgStarIndex,
+    };
+  }
+}
+
+function parseWeekStartQuery(raw: string): string {
+  if (!WEEK_START_RE.test(raw)) {
+    throw new BadRequestException('weekStart는 YYYY-MM-DD 형식이어야 합니다.');
+  }
+  const d = new Date(`${raw}T12:00:00Z`);
+  if (Number.isNaN(d.getTime())) {
+    throw new BadRequestException('weekStart가 유효한 날짜가 아닙니다.');
+  }
+  return raw.slice(0, 10);
+}


### PR DESCRIPTION
## 🔎 What

- 앱이 주간 TOP5(지난주 월~일 7일 구간을 집계한 결과)를 읽을 수 있는 GET /top5/weekly API 틀을 만든다.
- week_start는 집계에 쓴 그 한 주의 시작일(지난주 월요일, DATE) 과 동일한 값으로 조회한다.
- 해당 주 데이터가 없으면 [] 로 응답한다(HTTP 200).

## 🔗 Issue 

- Closes: #52 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
