### PR TITLE
feat(notifications): Star-Index 임계 알림(FCM) 및 기준 명소 설정

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,6 +45,13 @@ FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY----
 # 매주 월요일 07:05 KST 주간 TOP5 요약 푸시 (집계는 같은 날 07:00 Cron). 실제 발송 전까지 false 권장.
 # FCM_SCHEDULED_TOP5_PUSH_ENABLED=true
 
+# 매시 15분 KST — 사용자가 지정한 기준 명소의 Star-Index가 임계 이상일 때 당일 1회 푸시 (중복 방지 테이블).
+# FCM_SCHEDULED_STAR_INDEX_PUSH_ENABLED=true
+# STAR_INDEX_ALERT_THRESHOLD=70
+
+# production 에서 POST /notifications/dev/run-star-index-scheduled-push 로 스케줄을 즉시 돌리려면 true (개발은 NODE_ENV≠production 이면 생략 가능)
+# FCM_STAR_INDEX_MANUAL_TRIGGER_ENABLED=true
+
 # 서버 포트 (로컬 Windows에서 3000 EACCES 시 3333 권장 — Railway는 플랫폼이 PORT 지정)
 PORT=3333
 # 기본은 개발에서 127.0.0.1 만 listen → 폰으로 http://PC Wi-Fi IP:PORT 접속 시 타임아웃.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,6 +25,7 @@
         "cache-manager": "^5.4.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.4",
+        "dotenv": "^16.4.5",
         "firebase-admin": "^13.9.0",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,6 +40,7 @@
     "cache-manager": "^5.4.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.4",
+    "dotenv": "^16.4.5",
     "firebase-admin": "^13.9.0",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -23,8 +23,16 @@ import { KakaoPageController } from './kakao-page.controller';
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      /** npm run 에서 cwd 가 backend 여야 함. 혹시 루트에서 실행해도 backend/.env 를 읽도록 보조 경로 포함 */
-      envFilePath: [join(process.cwd(), '.env'), join(__dirname, '..', '.env')],
+      /**
+       * 1) 컴파일 결과 기준 backend/.env — cwd 와 무관하게 동일 서버 설정.
+       * 2) cwd 의 .env / 레포 루트에서 실행 시 backend/.env 보조.
+       * dotenv 는 이미 설정된 키를 나중 파일에서 덮어쓰지 않으므로, 가장 신뢰할 소스를 앞에 둠.
+       */
+      envFilePath: [
+        join(__dirname, '..', '.env'),
+        join(process.cwd(), '.env'),
+        join(process.cwd(), 'backend', '.env'),
+      ],
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],

--- a/backend/src/common/interfaces/notification.repository.ts
+++ b/backend/src/common/interfaces/notification.repository.ts
@@ -16,6 +16,8 @@ export interface NotificationPreference {
   starIndexAlertEnabled: boolean;
   astronomyEventAlertEnabled: boolean;
   top5AlertEnabled: boolean;
+  /** Star-Index 임계 알림용 기준 명소 */
+  alertSpotId: string | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -34,6 +36,7 @@ export interface NotificationRepository {
     starIndexAlertEnabled: boolean;
     astronomyEventAlertEnabled: boolean;
     top5AlertEnabled: boolean;
+    alertSpotId: string | null;
   }): Promise<NotificationPreference>;
 
   /** 실발송 테스트 등: 활성 토큰만 */
@@ -43,6 +46,23 @@ export interface NotificationRepository {
   findAndroidRecipientsTop5Enabled(): Promise<
     Array<{ userId: string; fcmToken: string }>
   >;
+
+  /** Star-Index 임계 알림: 알림·Star-Index ON + 기준 명소 지정 + 안드로이드 토큰 */
+  findAndroidRecipientsStarIndexThreshold(): Promise<
+    Array<{ userId: string; fcmToken: string; alertSpotId: string }>
+  >;
+
+  hasStarIndexPushSentForKstDay(params: {
+    userId: string;
+    spotId: string;
+    dayKstYmd: string;
+  }): Promise<boolean>;
+
+  recordStarIndexPushSent(params: {
+    userId: string;
+    spotId: string;
+    dayKstYmd: string;
+  }): Promise<void>;
 }
 
 export const NOTIFICATION_REPOSITORY = 'NOTIFICATION_REPOSITORY';

