### PR TITLE
feat: 주간 TOP5 카드 UI

### DIFF
--- a/backend/src/weekly-top5/dto/weekly-top5-item.dto.ts
+++ b/backend/src/weekly-top5/dto/weekly-top5-item.dto.ts
@@ -18,4 +18,10 @@ export class WeeklyTop5ItemDto {
 
   @ApiProperty({ example: 82.5 })
   avgStarIndex: number;
+
+  @ApiProperty({
+    description: '표시용 문자열',
+    example: '82.5',
+  })
+  avgStarIndexText: string;
 }

--- a/backend/src/weekly-top5/typeorm-weekly-top5.repository.ts
+++ b/backend/src/weekly-top5/typeorm-weekly-top5.repository.ts
@@ -16,20 +16,25 @@ export class TypeOrmWeeklyTop5Repository implements WeeklyTop5Repository {
   ) {}
 
   async findByWeekStart(weekStart: string): Promise<WeeklyTop5Entry[]> {
-    const rows = await this.repo.find({
-      where: { weekStart },
-      order: { rank: 'ASC', spotId: 'ASC' },
-    });
+    const rows = await this.repo
+      .createQueryBuilder('w')
+      // QueryBuilder에서는 엔티티 프로퍼티명을 사용해야 안정적으로 컬럼 매핑된다.
+      .where('w.weekStart = :weekStart', { weekStart })
+      .orderBy('w.rank', 'ASC')
+      .addOrderBy('w.spotId', 'ASC')
+      .getMany();
     return rows.map((e) => this.toEntry(e));
   }
 
   async findLatestWeekStart(): Promise<string | null> {
-    const row = await this.repo
-      .createQueryBuilder('w')
-      .select('MAX(w.week_start)', 'max')
-      .getRawOne<{ max: string | Date | null }>();
-    if (row?.max == null) return null;
-    return normalizeDateOnly(row.max);
+    // `MAX()` 대신 최신 row를 정렬로 조회 (date 타입 + driver 매핑 이슈 회피)
+    const [row] = await this.repo.find({
+      select: { weekStart: true } as unknown as { weekStart: true },
+      order: { weekStart: 'DESC' },
+      take: 1,
+    });
+    if (!row?.weekStart) return null;
+    return normalizeDateOnly(row.weekStart);
   }
 
   async replaceWeek(

--- a/backend/src/weekly-top5/weekly-top5.service.ts
+++ b/backend/src/weekly-top5/weekly-top5.service.ts
@@ -48,6 +48,7 @@ export class WeeklyTop5Service {
       spotId: row.spotId,
       spotName: spot?.name ?? '(명소 없음)',
       avgStarIndex: row.avgStarIndex,
+      avgStarIndexText: String(row.avgStarIndex),
     };
   }
 }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -40,13 +40,14 @@ import { getDefaultSpotId } from './lib/config';
 import {
   ApiRequestError,
   type CorrectionAggregateDto,
+  fetchWeeklyTop5,
   fetchCorrectionAggregate,
   fetchStarIndex,
   SessionExpiredError,
   submitStarIndexCorrection,
 } from './lib/api-client';
 import { starIndexResponseToCardModel } from './lib/star-index-display';
-import type { StarIndexResponseDto } from './lib/types/api';
+import type { StarIndexResponseDto, WeeklyTop5ItemDto } from './lib/types/api';
 
 function starIndexErrorFromApi(e: ApiRequestError): StatefulCardError {
   if (e.status === 503) {
@@ -103,6 +104,10 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
   const [perceivedQuality, setPerceivedQuality] = useState(75);
   const [corrBusy, setCorrBusy] = useState(false);
   const [corrMsg, setCorrMsg] = useState<string | null>(null);
+
+  const [top5Loading, setTop5Loading] = useState(false);
+  const [top5Error, setTop5Error] = useState<string | null>(null);
+  const [top5Items, setTop5Items] = useState<WeeklyTop5ItemDto[] | null>(null);
 
   /** 가상 밤하늘 — 관측 시각(UTC) 스크럽용 */
   const [skyObserveAtIso, setSkyObserveAtIso] = useState(() =>
@@ -173,6 +178,36 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
       cancelled = true;
     };
   }, [activeTab, focusSpotId, siRefreshKey]);
