### PR TITLE
feat: 주간 TOP5 - 일별 스냅샷·주간 집계·Cron·API

### DIFF
--- a/backend/src/common/interfaces/weekly-top5.repository.ts
+++ b/backend/src/common/interfaces/weekly-top5.repository.ts
@@ -1,11 +1,5 @@
-// ──────────────────────────────────────────────────────────────
-// Repository 패턴 — weekly_top5 조회·저장은 서비스가 이 인터페이스만 사용
-// ──────────────────────────────────────────────────────────────
-
-/** 도메인 단위 행 (spots 조인은 호출 측 또는 후속 메서드에서) */
 export interface WeeklyTop5Entry {
   id: string;
-  /** YYYY-MM-DD */
   weekStart: string;
   rank: number;
   spotId: string;
@@ -14,11 +8,12 @@ export interface WeeklyTop5Entry {
 }
 
 export interface WeeklyTop5Repository {
-  /** 해당 주 차 순위표를 rank 오름차순으로 조회 (동순위 시 spot_id 안정 정렬) */
   findByWeekStart(weekStart: string): Promise<WeeklyTop5Entry[]>;
-
-  /** 집계된 행이 있을 때 가장 최근 `week_start`(DATE). 없으면 null */
   findLatestWeekStart(): Promise<string | null>;
+  replaceWeek(
+    weekStart: string,
+    rows: Array<{ rank: number; spotId: string; avgStarIndex: number }>,
+  ): Promise<void>;
 }
 
 export const WEEKLY_TOP5_REPOSITORY = 'WEEKLY_TOP5_REPOSITORY';

--- a/backend/src/common/kst-date.ts
+++ b/backend/src/common/kst-date.ts
@@ -1,0 +1,74 @@
+/** 서울 달력 기준 유틸 — Cron·집계 주차·moon 캐시 키에 사용 */
+
+export function getKstYmd(d = new Date()): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(d);
+}
+
+/** 해당 KST 날짜의 KST 자정을 나타내는 UTC 시각(ms) — 날짜 가산에 사용 */
+export function kstYmdToUtcMs(ymd: string): number {
+  const [y, m, d] = ymd.split('-').map(Number);
+  return Date.UTC(y, m - 1, d, -9, 0, 0);
+}
+
+export function addDaysKst(ymd: string, n: number): string {
+  const t = kstYmdToUtcMs(ymd) + n * 86400000;
+  return getKstYmd(new Date(t));
+}
+
+/** 0=월 … 6=일 (KST) */
+export function kstWeekdayMon0(ymd: string): number {
+  const wd = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Seoul',
+    weekday: 'short',
+  }).format(new Date(kstYmdToUtcMs(ymd) + 43200000));
+  const map: Record<string, number> = {
+    Mon: 0,
+    Tue: 1,
+    Wed: 2,
+    Thu: 3,
+    Fri: 4,
+    Sat: 5,
+    Sun: 6,
+  };
+  return map[wd] ?? 0;
+}
+
+/** KST 기준 해당 날짜가 속한 주의 월요일(YYYY-MM-DD) */
+export function thisWeekMondayKst(ymd: string): string {
+  return addDaysKst(ymd, -kstWeekdayMon0(ymd));
+}
+
+/**
+ * 직전에 끝난 월~일 주간의 week_start(월요일).
+ * 월요일 07:00 KST에 돌리면 방금 끝난 주(월~일)의 월요일.
+ */
+export function lastCompletedWeekMondayKst(d = new Date()): string {
+  const today = getKstYmd(d);
+  const thisMon = thisWeekMondayKst(today);
+  return addDaysKst(thisMon, -7);
+}
+
+export function weekEndSundayKst(weekMonday: string): string {
+  return addDaysKst(weekMonday, 6);
+}
+
+export type ParseKstYmdResult =
+  | { ok: true; ymd: string }
+  | { ok: false; error: 'format' | 'date' };
+
+/** `weekStart` 쿼리 등 — trim 후 YYYY-MM-DD 검증만 (요일 정규화 없음). */
+export function parseKstYmdInput(raw: string): ParseKstYmdResult {
+  const ymd = raw.trim().slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(ymd)) {
+    return { ok: false, error: 'format' };
+  }
+  if (Number.isNaN(new Date(`${ymd}T12:00:00Z`).getTime())) {
+    return { ok: false, error: 'date' };
+  }
+  return { ok: true, ymd };
+}