--- a/backend/src/load-env.ts
+++ b/backend/src/load-env.ts
@@ -1,0 +1,40 @@
+import { config } from 'dotenv';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Nest 기동 전 process.env 에 .env 주입.
+ * - 이 파일은 dist/load-env.js 로 컴파일되므로 __dirname/../.env = backend/.env
+ * - Windows 등에서 비어 있는 동명 환경변수가 이미 있으면 dotenv 기본 동작은 덮어쓰지 않음 → override: true
+ */
+const fromThisFile = resolve(__dirname, '..', '.env');
+const fromMonorepoRoot = resolve(process.cwd(), 'backend', '.env');
+const fromCwd = resolve(process.cwd(), '.env');
+
+let loadedPath: string | null = null;
+for (const p of [fromThisFile, fromMonorepoRoot, fromCwd]) {
+  if (!existsSync(p)) continue;
+  const r = config({ path: p, override: true });
+  if (r.error) {
+    // eslint-disable-next-line no-console
+    console.warn(`[load-env] dotenv 파싱 오류 (${p}):`, r.error.message);
+    continue;
+  }
+  loadedPath = p;
+  break;
+}
+
+if (!loadedPath && process.env.NODE_ENV !== 'production') {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[load-env] .env 파일 없음. 시도한 경로:\n  ${fromThisFile}\n  ${fromMonorepoRoot}\n  ${fromCwd}`,
+  );
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  const v = process.env.FCM_SCHEDULED_STAR_INDEX_PUSH_ENABLED;
+  // eslint-disable-next-line no-console
+  console.log(
+    `[load-env] FCM_SCHEDULED_STAR_INDEX_PUSH_ENABLED=${JSON.stringify(v)} (파일: ${loadedPath ?? '없음'})`,
+  );
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,3 +1,4 @@
+import './load-env';
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, Logger } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';

--- a/backend/src/migrations/1735000000000-add-alert-spot-star-index-push-sent.ts
+++ b/backend/src/migrations/1735000000000-add-alert-spot-star-index-push-sent.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAlertSpotStarIndexPushSent1735000000000
+  implements MigrationInterface
+{
+  name = 'AddAlertSpotStarIndexPushSent1735000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE notification_preferences
+      ADD COLUMN IF NOT EXISTS alert_spot_id uuid NULL
+      REFERENCES spots(id) ON DELETE SET NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS star_index_push_sent (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        spot_id uuid NOT NULL REFERENCES spots(id) ON DELETE CASCADE,
+        sent_day_kst date NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        UNIQUE(user_id, spot_id, sent_day_kst)
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_star_index_push_sent_day
+      ON star_index_push_sent(sent_day_kst)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS star_index_push_sent`);
+    await queryRunner.query(`
+      ALTER TABLE notification_preferences
+      DROP COLUMN IF EXISTS alert_spot_id
+    `);
+  }
+}

--- a/backend/src/notifications/dto/update-notification-preferences.dto.ts
+++ b/backend/src/notifications/dto/update-notification-preferences.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsBoolean, IsOptional } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsUUID, ValidateIf } from 'class-validator';
 
 export class UpdateNotificationPreferencesDto {
   @ApiProperty({ required: false, example: true })
@@ -21,4 +21,14 @@ export class UpdateNotificationPreferencesDto {
   @IsOptional()
   @IsBoolean()
   top5AlertEnabled?: boolean;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Star-Index 임계 알림 기준 명소 UUID. null 이면 기준 명소 해제.',
+  })
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null && v !== undefined)
+  @IsUUID('4')
+  alertSpotId?: string | null;
 }