+
+  useEffect(() => {
+    if (activeTab !== 'home') return;
+    let cancelled = false;
+    (async () => {
+      setTop5Loading(true);
+      setTop5Error(null);
+      try {
+        const items = await fetchWeeklyTop5();
+        if (!cancelled) setTop5Items(items);
+      } catch (e) {
+        if (e instanceof SessionExpiredError) {
+          if (!cancelled) setTop5Error('세션이 만료되었습니다. 다시 로그인해 주세요.');
+          await onSessionInvalidated();
+          return;
+        }
+        if (e instanceof ApiRequestError) {
+          if (!cancelled) setTop5Error(e.message);
+        } else {
+          if (!cancelled) setTop5Error('주간 TOP5를 불러오지 못했습니다.');
+        }
+        if (!cancelled) setTop5Items(null);
+      } finally {
+        if (!cancelled) setTop5Loading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, onSessionInvalidated]);
 
   const kakaoJavascriptKey = process.env.EXPO_PUBLIC_KAKAO_JAVASCRIPT_KEY;
   const kakaoMapPageUrl = process.env.EXPO_PUBLIC_KAKAO_MAP_PAGE_URL;
@@ -463,6 +498,90 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
               <Badge label="주차" variant="muted" />
               <Badge label="Red Mode" variant="red" />
             </View>
+
+            <Card
+              title="주간 TOP5"
+              description="지난주 Star-Index 평균이 높은 명소"
+            >
+              {top5Loading ? (
+                <Text style={{ color: theme.mutedForeground, fontSize: 12 }}>
+                  불러오는 중…
+                </Text>
+              ) : top5Error ? (
+                <Text style={{ color: theme.destructive, fontSize: 12 }}>
+                  {top5Error}
+                </Text>
+              ) : top5Items == null ? (
+                <Text style={{ color: theme.mutedForeground, fontSize: 12 }}>
+                  데이터를 준비 중입니다.
+                </Text>
+              ) : top5Items.length === 0 ? (
+                <Text style={{ color: theme.mutedForeground, fontSize: 12 }}>
+                  지난주 TOP5 데이터가 아직 없습니다.
+                </Text>
+              ) : (
+                <View style={{ gap: 8 }}>
+                  {top5Items.slice(0, 5).map((item) => (
+                    <Pressable
+                      key={item.id}
+                      onPress={() => setFocusSpotId(item.spotId)}
+                      style={({ pressed }) => {
+                        const selected = focusSpotId === item.spotId;
+                        return {
+                          paddingVertical: 8,
+                          paddingHorizontal: 10,
+                          borderRadius: theme.radius,
+                          borderWidth: 1,
+                          borderColor: selected ? theme.ring : theme.borderSubtle,
+                          backgroundColor: pressed || selected ? theme.input : 'transparent',
+                          opacity: pressed ? 0.95 : 1,
+                        };
+                      }}
+                    >
+                      <View
+                        style={{
+                          flexDirection: 'row',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          gap: 10,
+                        }}
+                      >
+                        <View style={{ flex: 1, minWidth: 0, flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                          <Badge
+                            label={`${item.rank}위`}
+                            mono
+                            variant={
+                              item.rank === 1
+                                ? 'gold'     // 1위: gold
+                                : item.rank === 2
+                                  ? 'steel' // 2위: steel
+                                  : item.rank === 3
+                                    ? 'bronze' // 3위: bronze
+                                    : 'muted'
+                            }
+                          />
+                          <Text
+                            style={{ color: theme.foreground, fontSize: 13, fontWeight: '600' }}
+                            numberOfLines={1}
+                          >
+                            {item.spotName}
+                          </Text>
+                        </View>
+                        <Text
+                          style={{
+                            color: theme.starGold,
+                            fontFamily: 'SpaceMono-Regular',
+                            fontSize: 13,
+                          }}
+                        >
+                          {item.avgStarIndexText || '—'}
+                        </Text>
+                      </View>
+                    </Pressable>
+                  ))}
+                </View>
+              )}
+            </Card>
 
             {focusSpotId ? (
               <Text

--- a/frontend/components/ui/Badge.tsx
+++ b/frontend/components/ui/Badge.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { StyleSheet, Text, View, type ViewStyle } from 'react-native';
 import { useTheme } from '../../themes/ThemeContext';
 
-export type BadgeVariant = 'gold' | 'steel' | 'muted' | 'red' | 'outline';
+export type BadgeVariant = 'gold' | 'bronze' | 'steel' | 'muted' | 'red' | 'outline';
 
 interface BadgeProps {
   label:    string;
@@ -26,6 +26,12 @@ export function Badge({ label, variant = 'muted', mono = false, style }: BadgePr
       bg:     theme.starGold + '1A',  // 10% alpha
       text:   theme.starGold,
       border: theme.starGold + '45',  // 27% alpha
+    },
+    bronze: {
+      // 테마 토큰에 없어서 고정 hex 사용 (Blue/Green 없음)
+      bg:     '#7A4A2A14',   // ~8% alpha
+      text:   '#A8643A',     // muted copper
+      border: '#7A4A2A52',   // ~32% alpha
     },
     steel: {
       bg:     theme.nebulaSteel + '26',

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -10,6 +10,7 @@ import type {
   AuthTokensResponseDto,
   RefreshAccessResponseDto,
   StarIndexResponseDto,
+  WeeklyTop5ItemDto,
 } from './types/api';
 import { isAccessTokenExpired } from './jwt-utils';
 
@@ -219,6 +220,13 @@ export async function ensureFreshAccessToken(): Promise<{
 export function fetchStarIndex(spotId: string): Promise<StarIndexResponseDto> {
   const q = encodeURIComponent(spotId);
   return authorizedGetJson<StarIndexResponseDto>(`/star-index?spotId=${q}`);
+}
+
+export function fetchWeeklyTop5(weekStart?: string): Promise<WeeklyTop5ItemDto[]> {
+  const q = new URLSearchParams();
+  if (weekStart && weekStart.trim() !== '') q.set('weekStart', weekStart.trim());
+  const suffix = q.size ? `?${q.toString()}` : '';
+  return authorizedGetJson<WeeklyTop5ItemDto[]>(`/top5/weekly${suffix}`);
 }
 
 export interface SkyStarDto {

--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -52,3 +52,15 @@ export interface SpotDto {
   hasToilet: boolean;
   locationRadiusM: number;
 }
+
+export interface WeeklyTop5ItemDto {
+  id: string;
+  /** 집계 주 월요일 (YYYY-MM-DD) */
+  weekStart: string;
+  rank: number;
+  spotId: string;
+  spotName: string;
+  avgStarIndex: number;
+  /** 표시용 문자열(불필요한 0 제거) */
+  avgStarIndexText: string;
+}


### PR DESCRIPTION
## 🔎 What

- 홈 화면에 주간 TOP5(Star-index 점수 기반 명소 랭킹) 카드를 추가한다.
- 카드에는 1~5위까지 순위 + 명소 이름 + 점수를 5개 행으로 표시한다.
- 각 행을 탭하면 해당 spotId를 앱의 **기준 명소(focusSpotId)**로 설정하여, 홈의 Star-Index/명소 카드 및 로그 탭에서 동일한 기준 명소가 적용되게 한다.

## 시연

https://github.com/user-attachments/assets/60634e54-5154-4eea-b49c-3d7e98602068


## 🔗 Issue 

- Closes: #67 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