--- a/backend/src/common/kst-week-start.ts
+++ b/backend/src/common/kst-week-start.ts
@@ -1,0 +1,27 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  lastCompletedWeekMondayKst,
+  parseKstYmdInput,
+  thisWeekMondayKst,
+} from './kst-date';
+
+/** `GET /top5/weekly?weekStart=` — DB `week_start`와 맞는 YYYY-MM-DD. */
+export function requireQueryYmd(raw: string): string {
+  const r = parseKstYmdInput(raw);
+  if (!r.ok) {
+    throw new BadRequestException(
+      r.error === 'format'
+        ? 'weekStart는 YYYY-MM-DD 형식이어야 합니다.'
+        : 'weekStart가 유효한 날짜가 아닙니다.',
+    );
+  }
+  return r.ymd;
+}
+
+/** `job=weeklyTop5` — 비우면 직전 완료 주 월요일, 있으면 해당 날짜가 속한 KST 주의 월요일. */
+export function resolveAggregationWeekMonday(weekStart?: string): string {
+  if (weekStart == null || weekStart.trim() === '') {
+    return lastCompletedWeekMondayKst();
+  }
+  return thisWeekMondayKst(requireQueryYmd(weekStart));
+}

--- a/backend/src/cron/cron.controller.ts
+++ b/backend/src/cron/cron.controller.ts
@@ -7,17 +7,52 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CronService } from './cron.service';
+import { WeeklyTop5AggregationService } from '../weekly-top5/weekly-top5-aggregation.service';
 
 @ApiTags('cron')
 @Controller('cron')
 export class CronController {
-  constructor(private readonly cronService: CronService) {}
+  constructor(
+    private readonly cronService: CronService,
+    private readonly weeklyTop5Aggregation: WeeklyTop5AggregationService,
+  ) {}
 
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @Post('run-once')
-  @ApiOperation({ summary: '기상/미세먼지/달 캐시 수집 즉시 실행 (개발 검증용)' })
-  async runOnce() {
+  @ApiOperation({
+    summary: 'Cron 수동 실행 (개발 검증용)',
+    description:
+      '`job` 없음 또는 `weather`: 기상·미세먼지·달 캐시 수집. ' +
+      '`todayStarIndexSnapshot`: KST **오늘** 명소별 Star-Index 점수를 캐시 기준으로 `spot_star_index_daily`에 upsert. ' +
+      '`weeklyTop5`: 일별 평균 TOP5 저장. `weekStart` 생략=직전 완료 주, 지정=해당 날짜가 속한 KST 주(월~일).',
+  })
+  @ApiQuery({
+    name: 'job',
+    required: false,
+    enum: ['weather', 'todayStarIndexSnapshot', 'weeklyTop5'],
+  })
+  @ApiQuery({
+    name: 'weekStart',
+    required: false,
+    description:
+      '`job=weeklyTop5`일 때만 사용. YYYY-MM-DD — 그 날짜가 속한 주의 월요일로 정규화 후 그 주를 집계.',
+    example: '2026-04-28',
+  })
+  async runOnce(
+    @Query('job') job?: string,
+    @Query('weekStart') weekStart?: string,
+  ) {
+    if (job === 'weeklyTop5') {
+      const r =
+        await this.weeklyTop5Aggregation.aggregateWeekTop5FromDaily(weekStart);
+      return { message: '주간 TOP5 집계 완료', ...r };
+    }
+    if (job === 'todayStarIndexSnapshot') {
+      const r =
+        await this.weeklyTop5Aggregation.snapshotTodayStarIndexScores();
+      return { message: '오늘(KST) 일별 Star-Index 스냅샷 완료', ...r };
+    }
     await this.cronService.runCollectionOnce();
     return { message: 'Cron 수집 실행 완료' };
   }

--- a/backend/src/cron/cron.module.ts
+++ b/backend/src/cron/cron.module.ts
@@ -3,9 +3,10 @@ import { CronService } from './cron.service';
 import { SkyModule } from '../sky/sky.module';
 import { CronController } from './cron.controller';
 import { SpotsModule } from '../spots/spots.module';
+import { WeeklyTop5Module } from '../weekly-top5/weekly-top5.module';
 
 @Module({
-  imports: [SkyModule, SpotsModule],
+  imports: [SkyModule, SpotsModule, WeeklyTop5Module],
   controllers: [CronController],
   providers: [CronService],
   exports: [CronService],

--- a/backend/src/cron/cron.service.ts
+++ b/backend/src/cron/cron.service.ts
@@ -9,6 +9,8 @@ import {
   SPOT_REPOSITORY,
   type SpotRepository,
 } from '../common/interfaces/spot.repository';
+import { WeeklyTop5AggregationService } from '../weekly-top5/weekly-top5-aggregation.service';
+import { getKstYmd } from '../common/kst-date';
 
 // ──────────────────────────────────────────────────────────────
 // Cron 수집기 — 장성재(A) 담당
@@ -24,6 +26,7 @@ export class CronService {
     private readonly config: ConfigService,
     private readonly skyService: SkyService,
     @Inject(SPOT_REPOSITORY) private readonly spots: SpotRepository,
+    private readonly weeklyTop5Aggregation: WeeklyTop5AggregationService,
   ) {}
 
   private latLngToGrid(lat: number, lng: number): { nx: number; ny: number } {
@@ -233,12 +236,28 @@ export class CronService {
     }
   }
 
-  // ── 주간 TOP5 — 매주 월요일 오전 7시 갱신 ────────────────────
-  @Cron('0 7 * * 1')
+  // ── 주간 TOP5 일별 입력 — 매일 00:10 KST (moon·weather 캐시가 KST 날짜와 맞춘 뒤) ──
+  @Cron('10 0 * * *', { timeZone: 'Asia/Seoul' })
+  async snapshotDailyStarIndexScoresJob() {
+    this.logger.log('[Cron] 일별 Star-Index 스냅샷(명소 전체) 시작...');
+    try {
+      await this.weeklyTop5Aggregation.snapshotTodayStarIndexScores();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.logger.error(`[Cron] 일별 스냅샷 실패: ${msg}`);
+    }
+  }
+
+  // ── 주간 TOP5 — 매주 월요일 07:00 KST (직전 월~일 평균) ────────────────────
+  @Cron('0 7 * * 1', { timeZone: 'Asia/Seoul' })
   async calcWeeklyTop5() {
-    this.logger.log('주간 TOP5 산출 시작...');
-    // TODO: 김세희(B) — 5주차 구현
-    // cache.set(`top5:weekly:${week}`, data, 86400)
+    this.logger.log('[Cron] 주간 TOP5 집계 시작...');
+    try {
+      await this.weeklyTop5Aggregation.aggregateWeekTop5FromDaily();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.logger.error(`[Cron] 주간 TOP5 집계 실패: ${msg}`);
+    }
   }
 
   /**
@@ -267,7 +286,7 @@ export class CronService {
     const { nx, ny } = this.latLngToGrid(lat, lng);
     const weatherKey = `weather:${nx}:${ny}`;
     const dustKey = 'dust:서울';
-    const moonKey = `moon:${new Date().toISOString().slice(0, 10).replace(/-/g, '')}`;
+    const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
 
     const [weather, dust, moon] = await Promise.all([
       this.cache.get(weatherKey),

--- a/backend/src/migrations/1720050000000-add-spot-star-index-daily.ts
+++ b/backend/src/migrations/1720050000000-add-spot-star-index-daily.ts
@@ -1,0 +1,50 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * - `weekly_top5`: 주간 TOP5 결과 (신규 환경용 IF NOT EXISTS)
+ * - `spot_star_index_daily`: 명소별 일별 Star-Index 스냅샷 (주간 평균 집계 입력)
+ */
+export class AddSpotStarIndexDaily1720050000000 implements MigrationInterface {
+  name = 'AddSpotStarIndexDaily1720050000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS pgcrypto`);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS weekly_top5 (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        week_start date NOT NULL,
+        rank smallint NOT NULL CHECK (rank BETWEEN 1 AND 5),
+        spot_id uuid NOT NULL REFERENCES spots(id) ON DELETE CASCADE,
+        avg_star_index numeric(5, 2) NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        UNIQUE (week_start, rank)
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_weekly_top5_week_rank
+      ON weekly_top5 (week_start DESC, rank ASC)
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS spot_star_index_daily (
+        spot_id uuid NOT NULL REFERENCES spots(id) ON DELETE CASCADE,
+        day date NOT NULL,
+        score numeric(5, 2) NOT NULL CHECK (score >= 0 AND score <= 100),
+        created_at timestamptz NOT NULL DEFAULT now(),
+        PRIMARY KEY (spot_id, day)
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_spot_star_index_daily_day
+      ON spot_star_index_daily (day)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS spot_star_index_daily`);
+    await queryRunner.query(`DROP TABLE IF EXISTS weekly_top5`);
+  }
+}

--- a/backend/src/star-index/star-index.service.ts
+++ b/backend/src/star-index/star-index.service.ts
@@ -11,6 +11,7 @@ import { MOON_ALTITUDE_MISSING_SENTINEL } from '../sky/kasi.mapper';
 import type { WeatherSnapshot } from '../common/interfaces/weather-snapshot';
 import { normalizeWeatherSnapshotForStorage } from '../common/interfaces/weather-snapshot';
 import { CorrectionsService } from '../corrections/corrections.service';
+import { getKstYmd } from '../common/kst-date';
 
 // ── 기상 데이터 타입 ─────────────────────────────────────────
 interface WeatherData {
@@ -62,7 +63,7 @@ export class StarIndexService {
     const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
     const weatherKey = `weather:${nx}:${ny}`;
     const dustKey = 'dust:서울';
-    const moonKey = `moon:${new Date().toISOString().slice(0, 10).replace(/-/g, '')}`;
+    const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
 
     const weather = await this.cache.get<WeatherData>(weatherKey);
     const dust = await this.cache.get<DustData>(dustKey);
@@ -99,6 +100,47 @@ export class StarIndexService {
       weatherSnapshot,
       cacheKeys: { weatherKey, dustKey, moonKey },
     };
+  }
+
+  /**
+   * `star_index:{spotId}` 캐시를 보지 않고, 현재 weather/dust/moon 캐시만으로 점수 계산.
+   * 일별 스냅샷·주간 TOP5 집계 등 배치용.
+   */
+  async computeFreshScoreFromCache(spot: Spot): Promise<number> {
+    const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
+    const weatherKey = `weather:${nx}:${ny}`;
+    const dustKey = 'dust:서울';
+    const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
+
+    const weather = await this.cache.get<WeatherData>(weatherKey);
+    const dust = await this.cache.get<DustData>(dustKey);
+    const moon = await this.cache.get<MoonData>(moonKey);
+
+    if (!weather || !dust || !moon) {
+      const missing = [
+        !weather ? weatherKey : null,
+        !dust ? dustKey : null,
+        !moon ? moonKey : null,
+      ]
+        .filter(Boolean)
+        .join(', ');
+      throw new ServiceUnavailableException(
+        `캐시 데이터가 부족합니다. 누락 키: ${missing}. Cron 수집기를 먼저 실행하세요.`,
+      );
+    }
+
+    const correctionScore =
+      await this.correctionsService.getAggregatedCorrectionScoreForSpot(spot.id);
+
+    const { score } = this.calcStarIndexWithSnapshot({
+      weather,
+      dust,
+      moon,
+      bortleClass: spot.bortleClass,
+      elevationM: spot.elevationM,
+      correctionScore,
+    });
+    return score;
   }
 
   /**

--- a/backend/src/weekly-top5/dto/weekly-top5-item.dto.ts
+++ b/backend/src/weekly-top5/dto/weekly-top5-item.dto.ts
@@ -1,26 +1,21 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-/** GET /top5/weekly 한 행 — spots 조인으로 채운 노출용 DTO */
 export class WeeklyTop5ItemDto {
   @ApiProperty({ format: 'uuid' })
   id: string;
 
-  @ApiProperty({
-    description:
-      '집계 구간이 시작된 월요일 (지난주 월~일 TOP5의 week_start, YYYY-MM-DD)',
-    example: '2026-05-04',
-  })
+  @ApiProperty({ description: '집계 주 월요일', example: '2026-05-04' })
   weekStart: string;
 
-  @ApiProperty({ description: 'TOP5 카드에 표시할 순위', minimum: 1, maximum: 5 })
+  @ApiProperty({ minimum: 1, maximum: 5 })
   rank: number;
 
   @ApiProperty({ format: 'uuid' })
   spotId: string;
 
-  @ApiProperty({ description: 'spots.name 조인' })
+  @ApiProperty()
   spotName: string;
 
-  @ApiProperty({ description: '해당 주 평균 Star-Index (스냅샷)', example: 82.5 })
+  @ApiProperty({ example: 82.5 })
   avgStarIndex: number;
 }

--- a/backend/src/weekly-top5/spot-star-index-daily.entity.ts
+++ b/backend/src/weekly-top5/spot-star-index-daily.entity.ts
@@ -1,0 +1,17 @@
+import { Column, CreateDateColumn, Entity, PrimaryColumn } from 'typeorm';
+
+/** 명소별 일별 Star-Index (주간 평균 입력). */
+@Entity('spot_star_index_daily')
+export class SpotStarIndexDailyEntity {
+  @PrimaryColumn({ name: 'spot_id', type: 'uuid' })
+  spotId: string;
+
+  @PrimaryColumn({ type: 'date' })
+  day: string;
+
+  @Column({ type: 'numeric', precision: 5, scale: 2 })
+  score: number;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/weekly-top5/typeorm-weekly-top5.repository.ts
+++ b/backend/src/weekly-top5/typeorm-weekly-top5.repository.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -29,6 +30,26 @@ export class TypeOrmWeeklyTop5Repository implements WeeklyTop5Repository {
       .getRawOne<{ max: string | Date | null }>();
     if (row?.max == null) return null;
     return normalizeDateOnly(row.max);
+  }
+
+  async replaceWeek(
+    weekStart: string,
+    rows: Array<{ rank: number; spotId: string; avgStarIndex: number }>,
+  ): Promise<void> {
+    await this.repo.manager.transaction(async (em) => {
+      await em.delete(WeeklyTop5Entity, { weekStart });
+      if (!rows.length) return;
+      await em.insert(
+        WeeklyTop5Entity,
+        rows.map((r) => ({
+          id: randomUUID(),
+          weekStart,
+          rank: r.rank,
+          spotId: r.spotId,
+          avgStarIndex: r.avgStarIndex.toFixed(2),
+        })),
+      );
+    });
   }
 
   private toEntry(e: WeeklyTop5Entity): WeeklyTop5Entry {

--- a/backend/src/weekly-top5/weekly-top5-aggregation.service.ts
+++ b/backend/src/weekly-top5/weekly-top5-aggregation.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { StarIndexService } from '../star-index/star-index.service';
+import {
+  SPOT_REPOSITORY,
+  type SpotRepository,
+} from '../common/interfaces/spot.repository';
+import {
+  WEEKLY_TOP5_REPOSITORY,
+  type WeeklyTop5Repository,
+} from '../common/interfaces/weekly-top5.repository';
+import { getKstYmd, weekEndSundayKst } from '../common/kst-date';
+import { resolveAggregationWeekMonday } from '../common/kst-week-start';
+import { SpotStarIndexDailyEntity } from './spot-star-index-daily.entity';
+
+const WEEKLY_TOP5_CACHE_MS = 86_400_000;
+
+@Injectable()
+export class WeeklyTop5AggregationService {
+  private readonly logger = new Logger(WeeklyTop5AggregationService.name);
+
+  constructor(
+    @Inject(SPOT_REPOSITORY) private readonly spots: SpotRepository,
+    private readonly starIndex: StarIndexService,
+    @InjectRepository(SpotStarIndexDailyEntity)
+    private readonly dailyRepo: Repository<SpotStarIndexDailyEntity>,
+    @Inject(WEEKLY_TOP5_REPOSITORY)
+    private readonly weeklyTop5: WeeklyTop5Repository,
+    @Inject(CACHE_MANAGER) private readonly cache: Cache,
+  ) {}
+
+  /** KST 오늘, 캐시 기준 점수 → `spot_star_index_daily` upsert. */
+  async snapshotTodayStarIndexScores(): Promise<{
+    day: string;
+    ok: number;
+    failed: number;
+    ms: number;
+  }> {
+    const t0 = Date.now();
+    const day = getKstYmd();
+    const all = await this.spots.findAll();
+    let ok = 0;
+    let failed = 0;
+
+    for (const spot of all) {
+      try {
+        const score = await this.starIndex.computeFreshScoreFromCache(spot);
+        await this.dailyRepo.upsert(
+          { spotId: spot.id, day, score },
+          ['spotId', 'day'],
+        );
+        ok++;
+      } catch (e) {
+        failed++;
+        const msg = e instanceof Error ? e.message : String(e);
+        this.logger.warn(`[TOP5 daily] spot ${spot.id} 스킵: ${msg}`);
+      }
+    }
+
+    const ms = Date.now() - t0;
+    this.logger.log(
+      `[TOP5 daily] 완료 day=${day} ok=${ok} failed=${failed} 소요=${ms}ms`,
+    );
+    return { day, ok, failed, ms };
+  }
+
+  /**
+   * `spot_star_index_daily` 주간 평균 TOP5 → `weekly_top5` + 캐시.
+   * `weekStart` 없음: 직전 완료 주(월~일). 있음: 그 날짜가 속한 KST 주.
+   */
+  async aggregateWeekTop5FromDaily(weekStart?: string): Promise<{
+    weekStart: string;
+    weekEnd: string;
+    inserted: number;
+    ms: number;
+  }> {
+    const t0 = Date.now();
+    const mon = resolveAggregationWeekMonday(weekStart);
+    const weekEnd = weekEndSundayKst(mon);
+
+    const raw = await this.dailyRepo
+      .createQueryBuilder('d')
+      .select('d.spot_id', 'spot_id')
+      .addSelect('ROUND(AVG(d.score)::numeric, 2)', 'avg_score')
+      .where('d.day >= :start AND d.day <= :end', { start: mon, end: weekEnd })
+      .groupBy('d.spot_id')
+      .orderBy('AVG(d.score)', 'DESC')
+      .addOrderBy('d.spot_id', 'ASC')
+      .limit(5)
+      .getRawMany<{ spot_id: string; avg_score: string }>();
+
+    const rows = raw.map((r, i) => ({
+      rank: i + 1,
+      spotId: r.spot_id,
+      avgStarIndex: Number(r.avg_score),
+    }));
+
+    await this.weeklyTop5.replaceWeek(mon, rows);
+
+    await this.cache.set(
+      `top5:weekly:${mon}`,
+      rows.map((r) => ({
+        weekStart: mon,
+        rank: r.rank,
+        spotId: r.spotId,
+        avgStarIndex: r.avgStarIndex,
+      })),
+      WEEKLY_TOP5_CACHE_MS,
+    );
+
+    const ms = Date.now() - t0;
+    this.logger.log(
+      `[TOP5 weekly] 완료 week_start=${mon}~${weekEnd} rows=${rows.length} 소요=${ms}ms`,
+    );
+    return { weekStart: mon, weekEnd, inserted: rows.length, ms };
+  }
+}

--- a/backend/src/weekly-top5/weekly-top5.controller.ts
+++ b/backend/src/weekly-top5/weekly-top5.controller.ts
@@ -19,16 +19,15 @@ export class WeeklyTop5Controller {
   @ApiBearerAuth()
   @Get('weekly')
   @ApiOperation({
-    summary: '주간 TOP5 조회 (지난주 월~일 집계, week_start = 그 주의 월요일)',
+    summary: '주간 TOP5 조회',
     description:
-      '`weekStart` 생략 시 DB에 존재하는 가장 최근 `week_start`로 조회합니다. ' +
-      '해당 주 데이터가 없으면 빈 배열 `[]`을 반환합니다.',
+      '저장된 `weekly_top5`만 조회. `weekStart` 생략 시 최근 `week_start`, 없으면 `[]`.',
   })
   @ApiQuery({
     name: 'weekStart',
     required: false,
-    description: '조회할 week_start (YYYY-MM-DD, 집계 구간의 월요일)',
-    example: '2026-05-04',
+    description: '그 주 월요일 YYYY-MM-DD. 생략 시 최근 집계 주.',
+    example: '2026-04-28',
   })
   @ApiOkResponse({ type: WeeklyTop5ItemDto, isArray: true })
   async getWeekly(

--- a/backend/src/weekly-top5/weekly-top5.module.ts
+++ b/backend/src/weekly-top5/weekly-top5.module.ts
@@ -2,17 +2,21 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { SpotsModule } from '../spots/spots.module';
+import { StarIndexModule } from '../star-index/star-index.module';
 import { WEEKLY_TOP5_REPOSITORY } from '../common/interfaces/weekly-top5.repository';
 import { TypeOrmWeeklyTop5Repository } from './typeorm-weekly-top5.repository';
 import { WeeklyTop5Entity } from './weekly-top5.entity';
+import { SpotStarIndexDailyEntity } from './spot-star-index-daily.entity';
 import { WeeklyTop5Controller } from './weekly-top5.controller';
 import { WeeklyTop5Service } from './weekly-top5.service';
+import { WeeklyTop5AggregationService } from './weekly-top5-aggregation.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([WeeklyTop5Entity]),
+    TypeOrmModule.forFeature([WeeklyTop5Entity, SpotStarIndexDailyEntity]),
     SpotsModule,
     AuthModule,
+    StarIndexModule,
   ],
   controllers: [WeeklyTop5Controller],
   providers: [
@@ -22,7 +26,8 @@ import { WeeklyTop5Service } from './weekly-top5.service';
       useExisting: TypeOrmWeeklyTop5Repository,
     },
     WeeklyTop5Service,
+    WeeklyTop5AggregationService,
   ],
-  exports: [WEEKLY_TOP5_REPOSITORY],
+  exports: [WEEKLY_TOP5_REPOSITORY, WeeklyTop5AggregationService],
 })
 export class WeeklyTop5Module {}

--- a/backend/src/weekly-top5/weekly-top5.service.ts
+++ b/backend/src/weekly-top5/weekly-top5.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadRequestException,
-  Injectable,
-  Inject,
-} from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import {
   WEEKLY_TOP5_REPOSITORY,
   type WeeklyTop5Entry,
@@ -12,9 +8,8 @@ import {
   SPOT_REPOSITORY,
   type SpotRepository,
 } from '../common/interfaces/spot.repository';
+import { requireQueryYmd } from '../common/kst-week-start';
 import { WeeklyTop5ItemDto } from './dto/weekly-top5-item.dto';
-
-const WEEK_START_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 @Injectable()
 export class WeeklyTop5Service {
@@ -25,13 +20,11 @@ export class WeeklyTop5Service {
     private readonly spots: SpotRepository,
   ) {}
 
-  /**
-   * @param weekStart YYYY-MM-DD 생략 시 DB의 MAX(week_start)
-   */
+  /** `weekStart` 생략 시 `MAX(week_start)` 주차. */
   async getWeekly(weekStart?: string): Promise<WeeklyTop5ItemDto[]> {
     const resolved =
       weekStart != null && weekStart.trim() !== ''
-        ? parseWeekStartQuery(weekStart.trim())
+        ? requireQueryYmd(weekStart)
         : await this.weeklyTop5Repo.findLatestWeekStart();
 
     if (resolved == null) {
@@ -39,7 +32,7 @@ export class WeeklyTop5Service {
     }
 
     const rows = await this.weeklyTop5Repo.findByWeekStart(resolved);
-    if (rows.length === 0) {
+    if (!rows.length) {
       return [];
     }
 
@@ -57,15 +50,4 @@ export class WeeklyTop5Service {
       avgStarIndex: row.avgStarIndex,
     };
   }
-}
-
-function parseWeekStartQuery(raw: string): string {
-  if (!WEEK_START_RE.test(raw)) {
-    throw new BadRequestException('weekStart는 YYYY-MM-DD 형식이어야 합니다.');
-  }
-  const d = new Date(`${raw}T12:00:00Z`);
-  if (Number.isNaN(d.getTime())) {
-    throw new BadRequestException('weekStart가 유효한 날짜가 아닙니다.');
-  }
-  return raw.slice(0, 10);
 }


### PR DESCRIPTION
## 🔎 What

- spot_star_index_daily: 명소별 일별 Star-Index 저장(마이그레이션·엔티티·upsert)
- 일별 스냅샷: 캐시 기준 점수 계산 → DB 반영, Cron 매일 00:10 KST, 수동 POST /cron/run-once?job=todayStarIndexSnapshot
- 주간 TOP5: 일별 평균으로 상위 5 → weekly_top5 교체 저장, Cron 매주 월 07:00 KST, 수동 ?job=weeklyTop5 + 선택 weekStart(특정 KST 주 집계)
- 조회 API: GET /top5/weekly (weekStart 생략 시 최근 집계 주), JWT
- Star-Index: 일별 경로 정리(과거일 외부 재구성 제거 등, 캐시 기반 일 스냅샷에 맞춤)
- 공통·리팩터: KST weekStart 파싱(kst-date / kst-week-start), 집계 메서드명 정리, weekly_top5 일괄 insert 등 정리

## 🔗 Issue 

- Closes: #53 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