--- a/backend/src/notifications/notification-preference.entity.ts
+++ b/backend/src/notifications/notification-preference.entity.ts
@@ -30,6 +30,10 @@ export class NotificationPreferenceEntity {
   @Column({ name: 'top5_alert_enabled', type: 'boolean', default: true })
   top5AlertEnabled: boolean;
 
+  /** Star-Index 임계 알림 기준 명소 — 없으면 해당 알림 스케줄에서 제외 */
+  @Column({ name: 'alert_spot_id', type: 'uuid', nullable: true })
+  alertSpotId: string | null;
+
   @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
   createdAt: Date;
 

--- a/backend/src/notifications/notification-scheduler.service.ts
+++ b/backend/src/notifications/notification-scheduler.service.ts
@@ -5,6 +5,12 @@ import {
   NOTIFICATION_REPOSITORY,
   type NotificationRepository,
 } from '../common/interfaces/notification.repository';
+import {
+  SPOT_REPOSITORY,
+  type SpotRepository,
+} from '../common/interfaces/spot.repository';
+import { getKstYmd } from '../common/kst-date';
+import { StarIndexService } from '../star-index/star-index.service';
 import { FcmPushService } from './fcm-push.service';
 import { WeeklyTop5Service } from '../weekly-top5/weekly-top5.service';
 
@@ -16,19 +22,27 @@ import { WeeklyTop5Service } from '../weekly-top5/weekly-top5.service';
 export class NotificationSchedulerService {
   private readonly logger = new Logger(NotificationSchedulerService.name);
 
+  /** process.env 우선 — load-env(override) 값이 ConfigService 내부 캐시에 가려지는 경우 방지 */
+  private envStr(key: string): string | undefined {
+    return process.env[key] ?? this.config.get<string | undefined>(key);
+  }
+
   constructor(
     private readonly config: ConfigService,
     private readonly fcm: FcmPushService,
     @Inject(NOTIFICATION_REPOSITORY)
     private readonly notifications: NotificationRepository,
     private readonly weeklyTop5: WeeklyTop5Service,
+    private readonly starIndex: StarIndexService,
+    @Inject(SPOT_REPOSITORY)
+    private readonly spots: SpotRepository,
   ) {}
 
-  @Cron('*/1 * * * *', { timeZone: 'Asia/Seoul' })
+  @Cron('5 7 * * 1', { timeZone: 'Asia/Seoul' })
   async sendWeeklyTop5Digest(): Promise<void> {
     // 방법 B(분당 실행) 검증 시 터미널에 찍히는지 확인용. 운영·월요일만 쓸 땐 로그를 줄이세요.
     this.logger.log('[TOP5 push] cron tick');
-    const raw = this.config.get<string | undefined>('FCM_SCHEDULED_TOP5_PUSH_ENABLED');
+    const raw = this.envStr('FCM_SCHEDULED_TOP5_PUSH_ENABLED');
     const enabled = String(raw ?? '').trim().toLowerCase() === 'true';
     if (!enabled) {
       this.logger.warn(
@@ -111,6 +125,124 @@ export class NotificationSchedulerService {
 
     this.logger.log(
       `[TOP5 push] 완료 weekStart=${weekStart} 대상=${recipients.length} 성공=${ok} 실패=${failed}`,
+    );
+  }
+
+  /** 매시 정각 15분 KST — 기준 명소 Star-Index가 임계 이상이면 1일 1회 푸시 */
+  @Cron('15 * * * *', { timeZone: 'Asia/Seoul' })
+  async sendStarIndexThresholdDigest(): Promise<void> {
+    this.logger.log('[Star-Index push] cron tick');
+    const raw = this.envStr('FCM_SCHEDULED_STAR_INDEX_PUSH_ENABLED');
+    const enabled = String(raw ?? '').trim().toLowerCase() === 'true';
+    if (!enabled) {
+      this.logger.warn(
+        `[Star-Index push] 건너뜀: FCM_SCHEDULED_STAR_INDEX_PUSH_ENABLED=${JSON.stringify(raw)}`,
+      );
+      return;
+    }
+    if (!this.fcm.isReady()) {
+      this.logger.warn(
+        '[Star-Index push] FCM 미초기화 — FIREBASE_* 환경변수를 확인하세요.',
+      );
+      return;
+    }
+
+    const thresholdRaw = this.envStr('STAR_INDEX_ALERT_THRESHOLD');
+    const threshold = Number.parseInt(String(thresholdRaw ?? '70').trim(), 10);
+    const thresholdScore = Number.isFinite(threshold) ? threshold : 70;
+
+    let recipients;
+    try {
+      recipients =
+        await this.notifications.findAndroidRecipientsStarIndexThreshold();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.logger.error(`[Star-Index push] 수신자 조회 실패: ${msg}`);
+      return;
+    }
+
+    if (!recipients.length) {
+      this.logger.log('[Star-Index push] 조건에 맞는 안드로이드 토큰 없음');
+      return;
+    }
+
+    const dayKst = getKstYmd();
+    let ok = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const { userId, fcmToken, alertSpotId } of recipients) {
+      const spot = await this.spots.findById(alertSpotId);
+      if (!spot) {
+        skipped++;
+        continue;
+      }
+
+      const already = await this.notifications.hasStarIndexPushSentForKstDay({
+        userId,
+        spotId: alertSpotId,
+        dayKstYmd: dayKst,
+      });
+      if (already) {
+        skipped++;
+        continue;
+      }
+
+      let score: number;
+      try {
+        score = await this.starIndex.computeFreshScoreFromCache(spot);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        this.logger.warn(
+          `[Star-Index push] 점수 계산 실패 spot=${alertSpotId.slice(0, 8)}… ${msg}`,
+        );
+        skipped++;
+        continue;
+      }
+
+      if (score < thresholdScore) {
+        skipped++;
+        continue;
+      }
+
+      const title = '별 보기 좋은 날 알림';
+      const body = `${spot.name}의 Star-Index가 ${Math.round(score)}입니다. 조건을 충족했어요.`;
+      const data: Record<string, string> = {
+        type: 'star_index_threshold',
+        spotId: alertSpotId,
+        score: String(Math.round(score)),
+        dayKst,
+      };
+
+      try {
+        await this.fcm.sendToToken(fcmToken, { title, body, data });
+        await this.notifications.recordStarIndexPushSent({
+          userId,
+          spotId: alertSpotId,
+          dayKstYmd: dayKst,
+        });
+        ok++;
+      } catch (err: unknown) {
+        failed++;
+        const message = err instanceof Error ? err.message : String(err);
+        if (
+          message.includes('not a valid FCM registration token') ||
+          message.includes('registration-token-not-registered')
+        ) {
+          await this.notifications.deactivateToken({ userId, fcmToken });
+          this.logger.warn(
+            `[Star-Index push] 무효 토큰 비활성화 user=${userId.slice(0, 8)}…`,
+          );
+        } else {
+          this.logger.warn(
+            `[Star-Index push] 발송 실패 user=${userId.slice(0, 8)}… ${message}`,
+          );
+        }
+      }
+    }
+
+    this.logger.log(
+      `[Star-Index push] 완료 dayKst=${dayKst} 임계=${thresholdScore} 대상=${recipients.length} 성공=${ok} 실패=${failed} 건너뜀=${skipped}`,
     );
   }
 }

--- a/backend/src/notifications/notifications.controller.ts
+++ b/backend/src/notifications/notifications.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, Get, Post, Put, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  ForbiddenException,
+  Get,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -7,6 +17,7 @@ import { DeactivateNotificationTokenDto } from './dto/deactivate-notification-to
 import { NotificationTestSendDto } from './dto/notification-test-send.dto';
 import { UpdateNotificationPreferencesDto } from './dto/update-notification-preferences.dto';
 import { UpsertNotificationTokenDto } from './dto/upsert-notification-token.dto';
+import { NotificationSchedulerService } from './notification-scheduler.service';
 import { NotificationsService } from './notifications.service';
 
 @ApiTags('notifications')
@@ -14,7 +25,11 @@ import { NotificationsService } from './notifications.service';
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
 export class NotificationsController {
-  constructor(private readonly notificationsService: NotificationsService) {}
+  constructor(
+    private readonly notificationsService: NotificationsService,
+    private readonly config: ConfigService,
+    private readonly notificationScheduler: NotificationSchedulerService,
+  ) {}
 
   @Post('token')
   @ApiOperation({ summary: 'FCM 토큰 등록/갱신 (로그인 후 디바이스별 호출)' })
@@ -60,5 +75,29 @@ export class NotificationsController {
     @Body() dto: NotificationTestSendDto,
   ) {
     return this.notificationsService.sendTestPush(user.userId, dto);
+  }
+
+  @Post('dev/run-star-index-scheduled-push')
+  @ApiOperation({
+    summary:
+      '개발·검증용: Star-Index 스케줄 잡을 즉시 1회 실행 (:15 기다리지 않음). production 은 FCM_STAR_INDEX_MANUAL_TRIGGER_ENABLED=true 만 허용',
+  })
+  async runStarIndexScheduledPush(@CurrentUser() user: JwtValidatedUser) {
+    const nodeEnv = this.config.get<string>('NODE_ENV');
+    const forced =
+      this.config.get<string>('FCM_STAR_INDEX_MANUAL_TRIGGER_ENABLED') === 'true';
+    const allowed = forced || nodeEnv !== 'production';
+    if (!allowed) {
+      throw new ForbiddenException(
+        'production 에서는 FCM_STAR_INDEX_MANUAL_TRIGGER_ENABLED=true 일 때만 사용 가능',
+      );
+    }
+    await this.notificationScheduler.sendStarIndexThresholdDigest();
+    return {
+      ok: true,
+      triggeredBy: user.userId,
+      message:
+        'Star-Index 스케줄 로직을 1회 실행했습니다. 서버 로그([Star-Index push])를 확인하세요.',
+    };
   }
 }

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -3,19 +3,28 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { NOTIFICATION_REPOSITORY } from '../common/interfaces/notification.repository';
 import { WeeklyTop5Module } from '../weekly-top5/weekly-top5.module';
+import { StarIndexModule } from '../star-index/star-index.module';
+import { SpotsModule } from '../spots/spots.module';
 import { FcmPushService } from './fcm-push.service';
 import { NotificationPreferenceEntity } from './notification-preference.entity';
 import { NotificationSchedulerService } from './notification-scheduler.service';
 import { NotificationTokenEntity } from './notification-token.entity';
 import { NotificationsController } from './notifications.controller';
 import { NotificationsService } from './notifications.service';
+import { StarIndexPushSentEntity } from './star-index-push-sent.entity';
 import { TypeOrmNotificationRepository } from './typeorm-notification.repository';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([NotificationTokenEntity, NotificationPreferenceEntity]),
+    TypeOrmModule.forFeature([
+      NotificationTokenEntity,
+      NotificationPreferenceEntity,
+      StarIndexPushSentEntity,
+    ]),
     AuthModule,
     WeeklyTop5Module,
+    StarIndexModule,
+    SpotsModule,
   ],
   controllers: [NotificationsController],
   providers: [

--- a/backend/src/notifications/notifications.service.ts
+++ b/backend/src/notifications/notifications.service.ts
@@ -40,6 +40,7 @@ export class NotificationsService {
       starIndexAlertEnabled: true,
       astronomyEventAlertEnabled: true,
       top5AlertEnabled: true,
+      alertSpotId: null,
     });
   }
 
@@ -56,6 +57,8 @@ export class NotificationsService {
       astronomyEventAlertEnabled:
         dto.astronomyEventAlertEnabled ?? current.astronomyEventAlertEnabled,
       top5AlertEnabled: dto.top5AlertEnabled ?? current.top5AlertEnabled,
+      alertSpotId:
+        dto.alertSpotId !== undefined ? dto.alertSpotId : current.alertSpotId,
     });
   }
 

--- a/backend/src/notifications/star-index-push-sent.entity.ts
+++ b/backend/src/notifications/star-index-push-sent.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+import { UserEntity } from '../users/user.entity';
+import { SpotEntity } from '../spots/spot.entity';
+
+/** Star-Index 임계 푸시 — 사용자·명소·KST 일 단위 중복 방지 */
+@Entity('star_index_push_sent')
+@Unique(['userId', 'spotId', 'sentDayKst'])
+@Index('idx_star_index_push_sent_day', ['sentDayKst'])
+export class StarIndexPushSentEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @ManyToOne(() => UserEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: UserEntity;
+
+  @Column({ name: 'spot_id', type: 'uuid' })
+  spotId: string;
+
+  @ManyToOne(() => SpotEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'spot_id' })
+  spot: SpotEntity;
+
+  /** KST 기준 YYYY-MM-DD */
+  @Column({ name: 'sent_day_kst', type: 'date' })
+  sentDayKst: string;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/notifications/typeorm-notification.repository.ts
+++ b/backend/src/notifications/typeorm-notification.repository.ts
@@ -8,6 +8,7 @@ import type {
 } from '../common/interfaces/notification.repository';
 import { NotificationPreferenceEntity } from './notification-preference.entity';
 import { NotificationTokenEntity } from './notification-token.entity';
+import { StarIndexPushSentEntity } from './star-index-push-sent.entity';
 
 @Injectable()
 export class TypeOrmNotificationRepository implements NotificationRepository {
@@ -16,6 +17,8 @@ export class TypeOrmNotificationRepository implements NotificationRepository {
     private readonly tokens: Repository<NotificationTokenEntity>,
     @InjectRepository(NotificationPreferenceEntity)
     private readonly prefs: Repository<NotificationPreferenceEntity>,
+    @InjectRepository(StarIndexPushSentEntity)
+    private readonly pushSent: Repository<StarIndexPushSentEntity>,
   ) {}
 
   async upsertToken(params: {
@@ -73,6 +76,7 @@ export class TypeOrmNotificationRepository implements NotificationRepository {
     starIndexAlertEnabled: boolean;
     astronomyEventAlertEnabled: boolean;
     top5AlertEnabled: boolean;
+    alertSpotId: string | null;
   }): Promise<NotificationPreference> {
     const existing = await this.prefs.findOne({ where: { userId: params.userId } });
     if (!existing) {
@@ -82,6 +86,7 @@ export class TypeOrmNotificationRepository implements NotificationRepository {
         starIndexAlertEnabled: params.starIndexAlertEnabled,
         astronomyEventAlertEnabled: params.astronomyEventAlertEnabled,
         top5AlertEnabled: params.top5AlertEnabled,
+        alertSpotId: params.alertSpotId,
       });
       return this.prefs.save(created);
     }
@@ -90,6 +95,7 @@ export class TypeOrmNotificationRepository implements NotificationRepository {
     existing.starIndexAlertEnabled = params.starIndexAlertEnabled;
     existing.astronomyEventAlertEnabled = params.astronomyEventAlertEnabled;
     existing.top5AlertEnabled = params.top5AlertEnabled;
+    existing.alertSpotId = params.alertSpotId;
     return this.prefs.save(existing);
   }
 
@@ -117,5 +123,75 @@ export class TypeOrmNotificationRepository implements NotificationRepository {
       userId: String(r.userId ?? r.userid ?? ''),
       fcmToken: String(r.fcmToken ?? r.fcmtoken ?? ''),
     })).filter((r) => r.userId.length > 0 && r.fcmToken.length > 0);
+  }
+
+  async findAndroidRecipientsStarIndexThreshold(): Promise<
+    Array<{ userId: string; fcmToken: string; alertSpotId: string }>
+  > {
+    const raw = await this.tokens
+      .createQueryBuilder('t')
+      .innerJoin(
+        NotificationPreferenceEntity,
+        'p',
+        'p.userId = t.userId AND p.alertsEnabled = true AND p.starIndexAlertEnabled = true AND p.alertSpotId IS NOT NULL',
+      )
+      .where('t.isActive = :active', { active: true })
+      .andWhere('t.platform = :plat', { plat: 'android' })
+      .select('t.userId', 'userId')
+      .addSelect('t.fcmToken', 'fcmToken')
+      .addSelect('p.alertSpotId', 'alertSpotId')
+      .getRawMany<
+        Record<string, string | undefined> & {
+          userId?: string;
+          fcmToken?: string;
+          alertSpotId?: string;
+        }
+      >();
+    return raw
+      .map((r) => ({
+        userId: String(r.userId ?? r.userid ?? ''),
+        fcmToken: String(r.fcmToken ?? r.fcmtoken ?? ''),
+        alertSpotId: String(r.alertSpotId ?? r.alertspotid ?? ''),
+      }))
+      .filter(
+        (r) =>
+          r.userId.length > 0 &&
+          r.fcmToken.length > 0 &&
+          r.alertSpotId.length > 0,
+      );
+  }
+
+  async hasStarIndexPushSentForKstDay(params: {
+    userId: string;
+    spotId: string;
+    dayKstYmd: string;
+  }): Promise<boolean> {
+    const n = await this.pushSent.count({
+      where: {
+        userId: params.userId,
+        spotId: params.spotId,
+        sentDayKst: params.dayKstYmd,
+      },
+    });
+    return n > 0;
+  }
+
+  async recordStarIndexPushSent(params: {
+    userId: string;
+    spotId: string;
+    dayKstYmd: string;
+  }): Promise<void> {
+    const row = this.pushSent.create({
+      userId: params.userId,
+      spotId: params.spotId,
+      sentDayKst: params.dayKstYmd,
+    });
+    try {
+      await this.pushSent.save(row);
+    } catch (e: unknown) {
+      const code = (e as { code?: string })?.code;
+      if (code === '23505') return;
+      throw e;
+    }
   }
 }

--- a/frontend/components/profile/ProfileTabScreen.tsx
+++ b/frontend/components/profile/ProfileTabScreen.tsx
@@ -1,6 +1,9 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
   StyleSheet,
   Switch,
   Text,
@@ -14,7 +17,8 @@ import {
   authorizedGetJson,
   authorizedPutJson,
 } from '../../lib/api-client';
-import type { NotificationPreferenceDto } from '../../lib/types/api';
+import type { NotificationPreferenceDto, SpotDto } from '../../lib/types/api';
+import { fetchSpotsAll } from '../../lib/spots-api';
 import { Button, Card } from '../ui';
 
 interface ProfileTabScreenProps {
@@ -39,6 +43,9 @@ export function ProfileTabScreen({
   const [prefsError, setPrefsError] = useState<string | null>(null);
   const [prefs, setPrefs] = useState<NotificationPreferenceDto | null>(null);
   const [prefsSaving, setPrefsSaving] = useState(false);
+  const [spots, setSpots] = useState<SpotDto[]>([]);
+  const [spotsLoading, setSpotsLoading] = useState(false);
+  const [spotPickerOpen, setSpotPickerOpen] = useState(false);
 
   const loadPrefs = useCallback(async () => {
     setPrefsError(null);
@@ -66,6 +73,42 @@ export function ProfileTabScreen({
     void loadPrefs();
   }, [loadPrefs]);
 
+  useEffect(() => {
+    let cancelled = false;
+    setSpotsLoading(true);
+    void (async () => {
+      try {
+        const list = await fetchSpotsAll();
+        if (!cancelled) setSpots(list);
+      } catch (e) {
+        if (e instanceof SessionExpiredError) {
+          await onSessionInvalidated();
+          return;
+        }
+        if (!cancelled && __DEV__) {
+          // eslint-disable-next-line no-console
+          console.warn('[ProfileTabScreen] 명소 목록 로드 실패', e);
+        }
+      } finally {
+        if (!cancelled) setSpotsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [onSessionInvalidated]);
+
+  const alertSpotLabel = useMemo(() => {
+    const id = prefs?.alertSpotId;
+    if (!id) return '선택 안 함';
+    const s = spots.find(x => x.id === id);
+    return s?.name ?? '선택한 명소';
+  }, [prefs?.alertSpotId, spots]);
+
+  const sortedSpots = useMemo(() => {
+    return [...spots].sort((a, b) => a.name.localeCompare(b.name, 'ko'));
+  }, [spots]);
+
   const persistPrefs = useCallback(
     async (next: NotificationPreferenceDto) => {
       setPrefsSaving(true);
@@ -78,6 +121,7 @@ export function ProfileTabScreen({
             starIndexAlertEnabled: next.starIndexAlertEnabled,
             astronomyEventAlertEnabled: next.astronomyEventAlertEnabled,
             top5AlertEnabled: next.top5AlertEnabled,
+            alertSpotId: next.alertSpotId ?? null,
           },
         );
         setPrefs(saved);
@@ -114,6 +158,7 @@ export function ProfileTabScreen({
         next.starIndexAlertEnabled = false;
         next.astronomyEventAlertEnabled = false;
         next.top5AlertEnabled = false;
+        next.alertSpotId = null;
       }
       setPrefs(next);
       void persistPrefs(next);
@@ -157,12 +202,26 @@ export function ProfileTabScreen({
             />
             <Row
               label="별 보기 좋은 날 (Star-Index)"
-              description="점수가 좋을 때 알림"
+              description="기준 명소의 점수가 서버 설정 임계 이상일 때 하루 한 번 알림"
               value={prefs.starIndexAlertEnabled}
               disabled={prefsSaving || !prefs.alertsEnabled}
               theme={theme}
               onValueChange={(v) => toggleField('starIndexAlertEnabled', v)}
             />
+            <View style={{ gap: 8, opacity: prefs.alertsEnabled ? 1 : 0.45 }}>
+              <Text style={[styles.spotHint, { color: theme.mutedForeground }]}>
+                기준 명소: {spotsLoading ? '목록 불러오는 중…' : alertSpotLabel}
+              </Text>
+              <Button
+                label="기준 명소 선택"
+                variant="outline"
+                fullWidth
+                disabled={
+                  prefsSaving || !prefs.alertsEnabled || spotsLoading || spots.length === 0
+                }
+                onPress={() => setSpotPickerOpen(true)}
+              />
+            </View>
             <Row
               label="하늘 이벤트"
               description="유성우·특별 천체 등"
@@ -189,6 +248,61 @@ export function ProfileTabScreen({
           </View>
         )}
       </Card>
+
+      <Modal
+        visible={spotPickerOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setSpotPickerOpen(false)}
+      >
+        <Pressable style={styles.modalBackdrop} onPress={() => setSpotPickerOpen(false)}>
+          <Pressable
+            style={[styles.modalSheet, { backgroundColor: theme.card, borderColor: theme.border }]}
+            onPress={e => e.stopPropagation()}
+          >
+            <Text style={[styles.modalTitle, { color: theme.foreground }]}>
+              Star-Index 알림 기준 명소
+            </Text>
+            <ScrollView style={{ maxHeight: 420 }}>
+              <Pressable
+                onPress={() => {
+                  setSpotPickerOpen(false);
+                  if (!prefs) return;
+                  void persistPrefs({ ...prefs, alertSpotId: null });
+                }}
+                style={({ pressed }) => [
+                  styles.modalRow,
+                  {
+                    borderBottomColor: theme.border,
+                    backgroundColor: pressed ? theme.muted : 'transparent',
+                  },
+                ]}
+              >
+                <Text style={{ color: theme.foreground }}>선택 안 함</Text>
+              </Pressable>
+              {sortedSpots.map(s => (
+                <Pressable
+                  key={s.id}
+                  onPress={() => {
+                    setSpotPickerOpen(false);
+                    if (!prefs) return;
+                    void persistPrefs({ ...prefs, alertSpotId: s.id });
+                  }}
+                  style={({ pressed }) => [
+                    styles.modalRow,
+                    {
+                      borderBottomColor: theme.border,
+                      backgroundColor: pressed ? theme.muted : 'transparent',
+                    },
+                  ]}
+                >
+                  <Text style={{ color: theme.foreground }}>{s.name}</Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          </Pressable>
+        </Pressable>
+      </Modal>
 
       <Card title="표시" description="야간 관측 시 눈부심을 줄입니다">
         <Button
@@ -259,4 +373,23 @@ const styles = StyleSheet.create({
   title: { fontSize: 20, fontFamily: 'SpaceMono-Regular', marginBottom: 16 },
   email: { fontSize: 14 },
   err: { fontSize: 13, marginBottom: 8 },
+  spotHint: { fontSize: 12 },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  modalSheet: {
+    borderRadius: 12,
+    borderWidth: 1,
+    padding: 16,
+    maxHeight: '80%',
+  },
+  modalTitle: { fontSize: 16, fontWeight: '700', marginBottom: 12 },
+  modalRow: {
+    paddingVertical: 14,
+    paddingHorizontal: 4,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
 });

--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -62,6 +62,8 @@ export interface NotificationPreferenceDto {
   starIndexAlertEnabled: boolean;
   astronomyEventAlertEnabled: boolean;
   top5AlertEnabled: boolean;
+  /** Star-Index 임계 알림 기준 명소 — 없으면 서버 스케줄에서 제외 */
+  alertSpotId?: string | null;
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
## 개요
사용자가 지정한 **기준 명소**의 Star-Index가 설정한 **임계값(기본 70) 이상**일 때, **안드로이드 FCM**으로 조건 알림을 보냅니다. **KST 기준 동일 일·사용자·명소**당 **최대 1회** 발송하도록 DB로 중복을 막습니다.

## 변경 사항
### 백엔드
- `notification_preferences`에 `alert_spot_id`(nullable, FK `spots`) 추가, `star_index_push_sent` 테이블 및 유니크 제약(사용자·명소·KST 일) 마이그레이션
- 알림 설정 DTO/API에 `alertSpotId` 반영, 저장소에 Star-Index 수신자 조회·중복 확인·발송 기록 메서드 추가
- 매시 **정각 15분 KST** Cron으로 스케줄 실행 (`FCM_SCHEDULED_STAR_INDEX_PUSH_ENABLED`, `STAR_INDEX_ALERT_THRESHOLD`)
- `StarIndexModule`·`SpotsModule` 연동으로 점수 계산 및 명소 조회
- 개발·검증용 **`POST /notifications/dev/run-star-index-scheduled-push`** (Cron 대기 없이 1회 실행, production은 플래그로 제한)
- `.env` 로딩 안정화: `load-env.ts` 선주입, 스케줄러에서 `process.env` 우선 읽기 등

### 프론트엔드
- `NotificationPreferenceDto`에 `alertSpotId` 추가
- 마이페이지에서 **기준 명소 선택**(목록 모달, 선택 해제), 저장 시 `PUT`에 포함

### 문서·설정
- `backend/.env.example`에 관련 변수 설명 추가

## 환경 변수
| 변수 | 설명 |
|------|------|
| `FCM_SCHEDULED_STAR_INDEX_PUSH_ENABLED` | `true`일 때만 스케줄에서 Star-Index 조건 푸시 발송 |
| `STAR_INDEX_ALERT_THRESHOLD` | 임계 점수 (미설정 시 기본 70) |
| `FCM_STAR_INDEX_MANUAL_TRIGGER_ENABLED` | production에서 수동 실행 API 허용 시 `true` (로컬 개발은 보통 불필요) |

## 배포 시 유의사항
- 마이그레이션 실행 후 배포 (`npm run migration:run`)
- 운영 `.env`에 위 변수 반영 및 **파일 저장 여부** 확인 (줄이 붙어 한 줄이 되지 않도록)

## 테스트
- [x] `GET/PUT /notifications/preferences`로 `alertSpotId` 저장·조회
- [x] 안드로이드 FCM 토큰 등록 후, 조건 충족 시 **`star_index_push_sent`** 기록 및 기기 알림 수신
- [x] 수동 엔드포인트로 Cron 없이 스케줄 로직 1회 실행 검증 (선택)

## 🔗 Issue 

- Closes: #이슈번호

## ✅ 체크리스트

- [ ] 브랜치 base가 적절한가요?
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
