### PR TITLE
feat: Star-Index 카드 CLOUD·PM2.5·MOON 고정값 수정 및 에어코리아 측정소 JSON 접목

### DIFF
--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -4,6 +4,7 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
+    "tsConfigPath": "tsconfig.build.json",
     "assets": [
       {
         "include": "sky/data/*.json",
@@ -11,6 +12,10 @@
       },
       {
         "include": "astronomy-events/data/*.json",
+        "watchAssets": true
+      },
+      {
+        "include": "cache-hydration/data/*.json",
         "watchAssets": true
       }
     ]

--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,8 @@
     "migration:revert": "npm run typeorm -- migration:revert",
     "migration:create": "npm run typeorm -- migration:create src/migrations/manual-migration",
     "migration:generate": "npm run typeorm -- migration:generate src/migrations/auto-migration",
-    "seed": "ts-node src/seeds/spots.seed.ts"
+    "seed": "ts-node src/seeds/spots.seed.ts",
+    "seed:airkorea-stations": "ts-node scripts/seed-airkorea-stations.ts"
   },
   "dependencies": {
     "@nestjs/cache-manager": "^2.2.0",

--- a/backend/scripts/seed-airkorea-stations.ts
+++ b/backend/scripts/seed-airkorea-stations.ts
@@ -1,0 +1,154 @@
+/**
+ * 전국 에어코리아 측정소 좌표 JSON 생성 (개발자 로컬 1회 실행)
+ *
+ *   cd backend
+ *   npx ts-node scripts/seed-airkorea-stations.ts
+ *
+ * 필요: backend/.env 에 AIRKOREA_API_KEY
+ * 소요: Nominatim 1req/s → 약 10~15분
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: path.join(__dirname, '..', '.env') });
+
+const SIDOS = [
+  '서울', '부산', '대구', '인천', '광주', '대전', '울산', '세종',
+  '경기', '강원', '충북', '충남', '전북', '전남', '경북', '경남', '제주',
+] as const;
+
+type StationRow = { stationName: string; sidoName: string };
+
+function formatServiceKey(raw: string): string {
+  const t = raw.trim();
+  return /%[0-9A-Fa-f]{2}/.test(t) ? t : encodeURIComponent(t);
+}
+
+function extractItems(body: unknown): Array<{ stationName?: string }> {
+  const b = body as {
+    items?: Array<{ stationName?: string }> | { item?: unknown };
+  };
+  const items = b?.items;
+  if (!items) return [];
+  if (Array.isArray(items)) return items;
+  const item = items.item;
+  if (!item) return [];
+  return Array.isArray(item) ? item : [item as { stationName?: string }];
+}
+
+async function fetchSidoStations(
+  serviceKey: string,
+  sidoName: string,
+): Promise<StationRow[]> {
+  const url =
+    'https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty' +
+    `?serviceKey=${formatServiceKey(serviceKey)}&returnType=json&numOfRows=500&pageNo=1` +
+    `&sidoName=${encodeURIComponent(sidoName)}&ver=1.0`;
+  const res = await fetch(url);
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`${sidoName} HTTP ${res.status}: ${text.slice(0, 120)}`);
+  }
+  const parsed = JSON.parse(text) as {
+    response?: { header?: { resultCode?: string }; body?: unknown };
+  };
+  const code = parsed.response?.header?.resultCode;
+  if (code && code !== '00') {
+    throw new Error(`${sidoName} API ${code}`);
+  }
+  const rows: StationRow[] = [];
+  for (const item of extractItems(parsed.response?.body)) {
+    const name = item.stationName?.trim();
+    if (name) rows.push({ stationName: name, sidoName });
+  }
+  return rows;
+}
+
+async function geocodeStation(
+  stationName: string,
+  sidoName: string,
+): Promise<{ lat: number; lng: number } | null> {
+  await new Promise((r) => setTimeout(r, 1100));
+  const q = encodeURIComponent(`${stationName}, ${sidoName}, South Korea`);
+  const url = `https://nominatim.openstreetmap.org/search?q=${q}&format=json&limit=1`;
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'StarChaser/1.0 (seed-airkorea-stations)' },
+  });
+  if (!res.ok) return null;
+  const rows = (await res.json()) as Array<{ lat: string; lon: string }>;
+  const hit = rows[0];
+  if (!hit) return null;
+  const lat = Number(hit.lat);
+  const lng = Number(hit.lon);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  return { lat, lng };
+}
+
+async function main(): Promise<void> {
+  const key = process.env.AIRKOREA_API_KEY?.trim();
+  if (!key) {
+    console.error('AIRKOREA_API_KEY 없음 — backend/.env 확인');
+    process.exit(1);
+  }
+
+  const byKey = new Map<string, StationRow>();
+  for (const sido of SIDOS) {
+    const rows = await fetchSidoStations(key, sido);
+    for (const r of rows) {
+      byKey.set(`${r.sidoName}::${r.stationName}`, r);
+    }
+    console.log(`${sido} — 목록 ${rows.length}곳`);
+  }
+
+  const list = [...byKey.values()];
+  console.log(`\n지오코딩 시작 — ${list.length}곳\n`);
+
+  const stations: Array<{
+    stationName: string;
+    sidoName: string;
+    lat: number;
+    lng: number;
+  }> = [];
+  let fail = 0;
+
+  for (let i = 0; i < list.length; i += 1) {
+    const { stationName, sidoName } = list[i];
+    const coords = await geocodeStation(stationName, sidoName);
+    if (coords) {
+      stations.push({ stationName, sidoName, ...coords });
+      process.stdout.write(
+        `\r[${i + 1}/${list.length}] ${sidoName} ${stationName} OK`,
+      );
+    } else {
+      fail += 1;
+      process.stdout.write(
+        `\r[${i + 1}/${list.length}] ${sidoName} ${stationName} FAIL`,
+      );
+    }
+  }
+
+  const outPath = path.join(
+    __dirname,
+    '..',
+    'src',
+    'cache-hydration',
+    'data',
+    'airkorea-stations.json',
+  );
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  const payload = {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    stations,
+  };
+  fs.writeFileSync(outPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+
+  console.log(`\n\n완료 — 성공 ${stations.length}, 실패 ${fail}`);
+  console.log(`저장: ${outPath}`);
+}
+
+void main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/backend/src/cache-hydration/airkorea-api.util.spec.ts
+++ b/backend/src/cache-hydration/airkorea-api.util.spec.ts
@@ -1,0 +1,28 @@
+import {
+  arpltnInforUrl,
+  formatDataGoKrServiceKey,
+} from './airkorea-api.util';
+
+describe('airkorea-api.util', () => {
+  it('formatDataGoKrServiceKey encodes decoded keys', () => {
+    expect(formatDataGoKrServiceKey('abc/def==')).toBe(
+      encodeURIComponent('abc/def=='),
+    );
+  });
+
+  it('formatDataGoKrServiceKey leaves pre-encoded keys', () => {
+    const encoded = encodeURIComponent('abc/def==');
+    expect(formatDataGoKrServiceKey(encoded)).toBe(encoded);
+  });
+
+  it('arpltnInforUrl targets ArpltnInforInqireSvc', () => {
+    const url = arpltnInforUrl('getCtprvnRltmMesureDnsty', {
+      serviceKey: 'test',
+      returnType: 'json',
+      sidoName: '서울',
+      ver: '1.0',
+    });
+    expect(url).toContain('ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty');
+    expect(url).not.toContain('MsrstnInfoInqireSvc');
+  });
+});

--- a/backend/src/cache-hydration/airkorea-api.util.ts
+++ b/backend/src/cache-hydration/airkorea-api.util.ts
@@ -1,0 +1,30 @@
+/**
+ * 에어코리아 ArpltnInforInqireSvc — 공공데이터포털 인증키·URL 조립
+ * (MsrstnInfoInqireSvc 는 별도 활용신청 필요 → 사용하지 않음)
+ */
+
+/** 디코딩 키는 encode, 이미 인코딩된 키(% 포함)는 그대로 */
+export function formatDataGoKrServiceKey(raw: string): string {
+  const trimmed = raw.trim();
+  if (/%[0-9A-Fa-f]{2}/.test(trimmed)) {
+    return trimmed;
+  }
+  return encodeURIComponent(trimmed);
+}
+
+export function arpltnInforUrl(
+  operation: string,
+  params: Record<string, string>,
+): string {
+  const key = formatDataGoKrServiceKey(params.serviceKey);
+  const parts = [
+    `serviceKey=${key}`,
+    ...Object.entries(params)
+      .filter(([k]) => k !== 'serviceKey')
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`),
+  ];
+  return (
+    `https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/${operation}?` +
+    parts.join('&')
+  );
+}

--- a/backend/src/cache-hydration/airkorea-geocode.util.ts
+++ b/backend/src/cache-hydration/airkorea-geocode.util.ts
@@ -1,0 +1,102 @@
+import { Logger } from '@nestjs/common';
+
+const logger = new Logger('AirKoreaGeocode');
+
+const NOMINATIM_UA = 'StarChaser/1.0 (air-quality; contact: local-dev)';
+
+let lastNominatimAt = 0;
+
+async function throttleNominatim(): Promise<void> {
+  const wait = 1100 - (Date.now() - lastNominatimAt);
+  if (wait > 0) {
+    await new Promise((r) => setTimeout(r, wait));
+  }
+  lastNominatimAt = Date.now();
+}
+
+export type NominatimAddress = {
+  city?: string;
+  county?: string;
+  borough?: string;
+  town?: string;
+  village?: string;
+  province?: string;
+};
+
+/** 역지오코딩 — 행정구역 매칭 보조 */
+export async function reverseGeocodeKo(
+  lat: number,
+  lng: number,
+): Promise<NominatimAddress> {
+  await throttleNominatim();
+  const url =
+    `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}` +
+    '&format=json&accept-language=ko';
+  const response = await fetch(url, {
+    headers: { 'User-Agent': NOMINATIM_UA },
+  });
+  if (!response.ok) {
+    throw new Error(`Nominatim reverse HTTP ${response.status}`);
+  }
+  const data = (await response.json()) as { address?: NominatimAddress };
+  return data.address ?? {};
+}
+
+/** 측정소명 + 시·도 → WGS84 (OSM Nominatim) */
+export async function geocodeStation(
+  stationName: string,
+  sidoName: string,
+): Promise<{ lat: number; lng: number } | null> {
+  await throttleNominatim();
+  const query = encodeURIComponent(
+    `${sidoName} ${stationName} 대기환경측정소, South Korea`,
+  );
+  const url = `https://nominatim.openstreetmap.org/search?q=${query}&format=json&limit=1`;
+  const response = await fetch(url, {
+    headers: { 'User-Agent': NOMINATIM_UA },
+  });
+  if (!response.ok) {
+    logger.warn(`Nominatim search HTTP ${response.status} — ${stationName}`);
+    return null;
+  }
+  const rows = (await response.json()) as Array<{ lat: string; lon: string }>;
+  const hit = rows[0];
+  if (!hit) {
+    return null;
+  }
+  const lat = Number(hit.lat);
+  const lng = Number(hit.lon);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+    return null;
+  }
+  return { lat, lng };
+}
+
+/** stationName에 행정구역 토큰이 포함되는지 — 동명 측정소 우선 */
+export function scoreStationNameMatch(
+  stationName: string,
+  address: NominatimAddress,
+): number {
+  const tokens = [
+    address.city,
+    address.county,
+    address.borough,
+    address.town,
+    address.village,
+  ]
+    .filter((t): t is string => Boolean(t && t.trim()))
+    .map((t) => t.replace(/\s/g, ''));
+
+  const name = stationName.replace(/\s/g, '');
+  let score = 0;
+  for (const raw of tokens) {
+    const t = raw.replace(/(특별시|광역시|특별자치시|특별자치도|시|군|구|읍|면|동|리)$/g, '');
+    if (t.length >= 2 && name.includes(t)) {
+      score += 10;
+    }
+    if (raw.length >= 2 && name.includes(raw)) {
+      score += 5;
+    }
+  }
+  return score;
+}

--- a/backend/src/cache-hydration/airkorea-sido-bbox.util.spec.ts
+++ b/backend/src/cache-hydration/airkorea-sido-bbox.util.spec.ts
@@ -1,0 +1,7 @@
+import { findSidoByLatLng } from './airkorea-sido-bbox.util';
+
+describe('airkorea-sido-bbox.util', () => {
+  it('findSidoByLatLng for Seoul', () => {
+    expect(findSidoByLatLng(37.5665, 126.978)).toBe('서울');
+  });
+});

--- a/backend/src/cache-hydration/airkorea-sido-bbox.util.ts
+++ b/backend/src/cache-hydration/airkorea-sido-bbox.util.ts
@@ -1,0 +1,70 @@
+/** WGS84 경계 상자로 시·도 근사 (에어코리아 sidoName) */
+
+export type SidoBbox = {
+  sidoName: string;
+  minLat: number;
+  maxLat: number;
+  minLng: number;
+  maxLng: number;
+};
+
+export const AIRKOREA_SIDO_BBOXES: SidoBbox[] = [
+  { sidoName: '서울', minLat: 37.42, maxLat: 37.72, minLng: 126.76, maxLng: 127.18 },
+  { sidoName: '인천', minLat: 37.26, maxLat: 37.78, minLng: 126.28, maxLng: 126.89 },
+  { sidoName: '경기', minLat: 36.89, maxLat: 38.31, minLng: 126.47, maxLng: 127.98 },
+  { sidoName: '강원', minLat: 37.02, maxLat: 38.61, minLng: 127.05, maxLng: 129.46 },
+  { sidoName: '충북', minLat: 36.26, maxLat: 37.21, minLng: 127.29, maxLng: 128.58 },
+  { sidoName: '충남', minLat: 35.97, maxLat: 37.06, minLng: 126.08, maxLng: 127.68 },
+  { sidoName: '세종', minLat: 36.42, maxLat: 36.60, minLng: 127.21, maxLng: 127.37 },
+  { sidoName: '대전', minLat: 36.25, maxLat: 36.48, minLng: 127.30, maxLng: 127.54 },
+  { sidoName: '전북', minLat: 35.25, maxLat: 36.19, minLng: 126.42, maxLng: 127.69 },
+  { sidoName: '광주', minLat: 35.07, maxLat: 35.25, minLng: 126.68, maxLng: 126.95 },
+  { sidoName: '전남', minLat: 34.21, maxLat: 35.73, minLng: 125.99, maxLng: 127.59 },
+  { sidoName: '대구', minLat: 35.68, maxLat: 36.01, minLng: 128.35, maxLng: 128.78 },
+  { sidoName: '경북', minLat: 35.67, maxLat: 37.52, minLng: 127.98, maxLng: 129.60 },
+  { sidoName: '울산', minLat: 35.33, maxLat: 35.70, minLng: 128.99, maxLng: 129.48 },
+  { sidoName: '부산', minLat: 34.88, maxLat: 35.40, minLng: 128.74, maxLng: 129.32 },
+  { sidoName: '경남', minLat: 34.69, maxLat: 35.90, minLng: 127.57, maxLng: 129.30 },
+  { sidoName: '제주', minLat: 33.10, maxLat: 33.58, minLng: 126.15, maxLng: 126.98 },
+];
+
+export function findSidoByLatLng(lat: number, lng: number): string {
+  const hits = AIRKOREA_SIDO_BBOXES.filter(
+    (b) =>
+      lat >= b.minLat &&
+      lat <= b.maxLat &&
+      lng >= b.minLng &&
+      lng <= b.maxLng,
+  );
+  if (hits.length === 1) {
+    return hits[0].sidoName;
+  }
+  if (hits.length > 1) {
+    // 겹치는 경계(수도권 등) — 중심에 가장 가까운 시·도
+    let best = hits[0];
+    let bestD = Number.POSITIVE_INFINITY;
+    for (const b of hits) {
+      const cLat = (b.minLat + b.maxLat) / 2;
+      const cLng = (b.minLng + b.maxLng) / 2;
+      const d = (lat - cLat) ** 2 + (lng - cLng) ** 2;
+      if (d < bestD) {
+        bestD = d;
+        best = b;
+      }
+    }
+    return best.sidoName;
+  }
+  // 해상·국경 밖 — 전국 중심에 가장 가까운 시·도
+  let best = AIRKOREA_SIDO_BBOXES[0];
+  let bestD = Number.POSITIVE_INFINITY;
+  for (const b of AIRKOREA_SIDO_BBOXES) {
+    const cLat = (b.minLat + b.maxLat) / 2;
+    const cLng = (b.minLng + b.maxLng) / 2;
+    const d = (lat - cLat) ** 2 + (lng - cLng) ** 2;
+    if (d < bestD) {
+      bestD = d;
+      best = b;
+    }
+  }
+  return best.sidoName;
+}

--- a/backend/src/cache-hydration/airkorea-station-bundled.loader.ts
+++ b/backend/src/cache-hydration/airkorea-station-bundled.loader.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import { resolveBundledAssetPath } from '../common/resolve-bundled-asset.util';
+import type { AirKoreaStationCatalogEntry } from './airkorea-station.util';
+
+export type BundledStationCatalogFile = {
+  version: number;
+  generatedAt: string;
+  stations: AirKoreaStationCatalogEntry[];
+};
+
+let bundledCache: AirKoreaStationCatalogEntry[] | null = null;
+
+/** repo에 포함된 전국 측정소 좌표 (Nominatim 시드 스크립트로 생성) */
+export function loadBundledStationCatalog(): AirKoreaStationCatalogEntry[] | null {
+  if (bundledCache) {
+    return bundledCache;
+  }
+  const filePath = resolveBundledAssetPath(
+    __dirname,
+    'cache-hydration',
+    'airkorea-stations.json',
+  );
+  if (!filePath) {
+    return null;
+  }
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as BundledStationCatalogFile;
+    const stations = parsed.stations?.filter(
+      (s) =>
+        s.stationName &&
+        s.sidoName &&
+        Number.isFinite(s.lat) &&
+        Number.isFinite(s.lng),
+    );
+    if (!stations?.length) {
+      return null;
+    }
+    bundledCache = stations;
+    return bundledCache;
+  } catch {
+    return null;
+  }
+}

--- a/backend/src/cache-hydration/airkorea-station.util.spec.ts
+++ b/backend/src/cache-hydration/airkorea-station.util.spec.ts
@@ -1,0 +1,37 @@
+import { findSidoByLatLng } from './airkorea-sido-bbox.util';
+import {
+  findNearestStation,
+  parseStationCatalogFromCtprvn,
+  withStationCoords,
+} from './airkorea-station.util';
+
+describe('airkorea-station.util', () => {
+  it('parseStationCatalogFromCtprvn keeps sido without coords', () => {
+    const rows = parseStationCatalogFromCtprvn([{ stationName: '청송읍' }], '경북');
+    expect(rows.length).toBe(1);
+    expect(rows[0].stationName).toBe('청송읍');
+    expect(rows[0].sidoName).toBe('경북');
+    expect(Number.isNaN(rows[0].lat)).toBe(true);
+  });
+
+  it('findNearestStation uses geocoded entries', () => {
+    const catalog = [
+      withStationCoords(
+        parseStationCatalogFromCtprvn([{ stationName: 'A' }], '경북')[0],
+        36.0,
+        128.0,
+      ),
+      withStationCoords(
+        parseStationCatalogFromCtprvn([{ stationName: 'B' }], '경북')[0],
+        37.0,
+        129.0,
+      ),
+    ];
+    const near = findNearestStation(catalog, 36.05, 128.05);
+    expect(near.stationName).toBe('A');
+  });
+
+  it('findSidoByLatLng resolves 구미 to 경북', () => {
+    expect(findSidoByLatLng(36.152673, 128.3432401)).toBe('경북');
+  });
+});

--- a/backend/src/cache-hydration/airkorea-station.util.ts
+++ b/backend/src/cache-hydration/airkorea-station.util.ts
@@ -1,0 +1,141 @@
+/** 에어코리아 측정소 카탈로그·캐시 키·최근접 측정소 선택 */
+
+import type { AirKoreaStationRow } from './airkorea.util';
+
+export type AirKoreaStationCatalogEntry = {
+  stationName: string;
+  /** 에어코리아 getCtprvnRltmMesureDnsty sidoName 과 동일 */
+  sidoName: string;
+  lat: number;
+  lng: number;
+  addr?: string;
+};
+
+export const AIRKOREA_SIDO_ADDRS = [
+  '서울',
+  '부산',
+  '대구',
+  '인천',
+  '광주',
+  '대전',
+  '울산',
+  '세종',
+  '경기',
+  '강원',
+  '충북',
+  '충남',
+  '전북',
+  '전남',
+  '경북',
+  '경남',
+  '제주',
+] as const;
+
+export const AIRKOREA_STATION_CATALOG_CACHE_KEY = 'airkorea:station-catalog';
+
+/** 측정소별 PM2.5 캐시 — stationName은 에어코리아 공식 명칭 */
+export function dustStationCacheKey(stationName: string): string {
+  return `dust:st:${stationName}`;
+}
+
+export function haversineKm(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number,
+): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function hasStationCoords(s: AirKoreaStationCatalogEntry): boolean {
+  return Number.isFinite(s.lat) && Number.isFinite(s.lng);
+}
+
+/**
+ * getCtprvnRltmMesureDnsty item — 좌표 없이 stationName 만 사용 (폴백 카탈로그)
+ */
+export function parseStationCatalogFromCtprvn(
+  rows: readonly Pick<AirKoreaStationRow, 'stationName'>[],
+  sidoName: string,
+): AirKoreaStationCatalogEntry[] {
+  const seen = new Set<string>();
+  const list: AirKoreaStationCatalogEntry[] = [];
+  for (const row of rows) {
+    const stationName = row.stationName?.trim();
+    if (!stationName) continue;
+    const dedupeKey = `${sidoName}\u0000${stationName}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    list.push({
+      stationName,
+      sidoName,
+      lat: Number.NaN,
+      lng: Number.NaN,
+    });
+  }
+  return list;
+}
+
+/** 테스트 등 — 무좌표 항목에 좌표 부여 */
+export function withStationCoords(
+  entry: AirKoreaStationCatalogEntry,
+  lat: number,
+  lng: number,
+): AirKoreaStationCatalogEntry {
+  return { ...entry, lat, lng };
+}
+
+/**
+ * getMsrstnList item — dmX=경도, dmY=위도 (WGS84, 에어코리아·공공데이터 관례)
+ */
+export function parseStationCatalogRow(
+  row: Record<string, string | undefined>,
+): AirKoreaStationCatalogEntry | null {
+  const stationName = row.stationName?.trim();
+  const lng = Number(row.dmX);
+  const lat = Number(row.dmY);
+  const sidoName = row.sidoNm?.trim() ?? '';
+  if (!stationName || !Number.isFinite(lat) || !Number.isFinite(lng)) {
+    return null;
+  }
+  if (lat < 32.5 || lat > 39.8 || lng < 124 || lng > 132.5) {
+    return null;
+  }
+  return {
+    stationName,
+    sidoName,
+    lat,
+    lng,
+    addr: row.addr?.trim(),
+  };
+}
+
+/** 카탈로그에서 Haversine 최근접 측정소 (좌표 유효 항목만 전달할 것) */
+export function findNearestStation(
+  catalog: AirKoreaStationCatalogEntry[],
+  lat: number,
+  lng: number,
+): AirKoreaStationCatalogEntry {
+  if (!catalog.length) {
+    throw new Error('에어코리아 측정소 카탈로그가 비어 있습니다.');
+  }
+  let best = catalog[0];
+  let bestD = haversineKm(lat, lng, best.lat, best.lng);
+  for (let i = 1; i < catalog.length; i += 1) {
+    const s = catalog[i];
+    const d = haversineKm(lat, lng, s.lat, s.lng);
+    if (d < bestD) {
+      best = s;
+      bestD = d;
+    }
+  }
+  return best;
+}

--- a/backend/src/cache-hydration/airkorea.util.spec.ts
+++ b/backend/src/cache-hydration/airkorea.util.spec.ts
@@ -1,0 +1,30 @@
+import {
+  extractAirKoreaItems,
+  pickBestPm25Reading,
+  pm25UgToLabel,
+} from './airkorea.util';
+
+describe('airkorea.util', () => {
+  it('extractAirKoreaItems handles array and item wrapper', () => {
+    expect(extractAirKoreaItems({ items: [{ pm25Value: '10' }] })).toHaveLength(1);
+    expect(
+      extractAirKoreaItems({ items: { item: [{ pm25Value: '20' }, { pm25Value: '30' }] } }),
+    ).toHaveLength(2);
+  });
+
+  it('pickBestPm25Reading skips invalid values', () => {
+    const r = pickBestPm25Reading([
+      { pm25Value: '-', stationName: 'A' },
+      { pm25Value: '42', pm25Grade: '3', stationName: 'B' },
+    ]);
+    expect(r?.pm25).toBe(42);
+    expect(r?.pm25Label).toBe('나쁨');
+    expect(r?.stationName).toBe('B');
+  });
+
+  it('pm25UgToLabel matches AirKorea bands', () => {
+    expect(pm25UgToLabel(10)).toBe('좋음');
+    expect(pm25UgToLabel(25)).toBe('보통');
+    expect(pm25UgToLabel(50)).toBe('나쁨');
+  });
+});

--- a/backend/src/cache-hydration/airkorea.util.ts
+++ b/backend/src/cache-hydration/airkorea.util.ts
@@ -1,0 +1,102 @@
+/** 에어코리아 시도별 실시간 측정(getCtprvnRltmMesureDnsty) 응답 파싱 */
+
+export type AirKoreaStationRow = {
+  pm25Value?: string;
+  pm25Grade?: string;
+  stationName?: string;
+  /** 에어코리아 측정 시각 문자열 — 최신 행 선택용 */
+  dataTime?: string;
+};
+
+export type AirKoreaItemsBody = {
+  items?: AirKoreaStationRow[] | { item?: AirKoreaStationRow | AirKoreaStationRow[] };
+};
+
+/** response.body.items — 배열 또는 { item: [...] } 모두 처리 */
+export function extractAirKoreaItems(
+  body: AirKoreaItemsBody | undefined,
+): AirKoreaStationRow[] {
+  const items = body?.items;
+  if (!items) return [];
+  if (Array.isArray(items)) return items;
+  const item = items.item;
+  if (!item) return [];
+  return Array.isArray(item) ? item : [item];
+}
+
+/** 에어코리아 PM2.5 등급(1~4) → 한글 */
+export function pm25GradeToLabel(grade: number): string {
+  switch (grade) {
+    case 1:
+      return '좋음';
+    case 2:
+      return '보통';
+    case 3:
+      return '나쁨';
+    case 4:
+      return '매우나쁨';
+    default:
+      return '정보없음';
+  }
+}
+
+/** 농도(㎍/㎥)만으로 등급 근사 (에어코리아 기준) */
+export function pm25UgToLabel(pm25: number): string {
+  if (pm25 <= 15) return '좋음';
+  if (pm25 <= 35) return '보통';
+  if (pm25 <= 75) return '나쁨';
+  return '매우나쁨';
+}
+
+/**
+ * 유효 측정값이 있는 첫 측정소 — pm25Value·pm25Grade(1~4)
+ * 파싱 실패 시 null (호출 측에서 캐시 미저장 처리)
+ */
+export function pickBestPm25Reading(rows: AirKoreaStationRow[]): {
+  pm25: number;
+  pm25Grade: number;
+  pm25Label: string;
+  stationName: string | null;
+} | null {
+  for (const row of rows) {
+    const raw = row.pm25Value?.trim();
+    if (!raw || raw === '-' || raw === '점검중') continue;
+    const pm25 = Number(raw);
+    if (!Number.isFinite(pm25) || pm25 < 0) continue;
+
+    const gradeRaw = row.pm25Grade?.trim();
+    const gradeParsed = gradeRaw ? Number(gradeRaw) : NaN;
+    const pm25Grade = Number.isFinite(gradeParsed) && gradeParsed >= 1 && gradeParsed <= 4
+      ? gradeParsed
+      : pm25 <= 15
+        ? 1
+        : pm25 <= 35
+          ? 2
+          : pm25 <= 75
+            ? 3
+            : 4;
+
+    return {
+      pm25,
+      pm25Grade,
+      pm25Label: pm25GradeToLabel(pm25Grade),
+      stationName: row.stationName?.trim() ?? null,
+    };
+  }
+  return null;
+}
+
+/** dataTime 역순(최근 우선)으로 정렬한 뒤 pickBestPm25Reading — 측정소별 시계열 응답용 */
+export function pickLatestPm25Reading(rows: AirKoreaStationRow[]): {
+  pm25: number;
+  pm25Grade: number;
+  pm25Label: string;
+  stationName: string | null;
+} | null {
+  const sorted = [...rows].sort((a, b) => {
+    const ta = a.dataTime?.trim() ?? '';
+    const tb = b.dataTime?.trim() ?? '';
+    return tb.localeCompare(ta);
+  });
+  return pickBestPm25Reading(sorted);
+}

--- a/backend/src/cache-hydration/cache-hydration.module.ts
+++ b/backend/src/cache-hydration/cache-hydration.module.ts
@@ -1,9 +1,9 @@
 import { Module } from '@nestjs/common';
-import { SkyModule } from '../sky/sky.module';
+import { SpotsModule } from '../spots/spots.module';
 import { StarIndexCacheHydrationService } from './star-index-cache-hydration.service';
 
 @Module({
-  imports: [SkyModule],
+  imports: [SpotsModule],
   providers: [StarIndexCacheHydrationService],
   exports: [StarIndexCacheHydrationService],
 })

--- a/backend/src/cache-hydration/data/airkorea-stations.json
+++ b/backend/src/cache-hydration/data/airkorea-stations.json
@@ -1,0 +1,3756 @@
+{
+  "version": 1,
+  "generatedAt": "2026-05-17T05:03:13.598Z",
+  "stations": [
+    {
+      "stationName": "정릉로",
+      "sidoName": "서울",
+      "lat": 37.6040765,
+      "lng": 127.0308849
+    },
+    {
+      "stationName": "도봉구",
+      "sidoName": "서울",
+      "lat": 37.6686,
+      "lng": 127.0466
+    },
+    {
+      "stationName": "은평구",
+      "sidoName": "서울",
+      "lat": 37.6024,
+      "lng": 126.9293
+    },
+    {
+      "stationName": "서대문구",
+      "sidoName": "서울",
+      "lat": 37.5790747,
+      "lng": 126.9367861
+    },
+    {
+      "stationName": "마포구",
+      "sidoName": "서울",
+      "lat": 37.566571,
+      "lng": 126.9015317
+    },
+    {
+      "stationName": "신촌로",
+      "sidoName": "서울",
+      "lat": 37.5573744,
+      "lng": 126.9579806
+    },
+    {
+      "stationName": "강서구",
+      "sidoName": "서울",
+      "lat": 37.5509,
+      "lng": 126.8497
+    },
+    {
+      "stationName": "공항대로",
+      "sidoName": "서울",
+      "lat": 37.5552065,
+      "lng": 126.8848512
+    },
+    {
+      "stationName": "구로구",
+      "sidoName": "서울",
+      "lat": 37.4951999,
+      "lng": 126.8877
+    },
+    {
+      "stationName": "영등포구",
+      "sidoName": "서울",
+      "lat": 37.5262,
+      "lng": 126.8959
+    },
+    {
+      "stationName": "영등포로",
+      "sidoName": "서울",
+      "lat": 37.5185849,
+      "lng": 126.9148678
+    },
+    {
+      "stationName": "동작구",
+      "sidoName": "서울",
+      "lat": 37.5120999,
+      "lng": 126.9395
+    },
+    {
+      "stationName": "관악구",
+      "sidoName": "서울",
+      "lat": 37.4782,
+      "lng": 126.9518
+    },
+    {
+      "stationName": "강남구",
+      "sidoName": "서울",
+      "lat": 37.5177,
+      "lng": 127.0473
+    },
+    {
+      "stationName": "서초구",
+      "sidoName": "서울",
+      "lat": 37.4835,
+      "lng": 127.0322
+    },
+    {
+      "stationName": "도산대로",
+      "sidoName": "서울",
+      "lat": 37.5167677,
+      "lng": 127.0208986
+    },
+    {
+      "stationName": "강남대로",
+      "sidoName": "서울",
+      "lat": 37.5007544,
+      "lng": 127.0264297
+    },
+    {
+      "stationName": "송파구",
+      "sidoName": "서울",
+      "lat": 37.5145,
+      "lng": 127.1058
+    },
+    {
+      "stationName": "강동구",
+      "sidoName": "서울",
+      "lat": 37.53,
+      "lng": 127.1237
+    },
+    {
+      "stationName": "천호대로",
+      "sidoName": "서울",
+      "lat": 37.5734455,
+      "lng": 127.0399425
+    },
+    {
+      "stationName": "금천구",
+      "sidoName": "서울",
+      "lat": 37.4565,
+      "lng": 126.8954
+    },
+    {
+      "stationName": "시흥대로",
+      "sidoName": "서울",
+      "lat": 37.4393409,
+      "lng": 126.9030897
+    },
+    {
+      "stationName": "강북구",
+      "sidoName": "서울",
+      "lat": 37.6395,
+      "lng": 127.0255
+    },
+    {
+      "stationName": "양천구",
+      "sidoName": "서울",
+      "lat": 37.5171,
+      "lng": 126.8663
+    },
+    {
+      "stationName": "노원구",
+      "sidoName": "서울",
+      "lat": 37.654,
+      "lng": 127.0567
+    },
+    {
+      "stationName": "화랑로",
+      "sidoName": "서울",
+      "lat": 37.6176196,
+      "lng": 127.0734914
+    },
+    {
+      "stationName": "중구",
+      "sidoName": "서울",
+      "lat": 37.5636559,
+      "lng": 126.9975097
+    },
+    {
+      "stationName": "한강대로",
+      "sidoName": "서울",
+      "lat": 37.5304841,
+      "lng": 126.9689973
+    },
+    {
+      "stationName": "종로구",
+      "sidoName": "서울",
+      "lat": 37.5806949,
+      "lng": 126.9827989
+    },
+    {
+      "stationName": "청계천로",
+      "sidoName": "서울",
+      "lat": 37.5706385,
+      "lng": 127.0337149
+    },
+    {
+      "stationName": "종로",
+      "sidoName": "서울",
+      "lat": 37.5739193,
+      "lng": 127.0186266
+    },
+    {
+      "stationName": "용산구",
+      "sidoName": "서울",
+      "lat": 37.5323,
+      "lng": 126.99
+    },
+    {
+      "stationName": "광진구",
+      "sidoName": "서울",
+      "lat": 37.5362696,
+      "lng": 127.0879515
+    },
+    {
+      "stationName": "성동구",
+      "sidoName": "서울",
+      "lat": 37.5635,
+      "lng": 127.0365
+    },
+    {
+      "stationName": "강변북로",
+      "sidoName": "서울",
+      "lat": 37.5373896,
+      "lng": 127.0448427
+    },
+    {
+      "stationName": "중랑구",
+      "sidoName": "서울",
+      "lat": 37.6063,
+      "lng": 127.093
+    },
+    {
+      "stationName": "동대문구",
+      "sidoName": "서울",
+      "lat": 37.5741982,
+      "lng": 127.0395092
+    },
+    {
+      "stationName": "홍릉로",
+      "sidoName": "서울",
+      "lat": 37.5834824,
+      "lng": 127.0441365
+    },
+    {
+      "stationName": "성북구",
+      "sidoName": "서울",
+      "lat": 37.59,
+      "lng": 127.0165
+    },
+    {
+      "stationName": "광복동",
+      "sidoName": "부산",
+      "lat": 35.1003589,
+      "lng": 129.0306071
+    },
+    {
+      "stationName": "초량동",
+      "sidoName": "부산",
+      "lat": 35.1202009,
+      "lng": 129.037345
+    },
+    {
+      "stationName": "태종대",
+      "sidoName": "부산",
+      "lat": 35.05851,
+      "lng": 129.0876858
+    },
+    {
+      "stationName": "청학동",
+      "sidoName": "부산",
+      "lat": 35.09106,
+      "lng": 129.06497
+    },
+    {
+      "stationName": "전포동",
+      "sidoName": "부산",
+      "lat": 35.1572828,
+      "lng": 129.0745022
+    },
+    {
+      "stationName": "온천동",
+      "sidoName": "부산",
+      "lat": 35.2132323,
+      "lng": 129.0656907
+    },
+    {
+      "stationName": "명장동",
+      "sidoName": "부산",
+      "lat": 35.20755,
+      "lng": 129.10356
+    },
+    {
+      "stationName": "대연동",
+      "sidoName": "부산",
+      "lat": 35.1343823,
+      "lng": 129.0938404
+    },
+    {
+      "stationName": "용호동",
+      "sidoName": "부산",
+      "lat": 35.1132835,
+      "lng": 129.1167185
+    },
+    {
+      "stationName": "학장동",
+      "sidoName": "부산",
+      "lat": 35.1422194,
+      "lng": 128.9843177
+    },
+    {
+      "stationName": "덕천동",
+      "sidoName": "부산",
+      "lat": 35.2122143,
+      "lng": 129.0115542
+    },
+    {
+      "stationName": "화명동",
+      "sidoName": "부산",
+      "lat": 35.2385762,
+      "lng": 129.0257381
+    },
+    {
+      "stationName": "삼락동",
+      "sidoName": "부산",
+      "lat": 35.1837761,
+      "lng": 128.9791895
+    },
+    {
+      "stationName": "우동",
+      "sidoName": "부산",
+      "lat": 35.1769331,
+      "lng": 129.1485409
+    },
+    {
+      "stationName": "감천동",
+      "sidoName": "부산",
+      "lat": 35.0885858,
+      "lng": 129.004687
+    },
+    {
+      "stationName": "청룡동",
+      "sidoName": "부산",
+      "lat": 35.28324,
+      "lng": 129.07324
+    },
+    {
+      "stationName": "좌동",
+      "sidoName": "부산",
+      "lat": 35.1859071,
+      "lng": 129.1754505
+    },
+    {
+      "stationName": "재송동",
+      "sidoName": "부산",
+      "lat": 35.1843578,
+      "lng": 129.1277407
+    },
+    {
+      "stationName": "장림동",
+      "sidoName": "부산",
+      "lat": 35.0758278,
+      "lng": 128.9684803
+    },
+    {
+      "stationName": "대저동",
+      "sidoName": "부산",
+      "lat": 35.1586386,
+      "lng": 128.9535924
+    },
+    {
+      "stationName": "녹산동",
+      "sidoName": "부산",
+      "lat": 35.1116974,
+      "lng": 128.869001
+    },
+    {
+      "stationName": "명지동",
+      "sidoName": "부산",
+      "lat": 35.1071356,
+      "lng": 128.9179423
+    },
+    {
+      "stationName": "연산동",
+      "sidoName": "부산",
+      "lat": 35.1758928,
+      "lng": 129.0867411
+    },
+    {
+      "stationName": "기장읍",
+      "sidoName": "부산",
+      "lat": 35.2385796,
+      "lng": 129.2158159
+    },
+    {
+      "stationName": "용수리",
+      "sidoName": "부산",
+      "lat": 35.33662,
+      "lng": 129.17312
+    },
+    {
+      "stationName": "수정동",
+      "sidoName": "부산",
+      "lat": 35.1314847,
+      "lng": 129.0366427
+    },
+    {
+      "stationName": "회동동",
+      "sidoName": "부산",
+      "lat": 35.23105,
+      "lng": 129.12173
+    },
+    {
+      "stationName": "광안동",
+      "sidoName": "부산",
+      "lat": 35.1590134,
+      "lng": 129.113064
+    },
+    {
+      "stationName": "덕포동",
+      "sidoName": "부산",
+      "lat": 35.1754906,
+      "lng": 128.9854608
+    },
+    {
+      "stationName": "개금동",
+      "sidoName": "부산",
+      "lat": 35.1527311,
+      "lng": 129.0213975
+    },
+    {
+      "stationName": "당리동",
+      "sidoName": "부산",
+      "lat": 35.1071561,
+      "lng": 128.9768898
+    },
+    {
+      "stationName": "부산항",
+      "sidoName": "부산",
+      "lat": 35.1026,
+      "lng": 129.0405108
+    },
+    {
+      "stationName": "부산신항",
+      "sidoName": "부산",
+      "lat": 35.1178873,
+      "lng": 128.8467054
+    },
+    {
+      "stationName": "시지동",
+      "sidoName": "대구",
+      "lat": 35.84276,
+      "lng": 128.69352
+    },
+    {
+      "stationName": "진천동",
+      "sidoName": "대구",
+      "lat": 35.8107208,
+      "lng": 128.5212715
+    },
+    {
+      "stationName": "다사읍",
+      "sidoName": "대구",
+      "lat": 35.8622907,
+      "lng": 128.4620011
+    },
+    {
+      "stationName": "본동",
+      "sidoName": "대구",
+      "lat": 35.8354002,
+      "lng": 128.5397293
+    },
+    {
+      "stationName": "내당동",
+      "sidoName": "대구",
+      "lat": 35.8625618,
+      "lng": 128.5618878
+    },
+    {
+      "stationName": "침산동",
+      "sidoName": "대구",
+      "lat": 35.8920401,
+      "lng": 128.5878923
+    },
+    {
+      "stationName": "화원읍",
+      "sidoName": "대구",
+      "lat": 35.8024072,
+      "lng": 128.4964134
+    },
+    {
+      "stationName": "충혼탑",
+      "sidoName": "대구",
+      "lat": 36.2315523,
+      "lng": 128.571324
+    },
+    {
+      "stationName": "군위읍",
+      "sidoName": "대구",
+      "lat": 36.2399401,
+      "lng": 128.568785
+    },
+    {
+      "stationName": "남산1동",
+      "sidoName": "대구",
+      "lat": 35.8595505,
+      "lng": 128.5928209
+    },
+    {
+      "stationName": "수창동",
+      "sidoName": "대구",
+      "lat": 35.87504,
+      "lng": 128.58662
+    },
+    {
+      "stationName": "지산동",
+      "sidoName": "대구",
+      "lat": 35.8239902,
+      "lng": 128.6345138
+    },
+    {
+      "stationName": "서호동",
+      "sidoName": "대구",
+      "lat": 35.86495,
+      "lng": 128.70906
+    },
+    {
+      "stationName": "용계동",
+      "sidoName": "대구",
+      "lat": 35.87377,
+      "lng": 128.68835
+    },
+    {
+      "stationName": "이현동",
+      "sidoName": "대구",
+      "lat": 35.87628,
+      "lng": 128.53886
+    },
+    {
+      "stationName": "평리동",
+      "sidoName": "대구",
+      "lat": 35.8732984,
+      "lng": 128.5569201
+    },
+    {
+      "stationName": "대명동",
+      "sidoName": "대구",
+      "lat": 35.8355675,
+      "lng": 128.5717849
+    },
+    {
+      "stationName": "신암동",
+      "sidoName": "대구",
+      "lat": 35.88399,
+      "lng": 128.62359
+    },
+    {
+      "stationName": "태전동",
+      "sidoName": "대구",
+      "lat": 35.9214358,
+      "lng": 128.5461523
+    },
+    {
+      "stationName": "산격동",
+      "sidoName": "대구",
+      "lat": 35.90163,
+      "lng": 128.60464
+    },
+    {
+      "stationName": "서변동",
+      "sidoName": "대구",
+      "lat": 35.9235922,
+      "lng": 128.5955669
+    },
+    {
+      "stationName": "연호동",
+      "sidoName": "대구",
+      "lat": 35.84173,
+      "lng": 128.6723
+    },
+    {
+      "stationName": "만촌동",
+      "sidoName": "대구",
+      "lat": 35.8598791,
+      "lng": 128.6484485
+    },
+    {
+      "stationName": "호림동",
+      "sidoName": "대구",
+      "lat": 35.83568,
+      "lng": 128.48178
+    },
+    {
+      "stationName": "유가읍",
+      "sidoName": "대구",
+      "lat": 35.6940422,
+      "lng": 128.4597255
+    },
+    {
+      "stationName": "이곡동",
+      "sidoName": "대구",
+      "lat": 35.85409,
+      "lng": 128.50764
+    },
+    {
+      "stationName": "신흥",
+      "sidoName": "인천",
+      "lat": 37.46593,
+      "lng": 126.63732
+    },
+    {
+      "stationName": "서해",
+      "sidoName": "인천",
+      "lat": 37.4239194,
+      "lng": 126.6517561
+    },
+    {
+      "stationName": "영종",
+      "sidoName": "인천",
+      "lat": 37.5118887,
+      "lng": 126.524599
+    },
+    {
+      "stationName": "구월동",
+      "sidoName": "인천",
+      "lat": 37.4473875,
+      "lng": 126.706289
+    },
+    {
+      "stationName": "숭의",
+      "sidoName": "인천",
+      "lat": 37.4607927,
+      "lng": 126.6382349
+    },
+    {
+      "stationName": "석바위",
+      "sidoName": "인천",
+      "lat": 37.458094,
+      "lng": 126.6883289
+    },
+    {
+      "stationName": "부평역",
+      "sidoName": "인천",
+      "lat": 37.4927528,
+      "lng": 126.7231341
+    },
+    {
+      "stationName": "남동",
+      "sidoName": "인천",
+      "lat": 37.4336291,
+      "lng": 126.7093944
+    },
+    {
+      "stationName": "주안",
+      "sidoName": "인천",
+      "lat": 37.4650814,
+      "lng": 126.6806313
+    },
+    {
+      "stationName": "부평",
+      "sidoName": "인천",
+      "lat": 37.489454,
+      "lng": 126.7245591
+    },
+    {
+      "stationName": "연희",
+      "sidoName": "인천",
+      "lat": 37.5486392,
+      "lng": 126.6826642
+    },
+    {
+      "stationName": "검단",
+      "sidoName": "인천",
+      "lat": 37.6059295,
+      "lng": 126.6660333
+    },
+    {
+      "stationName": "중봉",
+      "sidoName": "인천",
+      "lat": 37.5182794,
+      "lng": 126.6489698
+    },
+    {
+      "stationName": "계산",
+      "sidoName": "인천",
+      "lat": 37.543336,
+      "lng": 126.7278571
+    },
+    {
+      "stationName": "효성",
+      "sidoName": "인천",
+      "lat": 37.5330069,
+      "lng": 126.6911487
+    },
+    {
+      "stationName": "임학",
+      "sidoName": "인천",
+      "lat": 37.5451309,
+      "lng": 126.7387234
+    },
+    {
+      "stationName": "고잔",
+      "sidoName": "인천",
+      "lat": 37.3941796,
+      "lng": 126.6966863
+    },
+    {
+      "stationName": "서창",
+      "sidoName": "인천",
+      "lat": 37.4321061,
+      "lng": 126.7491895
+    },
+    {
+      "stationName": "석남",
+      "sidoName": "인천",
+      "lat": 37.5062862,
+      "lng": 126.6746369
+    },
+    {
+      "stationName": "송해",
+      "sidoName": "인천",
+      "lat": 37.7697134,
+      "lng": 126.4606061
+    },
+    {
+      "stationName": "동춘",
+      "sidoName": "인천",
+      "lat": 37.4048204,
+      "lng": 126.6802706
+    },
+    {
+      "stationName": "운서",
+      "sidoName": "인천",
+      "lat": 37.4928006,
+      "lng": 126.4937678
+    },
+    {
+      "stationName": "송현",
+      "sidoName": "인천",
+      "lat": 37.2529119,
+      "lng": 126.4752337
+    },
+    {
+      "stationName": "논현",
+      "sidoName": "인천",
+      "lat": 37.4006866,
+      "lng": 126.7225648
+    },
+    {
+      "stationName": "청라",
+      "sidoName": "인천",
+      "lat": 37.5702484,
+      "lng": 126.6705968
+    },
+    {
+      "stationName": "송도",
+      "sidoName": "인천",
+      "lat": 37.4299382,
+      "lng": 126.6547155
+    },
+    {
+      "stationName": "아암",
+      "sidoName": "인천",
+      "lat": 37.3898221,
+      "lng": 126.6713601
+    },
+    {
+      "stationName": "동막",
+      "sidoName": "인천",
+      "lat": 37.3986231,
+      "lng": 126.6735412
+    },
+    {
+      "stationName": "원당",
+      "sidoName": "인천",
+      "lat": 37.5932591,
+      "lng": 126.724256
+    },
+    {
+      "stationName": "길상",
+      "sidoName": "인천",
+      "lat": 37.63804,
+      "lng": 126.490488
+    },
+    {
+      "stationName": "삼산",
+      "sidoName": "인천",
+      "lat": 37.507666,
+      "lng": 126.7376184
+    },
+    {
+      "stationName": "경인항",
+      "sidoName": "인천",
+      "lat": 37.5618583,
+      "lng": 126.610139
+    },
+    {
+      "stationName": "인천항",
+      "sidoName": "인천",
+      "lat": 37.4600226,
+      "lng": 126.5937709
+    },
+    {
+      "stationName": "석모리",
+      "sidoName": "인천",
+      "lat": 37.7053498,
+      "lng": 126.3176717
+    },
+    {
+      "stationName": "덕적도",
+      "sidoName": "인천",
+      "lat": 37.241879,
+      "lng": 126.1155925
+    },
+    {
+      "stationName": "백령도",
+      "sidoName": "인천",
+      "lat": 37.9498034,
+      "lng": 124.6724295
+    },
+    {
+      "stationName": "영흥",
+      "sidoName": "인천",
+      "lat": 37.2424686,
+      "lng": 126.4384467
+    },
+    {
+      "stationName": "연평도",
+      "sidoName": "인천",
+      "lat": 37.9324569,
+      "lng": 124.6826506
+    },
+    {
+      "stationName": "울도",
+      "sidoName": "인천",
+      "lat": 37.0289379,
+      "lng": 125.9883866
+    },
+    {
+      "stationName": "서석동",
+      "sidoName": "광주",
+      "lat": 35.1425263,
+      "lng": 126.928997
+    },
+    {
+      "stationName": "농성동",
+      "sidoName": "광주",
+      "lat": 35.1541526,
+      "lng": 126.8884127
+    },
+    {
+      "stationName": "치평동",
+      "sidoName": "광주",
+      "lat": 35.152758,
+      "lng": 126.8449919
+    },
+    {
+      "stationName": "노대동",
+      "sidoName": "광주",
+      "lat": 35.1013144,
+      "lng": 126.9064869
+    },
+    {
+      "stationName": "유촌동",
+      "sidoName": "광주",
+      "lat": 35.1643042,
+      "lng": 126.851776
+    },
+    {
+      "stationName": "두암동",
+      "sidoName": "광주",
+      "lat": 35.1705473,
+      "lng": 126.9358089
+    },
+    {
+      "stationName": "운암동",
+      "sidoName": "광주",
+      "lat": 35.177893,
+      "lng": 126.8784333
+    },
+    {
+      "stationName": "건국동",
+      "sidoName": "광주",
+      "lat": 35.2229306,
+      "lng": 126.8816214
+    },
+    {
+      "stationName": "일곡동",
+      "sidoName": "광주",
+      "lat": 35.2093565,
+      "lng": 126.8950292
+    },
+    {
+      "stationName": "오선동",
+      "sidoName": "광주",
+      "lat": 35.2026696,
+      "lng": 126.7997842
+    },
+    {
+      "stationName": "우산동(광주)",
+      "sidoName": "광주",
+      "lat": 35.1542122,
+      "lng": 126.8152185
+    },
+    {
+      "stationName": "평동",
+      "sidoName": "광주",
+      "lat": 35.1248086,
+      "lng": 126.7695968
+    },
+    {
+      "stationName": "주월동",
+      "sidoName": "광주",
+      "lat": 35.1308326,
+      "lng": 126.8973416
+    },
+    {
+      "stationName": "읍내동",
+      "sidoName": "대전",
+      "lat": 36.3779187,
+      "lng": 127.4251848
+    },
+    {
+      "stationName": "문평동",
+      "sidoName": "대전",
+      "lat": 36.4456518,
+      "lng": 127.399871
+    },
+    {
+      "stationName": "문창동",
+      "sidoName": "대전",
+      "lat": 36.3179965,
+      "lng": 127.4358892
+    },
+    {
+      "stationName": "구성동",
+      "sidoName": "대전",
+      "lat": 36.3710748,
+      "lng": 127.3684842
+    },
+    {
+      "stationName": "노은동",
+      "sidoName": "대전",
+      "lat": 36.369181,
+      "lng": 127.3188784
+    },
+    {
+      "stationName": "상대동(대전)",
+      "sidoName": "대전",
+      "lat": 36.3407026,
+      "lng": 127.3294688
+    },
+    {
+      "stationName": "관평동",
+      "sidoName": "대전",
+      "lat": 36.4226991,
+      "lng": 127.3983671
+    },
+    {
+      "stationName": "지족동",
+      "sidoName": "대전",
+      "lat": 36.3802428,
+      "lng": 127.3075849
+    },
+    {
+      "stationName": "대성동",
+      "sidoName": "대전",
+      "lat": 36.2951648,
+      "lng": 127.4711093
+    },
+    {
+      "stationName": "정림동",
+      "sidoName": "대전",
+      "lat": 36.3041554,
+      "lng": 127.3660345
+    },
+    {
+      "stationName": "둔산동",
+      "sidoName": "대전",
+      "lat": 36.3560702,
+      "lng": 127.390656
+    },
+    {
+      "stationName": "월평동",
+      "sidoName": "대전",
+      "lat": 36.3514451,
+      "lng": 127.3571242
+    },
+    {
+      "stationName": "비래동",
+      "sidoName": "대전",
+      "lat": 36.3614197,
+      "lng": 127.4544419
+    },
+    {
+      "stationName": "화산리",
+      "sidoName": "울산",
+      "lat": 35.36733,
+      "lng": 129.2794
+    },
+    {
+      "stationName": "상남리",
+      "sidoName": "울산",
+      "lat": 35.47977,
+      "lng": 129.30882
+    },
+    {
+      "stationName": "삼남읍",
+      "sidoName": "울산",
+      "lat": 35.53088,
+      "lng": 129.10267
+    },
+    {
+      "stationName": "약사동",
+      "sidoName": "울산",
+      "lat": 35.570425,
+      "lng": 129.337294
+    },
+    {
+      "stationName": "웅촌면",
+      "sidoName": "울산",
+      "lat": 35.46545,
+      "lng": 129.20291
+    },
+    {
+      "stationName": "범서읍",
+      "sidoName": "울산",
+      "lat": 35.58914,
+      "lng": 129.24011
+    },
+    {
+      "stationName": "북부순환도로",
+      "sidoName": "울산",
+      "lat": 35.5554938,
+      "lng": 129.2755286
+    },
+    {
+      "stationName": "송정동",
+      "sidoName": "울산",
+      "lat": 35.6019215,
+      "lng": 129.3668462
+    },
+    {
+      "stationName": "산업로",
+      "sidoName": "울산",
+      "lat": 35.5418056,
+      "lng": 129.3538829
+    },
+    {
+      "stationName": "방어진순환도로",
+      "sidoName": "울산",
+      "lat": 35.5177085,
+      "lng": 129.3981211
+    },
+    {
+      "stationName": "울산항",
+      "sidoName": "울산",
+      "lat": 35.5105765,
+      "lng": 129.3749085
+    },
+    {
+      "stationName": "대송동",
+      "sidoName": "울산",
+      "lat": 35.5031757,
+      "lng": 129.4184443
+    },
+    {
+      "stationName": "성남동",
+      "sidoName": "울산",
+      "lat": 35.5528383,
+      "lng": 129.3182264
+    },
+    {
+      "stationName": "부곡동(울산)",
+      "sidoName": "울산",
+      "lat": 35.49979,
+      "lng": 129.33824
+    },
+    {
+      "stationName": "여천동(울산)",
+      "sidoName": "울산",
+      "lat": 35.5234259,
+      "lng": 129.3544862
+    },
+    {
+      "stationName": "선암동",
+      "sidoName": "울산",
+      "lat": 35.5157131,
+      "lng": 129.3243602
+    },
+    {
+      "stationName": "삼산동",
+      "sidoName": "울산",
+      "lat": 35.54126,
+      "lng": 129.34388
+    },
+    {
+      "stationName": "신정로",
+      "sidoName": "울산",
+      "lat": 35.54753,
+      "lng": 129.3172561
+    },
+    {
+      "stationName": "신정동",
+      "sidoName": "울산",
+      "lat": 35.53487,
+      "lng": 129.31199
+    },
+    {
+      "stationName": "덕신리",
+      "sidoName": "울산",
+      "lat": 35.4339806,
+      "lng": 129.3104539
+    },
+    {
+      "stationName": "무거동",
+      "sidoName": "울산",
+      "lat": 35.5430751,
+      "lng": 129.2549052
+    },
+    {
+      "stationName": "효문동",
+      "sidoName": "울산",
+      "lat": 35.57469,
+      "lng": 129.37727
+    },
+    {
+      "stationName": "조치원읍",
+      "sidoName": "세종",
+      "lat": 36.601795,
+      "lng": 127.2944592
+    },
+    {
+      "stationName": "아름동",
+      "sidoName": "세종",
+      "lat": 36.5175411,
+      "lng": 127.247467
+    },
+    {
+      "stationName": "한솔동",
+      "sidoName": "세종",
+      "lat": 36.4733355,
+      "lng": 127.2481655
+    },
+    {
+      "stationName": "부강면",
+      "sidoName": "세종",
+      "lat": 36.5287437,
+      "lng": 127.3790174
+    },
+    {
+      "stationName": "보람동",
+      "sidoName": "세종",
+      "lat": 36.4775742,
+      "lng": 127.2896146
+    },
+    {
+      "stationName": "전의면",
+      "sidoName": "세종",
+      "lat": 36.6814123,
+      "lng": 127.1957059
+    },
+    {
+      "stationName": "소사본동",
+      "sidoName": "경기",
+      "lat": 37.4734085,
+      "lng": 126.7947805
+    },
+    {
+      "stationName": "내동",
+      "sidoName": "경기",
+      "lat": 37.52041,
+      "lng": 126.77972
+    },
+    {
+      "stationName": "오정동",
+      "sidoName": "경기",
+      "lat": 37.5340894,
+      "lng": 126.7833694
+    },
+    {
+      "stationName": "송내대로(중동)",
+      "sidoName": "경기",
+      "lat": 37.5004329,
+      "lng": 126.7569355
+    },
+    {
+      "stationName": "백석읍",
+      "sidoName": "경기",
+      "lat": 37.7948404,
+      "lng": 126.9855291
+    },
+    {
+      "stationName": "고읍",
+      "sidoName": "경기",
+      "lat": 37.7883686,
+      "lng": 127.0771008
+    },
+    {
+      "stationName": "보산동",
+      "sidoName": "경기",
+      "lat": 37.9176604,
+      "lng": 127.0609443
+    },
+    {
+      "stationName": "봉산동",
+      "sidoName": "경기",
+      "lat": 37.0070947,
+      "lng": 127.2792156
+    },
+    {
+      "stationName": "공도읍",
+      "sidoName": "경기",
+      "lat": 36.9915,
+      "lng": 127.17214
+    },
+    {
+      "stationName": "죽산면",
+      "sidoName": "경기",
+      "lat": 37.0677159,
+      "lng": 127.418343
+    },
+    {
+      "stationName": "중앙동(경기)",
+      "sidoName": "경기",
+      "lat": 37.43887,
+      "lng": 127.15254
+    },
+    {
+      "stationName": "대신면",
+      "sidoName": "경기",
+      "lat": 37.38293,
+      "lng": 127.59799
+    },
+    {
+      "stationName": "가남읍",
+      "sidoName": "경기",
+      "lat": 37.21286,
+      "lng": 127.57724
+    },
+    {
+      "stationName": "연천",
+      "sidoName": "경기",
+      "lat": 38.1007279,
+      "lng": 127.0737179
+    },
+    {
+      "stationName": "전곡",
+      "sidoName": "경기",
+      "lat": 38.0245987,
+      "lng": 127.0718642
+    },
+    {
+      "stationName": "가평",
+      "sidoName": "경기",
+      "lat": 37.8146553,
+      "lng": 127.5107101
+    },
+    {
+      "stationName": "설악면",
+      "sidoName": "경기",
+      "lat": 37.6575,
+      "lng": 127.5031
+    },
+    {
+      "stationName": "용문면",
+      "sidoName": "경기",
+      "lat": 37.5022823,
+      "lng": 127.5915757
+    },
+    {
+      "stationName": "양평읍",
+      "sidoName": "경기",
+      "lat": 37.4868673,
+      "lng": 127.493973
+    },
+    {
+      "stationName": "신풍동",
+      "sidoName": "경기",
+      "lat": 37.28401,
+      "lng": 127.01292
+    },
+    {
+      "stationName": "인계동",
+      "sidoName": "경기",
+      "lat": 37.268208,
+      "lng": 127.0293802
+    },
+    {
+      "stationName": "광교동",
+      "sidoName": "경기",
+      "lat": 37.2842296,
+      "lng": 127.0521977
+    },
+    {
+      "stationName": "영통동",
+      "sidoName": "경기",
+      "lat": 37.2547147,
+      "lng": 127.0719349
+    },
+    {
+      "stationName": "천천동",
+      "sidoName": "경기",
+      "lat": 37.2958836,
+      "lng": 126.9789152
+    },
+    {
+      "stationName": "고색동",
+      "sidoName": "경기",
+      "lat": 37.2516324,
+      "lng": 126.9830331
+    },
+    {
+      "stationName": "호매실",
+      "sidoName": "경기",
+      "lat": 37.2596445,
+      "lng": 126.948709
+    },
+    {
+      "stationName": "대왕판교로(백현동)",
+      "sidoName": "경기",
+      "lat": 37.3854942,
+      "lng": 127.1024062
+    },
+    {
+      "stationName": "단대동",
+      "sidoName": "경기",
+      "lat": 37.45482,
+      "lng": 127.15767
+    },
+    {
+      "stationName": "정자동",
+      "sidoName": "경기",
+      "lat": 37.2966073,
+      "lng": 126.9928359
+    },
+    {
+      "stationName": "수내동",
+      "sidoName": "경기",
+      "lat": 37.37244,
+      "lng": 127.12236
+    },
+    {
+      "stationName": "복정동",
+      "sidoName": "경기",
+      "lat": 37.45896,
+      "lng": 127.1334
+    },
+    {
+      "stationName": "운중동",
+      "sidoName": "경기",
+      "lat": 37.3944345,
+      "lng": 127.074534
+    },
+    {
+      "stationName": "상대원동",
+      "sidoName": "경기",
+      "lat": 37.44211,
+      "lng": 127.17404
+    },
+    {
+      "stationName": "의정부동",
+      "sidoName": "경기",
+      "lat": 37.7393544,
+      "lng": 127.0464579
+    },
+    {
+      "stationName": "의정부1동",
+      "sidoName": "경기",
+      "lat": 37.7424836,
+      "lng": 127.0499686
+    },
+    {
+      "stationName": "송산3동",
+      "sidoName": "경기",
+      "lat": 37.755416,
+      "lng": 127.1118563
+    },
+    {
+      "stationName": "안양8동",
+      "sidoName": "경기",
+      "lat": 37.3841594,
+      "lng": 126.9319965
+    },
+    {
+      "stationName": "부림동",
+      "sidoName": "경기",
+      "lat": 37.3987517,
+      "lng": 126.9594554
+    },
+    {
+      "stationName": "호계3동",
+      "sidoName": "경기",
+      "lat": 37.3676428,
+      "lng": 126.9586821
+    },
+    {
+      "stationName": "안양2동",
+      "sidoName": "경기",
+      "lat": 37.4050333,
+      "lng": 126.9177988
+    },
+    {
+      "stationName": "철산동",
+      "sidoName": "경기",
+      "lat": 37.480209,
+      "lng": 126.8678124
+    },
+    {
+      "stationName": "소하동",
+      "sidoName": "경기",
+      "lat": 37.4432784,
+      "lng": 126.8823406
+    },
+    {
+      "stationName": "고잔동",
+      "sidoName": "경기",
+      "lat": 37.3157805,
+      "lng": 126.831162
+    },
+    {
+      "stationName": "초지동",
+      "sidoName": "경기",
+      "lat": 37.3134845,
+      "lng": 126.8115434
+    },
+    {
+      "stationName": "본오동",
+      "sidoName": "경기",
+      "lat": 37.2928744,
+      "lng": 126.8668397
+    },
+    {
+      "stationName": "원곡동",
+      "sidoName": "경기",
+      "lat": 37.3304454,
+      "lng": 126.7959133
+    },
+    {
+      "stationName": "대부동",
+      "sidoName": "경기",
+      "lat": 37.1987754,
+      "lng": 126.5772581
+    },
+    {
+      "stationName": "호수동",
+      "sidoName": "경기",
+      "lat": 37.3094921,
+      "lng": 126.8313312
+    },
+    {
+      "stationName": "중앙대로(고잔동)",
+      "sidoName": "경기",
+      "lat": 37.3173817,
+      "lng": 126.8242875
+    },
+    {
+      "stationName": "별양동",
+      "sidoName": "경기",
+      "lat": 37.4276861,
+      "lng": 126.9958682
+    },
+    {
+      "stationName": "과천동",
+      "sidoName": "경기",
+      "lat": 37.4497001,
+      "lng": 127.0008925
+    },
+    {
+      "stationName": "교문동",
+      "sidoName": "경기",
+      "lat": 37.5875737,
+      "lng": 127.1275277
+    },
+    {
+      "stationName": "동구동",
+      "sidoName": "경기",
+      "lat": 37.6117004,
+      "lng": 127.1393514
+    },
+    {
+      "stationName": "고천동",
+      "sidoName": "경기",
+      "lat": 37.3414144,
+      "lng": 126.9872221
+    },
+    {
+      "stationName": "정왕동",
+      "sidoName": "경기",
+      "lat": 37.343924,
+      "lng": 126.7308801
+    },
+    {
+      "stationName": "대야동",
+      "sidoName": "경기",
+      "lat": 37.3303161,
+      "lng": 126.9153537
+    },
+    {
+      "stationName": "목감동",
+      "sidoName": "경기",
+      "lat": 37.3820885,
+      "lng": 126.8516086
+    },
+    {
+      "stationName": "장현동",
+      "sidoName": "경기",
+      "lat": 37.3800041,
+      "lng": 126.7992337
+    },
+    {
+      "stationName": "서해안로",
+      "sidoName": "경기",
+      "lat": 37.4638221,
+      "lng": 126.8095091
+    },
+    {
+      "stationName": "배곧동",
+      "sidoName": "경기",
+      "lat": 37.3675747,
+      "lng": 126.7218267
+    },
+    {
+      "stationName": "금곡동",
+      "sidoName": "경기",
+      "lat": 37.63349,
+      "lng": 127.21651
+    },
+    {
+      "stationName": "오남읍",
+      "sidoName": "경기",
+      "lat": 37.6938801,
+      "lng": 127.2230356
+    },
+    {
+      "stationName": "별내동",
+      "sidoName": "경기",
+      "lat": 37.6565148,
+      "lng": 127.1216627
+    },
+    {
+      "stationName": "화도읍",
+      "sidoName": "경기",
+      "lat": 37.6538308,
+      "lng": 127.3196785
+    },
+    {
+      "stationName": "경춘로",
+      "sidoName": "경기",
+      "lat": 37.652725,
+      "lng": 127.2463321
+    },
+    {
+      "stationName": "와부읍",
+      "sidoName": "경기",
+      "lat": 37.5946765,
+      "lng": 127.2374641
+    },
+    {
+      "stationName": "진접읍",
+      "sidoName": "경기",
+      "lat": 37.7228358,
+      "lng": 127.1976354
+    },
+    {
+      "stationName": "비전동",
+      "sidoName": "경기",
+      "lat": 37.0008941,
+      "lng": 127.100778
+    },
+    {
+      "stationName": "안중",
+      "sidoName": "경기",
+      "lat": 36.9719691,
+      "lng": 126.9385092
+    },
+    {
+      "stationName": "평택항",
+      "sidoName": "경기",
+      "lat": 36.9700991,
+      "lng": 126.8474051
+    },
+    {
+      "stationName": "송북동",
+      "sidoName": "경기",
+      "lat": 37.0816418,
+      "lng": 127.0602516
+    },
+    {
+      "stationName": "청북읍",
+      "sidoName": "경기",
+      "lat": 37.0392736,
+      "lng": 126.9330358
+    },
+    {
+      "stationName": "고덕동",
+      "sidoName": "경기",
+      "lat": 37.0480854,
+      "lng": 127.0363555
+    },
+    {
+      "stationName": "금촌동",
+      "sidoName": "경기",
+      "lat": 37.7584627,
+      "lng": 126.7697535
+    },
+    {
+      "stationName": "운정",
+      "sidoName": "경기",
+      "lat": 37.725329,
+      "lng": 126.7670452
+    },
+    {
+      "stationName": "파주",
+      "sidoName": "경기",
+      "lat": 37.8150577,
+      "lng": 126.7924283
+    },
+    {
+      "stationName": "파주읍",
+      "sidoName": "경기",
+      "lat": 37.8306704,
+      "lng": 126.819981
+    },
+    {
+      "stationName": "행신동",
+      "sidoName": "경기",
+      "lat": 37.6194469,
+      "lng": 126.8372169
+    },
+    {
+      "stationName": "식사동",
+      "sidoName": "경기",
+      "lat": 37.6778734,
+      "lng": 126.8133169
+    },
+    {
+      "stationName": "신원동",
+      "sidoName": "경기",
+      "lat": 37.6704756,
+      "lng": 126.8820584
+    },
+    {
+      "stationName": "주엽동",
+      "sidoName": "경기",
+      "lat": 37.6712292,
+      "lng": 126.7618004
+    },
+    {
+      "stationName": "경안동",
+      "sidoName": "경기",
+      "lat": 37.41126,
+      "lng": 127.25393
+    },
+    {
+      "stationName": "오포1동",
+      "sidoName": "경기",
+      "lat": 37.3569168,
+      "lng": 127.2081261
+    },
+    {
+      "stationName": "곤지암",
+      "sidoName": "경기",
+      "lat": 37.3505063,
+      "lng": 127.346279
+    },
+    {
+      "stationName": "김량장동",
+      "sidoName": "경기",
+      "lat": 37.2339949,
+      "lng": 127.2029827
+    },
+    {
+      "stationName": "수지",
+      "sidoName": "경기",
+      "lat": 37.3307192,
+      "lng": 127.0920536
+    },
+    {
+      "stationName": "기흥",
+      "sidoName": "경기",
+      "lat": 37.2755132,
+      "lng": 127.1160129
+    },
+    {
+      "stationName": "중부대로(구갈동)",
+      "sidoName": "경기",
+      "lat": 37.2723009,
+      "lng": 127.1239925
+    },
+    {
+      "stationName": "모현읍",
+      "sidoName": "경기",
+      "lat": 37.3297,
+      "lng": 127.21703
+    },
+    {
+      "stationName": "이동읍",
+      "sidoName": "경기",
+      "lat": 37.141088,
+      "lng": 127.1958565
+    },
+    {
+      "stationName": "백암면",
+      "sidoName": "경기",
+      "lat": 37.1613883,
+      "lng": 127.3742911
+    },
+    {
+      "stationName": "설성면",
+      "sidoName": "경기",
+      "lat": 37.14012,
+      "lng": 127.52471
+    },
+    {
+      "stationName": "창전동",
+      "sidoName": "경기",
+      "lat": 37.2830213,
+      "lng": 127.447383
+    },
+    {
+      "stationName": "장호원읍",
+      "sidoName": "경기",
+      "lat": 37.13181,
+      "lng": 127.59698
+    },
+    {
+      "stationName": "부발읍",
+      "sidoName": "경기",
+      "lat": 37.283401,
+      "lng": 127.4872796
+    },
+    {
+      "stationName": "관인면",
+      "sidoName": "경기",
+      "lat": 38.13706,
+      "lng": 127.23977
+    },
+    {
+      "stationName": "선단동",
+      "sidoName": "경기",
+      "lat": 37.8642666,
+      "lng": 127.1466017
+    },
+    {
+      "stationName": "일동면",
+      "sidoName": "경기",
+      "lat": 37.9599732,
+      "lng": 127.3215602
+    },
+    {
+      "stationName": "사우동",
+      "sidoName": "경기",
+      "lat": 37.6199671,
+      "lng": 126.726365
+    },
+    {
+      "stationName": "고촌읍",
+      "sidoName": "경기",
+      "lat": 37.60599,
+      "lng": 126.76195
+    },
+    {
+      "stationName": "월곶면",
+      "sidoName": "경기",
+      "lat": 37.718175,
+      "lng": 126.5500645
+    },
+    {
+      "stationName": "한강신도시",
+      "sidoName": "경기",
+      "lat": 37.6535413,
+      "lng": 126.6726809
+    },
+    {
+      "stationName": "당동",
+      "sidoName": "경기",
+      "lat": 37.3473986,
+      "lng": 126.9425754
+    },
+    {
+      "stationName": "산본동",
+      "sidoName": "경기",
+      "lat": 37.3704501,
+      "lng": 126.9299906
+    },
+    {
+      "stationName": "오산동",
+      "sidoName": "경기",
+      "lat": 37.14782,
+      "lng": 127.06665
+    },
+    {
+      "stationName": "신장동",
+      "sidoName": "경기",
+      "lat": 37.08163,
+      "lng": 127.04957
+    },
+    {
+      "stationName": "미사",
+      "sidoName": "경기",
+      "lat": 37.5630546,
+      "lng": 127.192822
+    },
+    {
+      "stationName": "감일",
+      "sidoName": "경기",
+      "lat": 37.5000585,
+      "lng": 127.1683507
+    },
+    {
+      "stationName": "남양읍",
+      "sidoName": "경기",
+      "lat": 37.2098661,
+      "lng": 126.821926
+    },
+    {
+      "stationName": "향남읍",
+      "sidoName": "경기",
+      "lat": 37.129402,
+      "lng": 126.9325167
+    },
+    {
+      "stationName": "동탄",
+      "sidoName": "경기",
+      "lat": 37.2003594,
+      "lng": 127.0955764
+    },
+    {
+      "stationName": "우정읍",
+      "sidoName": "경기",
+      "lat": 37.0893354,
+      "lng": 126.8164031
+    },
+    {
+      "stationName": "청계동",
+      "sidoName": "경기",
+      "lat": 37.3843639,
+      "lng": 127.0117299
+    },
+    {
+      "stationName": "새솔동",
+      "sidoName": "경기",
+      "lat": 37.281408,
+      "lng": 126.8189116
+    },
+    {
+      "stationName": "봉담읍",
+      "sidoName": "경기",
+      "lat": 37.19482,
+      "lng": 126.94288
+    },
+    {
+      "stationName": "서신면",
+      "sidoName": "경기",
+      "lat": 37.1690451,
+      "lng": 126.7114352
+    },
+    {
+      "stationName": "중앙동(강원)",
+      "sidoName": "강원",
+      "lat": 37.7529663,
+      "lng": 128.8953507
+    },
+    {
+      "stationName": "문막읍",
+      "sidoName": "강원",
+      "lat": 37.3126434,
+      "lng": 127.8171631
+    },
+    {
+      "stationName": "지정면",
+      "sidoName": "강원",
+      "lat": 37.3654993,
+      "lng": 127.8383792
+    },
+    {
+      "stationName": "주문진읍",
+      "sidoName": "강원",
+      "lat": 37.8953624,
+      "lng": 128.831436
+    },
+    {
+      "stationName": "옥천동",
+      "sidoName": "강원",
+      "lat": 37.7606262,
+      "lng": 128.9035826
+    },
+    {
+      "stationName": "초당동",
+      "sidoName": "강원",
+      "lat": 37.7975733,
+      "lng": 128.9286885
+    },
+    {
+      "stationName": "천곡동",
+      "sidoName": "강원",
+      "lat": 37.5246248,
+      "lng": 129.1168709
+    },
+    {
+      "stationName": "평창읍",
+      "sidoName": "강원",
+      "lat": 37.3687653,
+      "lng": 128.3973536
+    },
+    {
+      "stationName": "북평면",
+      "sidoName": "강원",
+      "lat": 37.4605156,
+      "lng": 128.652297
+    },
+    {
+      "stationName": "정선읍",
+      "sidoName": "강원",
+      "lat": 37.3796216,
+      "lng": 128.6618047
+    },
+    {
+      "stationName": "간성읍",
+      "sidoName": "강원",
+      "lat": 38.3783535,
+      "lng": 128.4671265
+    },
+    {
+      "stationName": "치악산",
+      "sidoName": "강원",
+      "lat": 37.3651455,
+      "lng": 128.0556322
+    },
+    {
+      "stationName": "횡성읍",
+      "sidoName": "강원",
+      "lat": 37.492267,
+      "lng": 127.9926086
+    },
+    {
+      "stationName": "상리",
+      "sidoName": "강원",
+      "lat": 38.1132324,
+      "lng": 127.6914108
+    },
+    {
+      "stationName": "양양읍",
+      "sidoName": "강원",
+      "lat": 38.0805652,
+      "lng": 128.6240684
+    },
+    {
+      "stationName": "금호동",
+      "sidoName": "강원",
+      "lat": 38.21071,
+      "lng": 128.57933
+    },
+    {
+      "stationName": "갈말읍",
+      "sidoName": "강원",
+      "lat": 38.1455055,
+      "lng": 127.3082796
+    },
+    {
+      "stationName": "홍천읍",
+      "sidoName": "강원",
+      "lat": 37.6894014,
+      "lng": 127.8843043
+    },
+    {
+      "stationName": "영월읍",
+      "sidoName": "강원",
+      "lat": 37.1872797,
+      "lng": 128.465992
+    },
+    {
+      "stationName": "화천읍",
+      "sidoName": "강원",
+      "lat": 38.1042329,
+      "lng": 127.7073657
+    },
+    {
+      "stationName": "황지동",
+      "sidoName": "강원",
+      "lat": 37.1649855,
+      "lng": 128.9854495
+    },
+    {
+      "stationName": "인제읍",
+      "sidoName": "강원",
+      "lat": 38.070295,
+      "lng": 128.1723584
+    },
+    {
+      "stationName": "우천면",
+      "sidoName": "강원",
+      "lat": 37.47065,
+      "lng": 128.07702
+    },
+    {
+      "stationName": "중앙로",
+      "sidoName": "강원",
+      "lat": 37.8798707,
+      "lng": 127.7270908
+    },
+    {
+      "stationName": "퇴계동",
+      "sidoName": "강원",
+      "lat": 37.8548266,
+      "lng": 127.7287788
+    },
+    {
+      "stationName": "신사우동",
+      "sidoName": "강원",
+      "lat": 37.9201405,
+      "lng": 127.7298428
+    },
+    {
+      "stationName": "온의동",
+      "sidoName": "강원",
+      "lat": 37.8596868,
+      "lng": 127.7166353
+    },
+    {
+      "stationName": "방산면",
+      "sidoName": "강원",
+      "lat": 38.2239197,
+      "lng": 127.9497885
+    },
+    {
+      "stationName": "양구읍",
+      "sidoName": "강원",
+      "lat": 38.1079916,
+      "lng": 127.9904953
+    },
+    {
+      "stationName": "동해항",
+      "sidoName": "강원",
+      "lat": 37.4890308,
+      "lng": 129.1246058
+    },
+    {
+      "stationName": "묵호항",
+      "sidoName": "강원",
+      "lat": 37.539852,
+      "lng": 129.112032
+    },
+    {
+      "stationName": "삼척항",
+      "sidoName": "강원",
+      "lat": 37.4358828,
+      "lng": 129.1917402
+    },
+    {
+      "stationName": "봉명동",
+      "sidoName": "충북",
+      "lat": 36.6471584,
+      "lng": 127.4585429
+    },
+    {
+      "stationName": "사천동",
+      "sidoName": "충북",
+      "lat": 36.6707518,
+      "lng": 127.4735432
+    },
+    {
+      "stationName": "용담동",
+      "sidoName": "충북",
+      "lat": 36.6366461,
+      "lng": 127.5078315
+    },
+    {
+      "stationName": "용암동",
+      "sidoName": "충북",
+      "lat": 36.6139324,
+      "lng": 127.5127559
+    },
+    {
+      "stationName": "복대동",
+      "sidoName": "충북",
+      "lat": 36.6360473,
+      "lng": 127.4405923
+    },
+    {
+      "stationName": "호암동",
+      "sidoName": "충북",
+      "lat": 36.9515835,
+      "lng": 127.9320309
+    },
+    {
+      "stationName": "칠금동",
+      "sidoName": "충북",
+      "lat": 36.9841724,
+      "lng": 127.9119085
+    },
+    {
+      "stationName": "중앙탑면",
+      "sidoName": "충북",
+      "lat": 37.0319399,
+      "lng": 127.8531312
+    },
+    {
+      "stationName": "살미면",
+      "sidoName": "충북",
+      "lat": 36.9115864,
+      "lng": 127.9931536
+    },
+    {
+      "stationName": "장락동",
+      "sidoName": "충북",
+      "lat": 37.1509037,
+      "lng": 128.2265529
+    },
+    {
+      "stationName": "영천동",
+      "sidoName": "충북",
+      "lat": 37.1275137,
+      "lng": 128.2029241
+    },
+    {
+      "stationName": "청풍면",
+      "sidoName": "충북",
+      "lat": 37.00768,
+      "lng": 128.13983
+    },
+    {
+      "stationName": "송학면",
+      "sidoName": "충북",
+      "lat": 37.1999015,
+      "lng": 128.255838
+    },
+    {
+      "stationName": "오창읍",
+      "sidoName": "충북",
+      "lat": 36.7314494,
+      "lng": 127.4354605
+    },
+    {
+      "stationName": "산남동",
+      "sidoName": "충북",
+      "lat": 36.613772,
+      "lng": 127.468107
+    },
+    {
+      "stationName": "오송읍",
+      "sidoName": "충북",
+      "lat": 36.62874,
+      "lng": 127.32436
+    },
+    {
+      "stationName": "가덕면",
+      "sidoName": "충북",
+      "lat": 36.5578847,
+      "lng": 127.5611382
+    },
+    {
+      "stationName": "매포읍",
+      "sidoName": "충북",
+      "lat": 37.0466958,
+      "lng": 128.2979531
+    },
+    {
+      "stationName": "단성면",
+      "sidoName": "충북",
+      "lat": 36.9369817,
+      "lng": 128.3236696
+    },
+    {
+      "stationName": "단양읍",
+      "sidoName": "충북",
+      "lat": 36.9864257,
+      "lng": 128.3682432
+    },
+    {
+      "stationName": "청천면",
+      "sidoName": "충북",
+      "lat": 36.684251,
+      "lng": 127.8077291
+    },
+    {
+      "stationName": "괴산읍",
+      "sidoName": "충북",
+      "lat": 36.8128301,
+      "lng": 127.7978613
+    },
+    {
+      "stationName": "감물면",
+      "sidoName": "충북",
+      "lat": 36.8424379,
+      "lng": 127.876388
+    },
+    {
+      "stationName": "진천읍",
+      "sidoName": "충북",
+      "lat": 36.8548027,
+      "lng": 127.4414303
+    },
+    {
+      "stationName": "덕산읍",
+      "sidoName": "충북",
+      "lat": 36.8968631,
+      "lng": 127.5060402
+    },
+    {
+      "stationName": "금왕",
+      "sidoName": "충북",
+      "lat": 36.9862352,
+      "lng": 127.5716381
+    },
+    {
+      "stationName": "음성읍",
+      "sidoName": "충북",
+      "lat": 36.9306754,
+      "lng": 127.6796887
+    },
+    {
+      "stationName": "소이면",
+      "sidoName": "충북",
+      "lat": 36.9103281,
+      "lng": 127.7551869
+    },
+    {
+      "stationName": "영동읍",
+      "sidoName": "충북",
+      "lat": 36.1710097,
+      "lng": 127.7757737
+    },
+    {
+      "stationName": "황간면",
+      "sidoName": "충북",
+      "lat": 36.236126,
+      "lng": 127.897015
+    },
+    {
+      "stationName": "도안면",
+      "sidoName": "충북",
+      "lat": 36.8265842,
+      "lng": 127.6127442
+    },
+    {
+      "stationName": "증평읍",
+      "sidoName": "충북",
+      "lat": 36.7850497,
+      "lng": 127.5812194
+    },
+    {
+      "stationName": "보은읍",
+      "sidoName": "충북",
+      "lat": 36.4833355,
+      "lng": 127.7170924
+    },
+    {
+      "stationName": "옥천읍",
+      "sidoName": "충북",
+      "lat": 36.3070087,
+      "lng": 127.5747772
+    },
+    {
+      "stationName": "성황동",
+      "sidoName": "충남",
+      "lat": 36.8138633,
+      "lng": 127.1533872
+    },
+    {
+      "stationName": "백석동",
+      "sidoName": "충남",
+      "lat": 36.8242631,
+      "lng": 127.1178826
+    },
+    {
+      "stationName": "모종동",
+      "sidoName": "충남",
+      "lat": 36.7848603,
+      "lng": 127.0203644
+    },
+    {
+      "stationName": "배방읍",
+      "sidoName": "충남",
+      "lat": 36.76563,
+      "lng": 127.0662549
+    },
+    {
+      "stationName": "도고면",
+      "sidoName": "충남",
+      "lat": 36.7573924,
+      "lng": 126.8895814
+    },
+    {
+      "stationName": "둔포면",
+      "sidoName": "충남",
+      "lat": 36.9158923,
+      "lng": 127.0383651
+    },
+    {
+      "stationName": "인주면",
+      "sidoName": "충남",
+      "lat": 36.8637,
+      "lng": 126.89235
+    },
+    {
+      "stationName": "장재리",
+      "sidoName": "충남",
+      "lat": 36.7918624,
+      "lng": 127.1002598
+    },
+    {
+      "stationName": "송악면",
+      "sidoName": "충남",
+      "lat": 36.7305737,
+      "lng": 127.0097967
+    },
+    {
+      "stationName": "논산",
+      "sidoName": "충남",
+      "lat": 36.2069077,
+      "lng": 127.0928492
+    },
+    {
+      "stationName": "연무읍",
+      "sidoName": "충남",
+      "lat": 36.116767,
+      "lng": 127.0971567
+    },
+    {
+      "stationName": "성동면",
+      "sidoName": "충남",
+      "lat": 36.2037619,
+      "lng": 127.033264
+    },
+    {
+      "stationName": "파도리",
+      "sidoName": "충남",
+      "lat": 36.7379188,
+      "lng": 126.1385559
+    },
+    {
+      "stationName": "이원면",
+      "sidoName": "충남",
+      "lat": 36.88365,
+      "lng": 126.28795
+    },
+    {
+      "stationName": "태안읍",
+      "sidoName": "충남",
+      "lat": 36.757905,
+      "lng": 126.2965246
+    },
+    {
+      "stationName": "격렬비열도",
+      "sidoName": "충남",
+      "lat": 36.6172206,
+      "lng": 125.5744342
+    },
+    {
+      "stationName": "원북면",
+      "sidoName": "충남",
+      "lat": 36.8263,
+      "lng": 126.23819
+    },
+    {
+      "stationName": "예산군",
+      "sidoName": "충남",
+      "lat": 36.6808989,
+      "lng": 126.8448742
+    },
+    {
+      "stationName": "삽교읍",
+      "sidoName": "충남",
+      "lat": 36.687991,
+      "lng": 126.7393728
+    },
+    {
+      "stationName": "고덕면(충남)",
+      "sidoName": "충남",
+      "lat": 36.75549,
+      "lng": 126.72461
+    },
+    {
+      "stationName": "대천2동",
+      "sidoName": "충남",
+      "lat": 36.3533976,
+      "lng": 126.5897679
+    },
+    {
+      "stationName": "주교면",
+      "sidoName": "충남",
+      "lat": 36.38281,
+      "lng": 126.54718
+    },
+    {
+      "stationName": "외연도",
+      "sidoName": "충남",
+      "lat": 36.2285007,
+      "lng": 126.0851571
+    },
+    {
+      "stationName": "홍성읍",
+      "sidoName": "충남",
+      "lat": 36.5969032,
+      "lng": 126.6629617
+    },
+    {
+      "stationName": "내포",
+      "sidoName": "충남",
+      "lat": 36.6867805,
+      "lng": 126.7221982
+    },
+    {
+      "stationName": "금산읍",
+      "sidoName": "충남",
+      "lat": 36.1071141,
+      "lng": 127.490569
+    },
+    {
+      "stationName": "청양읍",
+      "sidoName": "충남",
+      "lat": 36.4531893,
+      "lng": 126.8067285
+    },
+    {
+      "stationName": "정산면",
+      "sidoName": "충남",
+      "lat": 36.4190556,
+      "lng": 126.9429941
+    },
+    {
+      "stationName": "엄사면",
+      "sidoName": "충남",
+      "lat": 36.2811419,
+      "lng": 127.2257159
+    },
+    {
+      "stationName": "대산항",
+      "sidoName": "충남",
+      "lat": 37.0131322,
+      "lng": 126.4243191
+    },
+    {
+      "stationName": "장항항",
+      "sidoName": "충남",
+      "lat": 36.0077641,
+      "lng": 126.6858027
+    },
+    {
+      "stationName": "서천읍",
+      "sidoName": "충남",
+      "lat": 36.0777327,
+      "lng": 126.6897534
+    },
+    {
+      "stationName": "서면",
+      "sidoName": "충남",
+      "lat": 36.1563227,
+      "lng": 126.5558596
+    },
+    {
+      "stationName": "장항읍",
+      "sidoName": "충남",
+      "lat": 36.0240164,
+      "lng": 126.6915659
+    },
+    {
+      "stationName": "성성동",
+      "sidoName": "충남",
+      "lat": 36.8417281,
+      "lng": 127.1307614
+    },
+    {
+      "stationName": "성거읍",
+      "sidoName": "충남",
+      "lat": 36.8780677,
+      "lng": 127.197568
+    },
+    {
+      "stationName": "신방동",
+      "sidoName": "충남",
+      "lat": 36.7840779,
+      "lng": 127.1253344
+    },
+    {
+      "stationName": "수신면",
+      "sidoName": "충남",
+      "lat": 36.72564,
+      "lng": 127.28376
+    },
+    {
+      "stationName": "사곡면",
+      "sidoName": "충남",
+      "lat": 36.5359891,
+      "lng": 127.0324459
+    },
+    {
+      "stationName": "공주",
+      "sidoName": "충남",
+      "lat": 36.3322371,
+      "lng": 127.0966368
+    },
+    {
+      "stationName": "탄천면",
+      "sidoName": "충남",
+      "lat": 36.3190188,
+      "lng": 127.0303035
+    },
+    {
+      "stationName": "부여읍",
+      "sidoName": "충남",
+      "lat": 36.2756729,
+      "lng": 126.9110693
+    },
+    {
+      "stationName": "독곶리",
+      "sidoName": "충남",
+      "lat": 36.9891273,
+      "lng": 126.371338
+    },
+    {
+      "stationName": "동문동",
+      "sidoName": "충남",
+      "lat": 36.7861432,
+      "lng": 126.4589307
+    },
+    {
+      "stationName": "대산리",
+      "sidoName": "충남",
+      "lat": 36.6185463,
+      "lng": 127.1026016
+    },
+    {
+      "stationName": "성연면",
+      "sidoName": "충남",
+      "lat": 36.83493,
+      "lng": 126.46189
+    },
+    {
+      "stationName": "송산면",
+      "sidoName": "충남",
+      "lat": 36.9430325,
+      "lng": 126.6782302
+    },
+    {
+      "stationName": "합덕읍",
+      "sidoName": "충남",
+      "lat": 36.7977632,
+      "lng": 126.7692259
+    },
+    {
+      "stationName": "복운리",
+      "sidoName": "충남",
+      "lat": 36.9341327,
+      "lng": 126.7761355
+    },
+    {
+      "stationName": "노송동",
+      "sidoName": "전북",
+      "lat": 35.8244307,
+      "lng": 127.1583728
+    },
+    {
+      "stationName": "군산항",
+      "sidoName": "전북",
+      "lat": 35.9719471,
+      "lng": 126.5597569
+    },
+    {
+      "stationName": "삼천동",
+      "sidoName": "전북",
+      "lat": 35.7917789,
+      "lng": 127.1173802
+    },
+    {
+      "stationName": "팔복동",
+      "sidoName": "전북",
+      "lat": 35.8536596,
+      "lng": 127.1062727
+    },
+    {
+      "stationName": "송천동",
+      "sidoName": "전북",
+      "lat": 35.8671684,
+      "lng": 127.1132245
+    },
+    {
+      "stationName": "서신동",
+      "sidoName": "전북",
+      "lat": 35.8338729,
+      "lng": 127.1150449
+    },
+    {
+      "stationName": "혁신동",
+      "sidoName": "전북",
+      "lat": 35.8376191,
+      "lng": 127.0613158
+    },
+    {
+      "stationName": "여의동",
+      "sidoName": "전북",
+      "lat": 35.8603478,
+      "lng": 127.0739209
+    },
+    {
+      "stationName": "효자동",
+      "sidoName": "전북",
+      "lat": 35.80455,
+      "lng": 127.1122589
+    },
+    {
+      "stationName": "신풍동(군산)",
+      "sidoName": "전북",
+      "lat": 35.9799905,
+      "lng": 126.7034977
+    },
+    {
+      "stationName": "소룡동",
+      "sidoName": "전북",
+      "lat": 35.9751154,
+      "lng": 126.6819351
+    },
+    {
+      "stationName": "사정동",
+      "sidoName": "전북",
+      "lat": 35.9614354,
+      "lng": 126.7502766
+    },
+    {
+      "stationName": "옥산면",
+      "sidoName": "전북",
+      "lat": 35.9418228,
+      "lng": 126.7481306
+    },
+    {
+      "stationName": "비응도동",
+      "sidoName": "전북",
+      "lat": 35.940018,
+      "lng": 126.5314323
+    },
+    {
+      "stationName": "말도",
+      "sidoName": "전북",
+      "lat": 35.855591,
+      "lng": 126.3227167
+    },
+    {
+      "stationName": "삼기면",
+      "sidoName": "전북",
+      "lat": 36.0200398,
+      "lng": 126.9912718
+    },
+    {
+      "stationName": "팔봉동",
+      "sidoName": "전북",
+      "lat": 35.9604508,
+      "lng": 127.011535
+    },
+    {
+      "stationName": "모현동",
+      "sidoName": "전북",
+      "lat": 35.9481772,
+      "lng": 126.9454257
+    },
+    {
+      "stationName": "용동면",
+      "sidoName": "전북",
+      "lat": 36.1056188,
+      "lng": 126.997189
+    },
+    {
+      "stationName": "함열읍",
+      "sidoName": "전북",
+      "lat": 36.0620914,
+      "lng": 126.9638923
+    },
+    {
+      "stationName": "춘포면",
+      "sidoName": "전북",
+      "lat": 35.927274,
+      "lng": 127.023882
+    },
+    {
+      "stationName": "여산면",
+      "sidoName": "전북",
+      "lat": 36.0475896,
+      "lng": 127.0908811
+    },
+    {
+      "stationName": "금마면",
+      "sidoName": "전북",
+      "lat": 36.0065883,
+      "lng": 127.0392656
+    },
+    {
+      "stationName": "연지동",
+      "sidoName": "전북",
+      "lat": 35.5719552,
+      "lng": 126.8441176
+    },
+    {
+      "stationName": "신태인",
+      "sidoName": "전북",
+      "lat": 35.6877264,
+      "lng": 126.8841325
+    },
+    {
+      "stationName": "영파동",
+      "sidoName": "전북",
+      "lat": 35.6081431,
+      "lng": 126.8516984
+    },
+    {
+      "stationName": "죽항동",
+      "sidoName": "전북",
+      "lat": 35.4084484,
+      "lng": 127.3889864
+    },
+    {
+      "stationName": "운봉읍",
+      "sidoName": "전북",
+      "lat": 35.437098,
+      "lng": 127.5328914
+    },
+    {
+      "stationName": "고창읍",
+      "sidoName": "전북",
+      "lat": 35.4315147,
+      "lng": 126.6972448
+    },
+    {
+      "stationName": "심원면",
+      "sidoName": "전북",
+      "lat": 35.51498,
+      "lng": 126.54444
+    },
+    {
+      "stationName": "부안읍",
+      "sidoName": "전북",
+      "lat": 35.7264518,
+      "lng": 126.7322134
+    },
+    {
+      "stationName": "새만금",
+      "sidoName": "전북",
+      "lat": 35.8531387,
+      "lng": 126.7059728
+    },
+    {
+      "stationName": "계화면",
+      "sidoName": "전북",
+      "lat": 35.7617797,
+      "lng": 126.6982798
+    },
+    {
+      "stationName": "요촌동",
+      "sidoName": "전북",
+      "lat": 35.8032071,
+      "lng": 126.8889287
+    },
+    {
+      "stationName": "광활면",
+      "sidoName": "전북",
+      "lat": 35.8333369,
+      "lng": 126.7412548
+    },
+    {
+      "stationName": "고산면",
+      "sidoName": "전북",
+      "lat": 35.9727722,
+      "lng": 127.2281284
+    },
+    {
+      "stationName": "봉동읍",
+      "sidoName": "전북",
+      "lat": 35.9508612,
+      "lng": 127.1440026
+    },
+    {
+      "stationName": "구이면",
+      "sidoName": "전북",
+      "lat": 35.71526,
+      "lng": 127.12113
+    },
+    {
+      "stationName": "진안읍",
+      "sidoName": "전북",
+      "lat": 35.77698,
+      "lng": 127.44458
+    },
+    {
+      "stationName": "운암면",
+      "sidoName": "전북",
+      "lat": 35.61409,
+      "lng": 127.14761
+    },
+    {
+      "stationName": "임실읍",
+      "sidoName": "전북",
+      "lat": 35.6078976,
+      "lng": 127.2828102
+    },
+    {
+      "stationName": "관촌면",
+      "sidoName": "전북",
+      "lat": 35.68868,
+      "lng": 127.28206
+    },
+    {
+      "stationName": "무주읍",
+      "sidoName": "전북",
+      "lat": 36.0121049,
+      "lng": 127.6692373
+    },
+    {
+      "stationName": "안성면",
+      "sidoName": "전북",
+      "lat": 35.85238,
+      "lng": 127.67152
+    },
+    {
+      "stationName": "순창읍",
+      "sidoName": "전북",
+      "lat": 35.37085,
+      "lng": 127.1378
+    },
+    {
+      "stationName": "장수읍",
+      "sidoName": "전북",
+      "lat": 35.62911,
+      "lng": 127.51364
+    },
+    {
+      "stationName": "장계면",
+      "sidoName": "전북",
+      "lat": 35.73123,
+      "lng": 127.60322
+    },
+    {
+      "stationName": "송단리",
+      "sidoName": "전남",
+      "lat": 35.18288,
+      "lng": 127.17394
+    },
+    {
+      "stationName": "화순읍",
+      "sidoName": "전남",
+      "lat": 35.05945,
+      "lng": 126.97312
+    },
+    {
+      "stationName": "영광읍",
+      "sidoName": "전남",
+      "lat": 35.2764376,
+      "lng": 126.5100626
+    },
+    {
+      "stationName": "안마도",
+      "sidoName": "전남",
+      "lat": 35.347871,
+      "lng": 126.0292628
+    },
+    {
+      "stationName": "장흥읍",
+      "sidoName": "전남",
+      "lat": 34.6791016,
+      "lng": 126.9031578
+    },
+    {
+      "stationName": "진도읍",
+      "sidoName": "전남",
+      "lat": 34.4826255,
+      "lng": 126.2649899
+    },
+    {
+      "stationName": "신지면",
+      "sidoName": "전남",
+      "lat": 34.33436,
+      "lng": 126.84281
+    },
+    {
+      "stationName": "함평읍",
+      "sidoName": "전남",
+      "lat": 35.06643,
+      "lng": 126.49242
+    },
+    {
+      "stationName": "고흥읍",
+      "sidoName": "전남",
+      "lat": 34.60741,
+      "lng": 127.27048
+    },
+    {
+      "stationName": "신안군",
+      "sidoName": "전남",
+      "lat": 34.8331095,
+      "lng": 126.3522531
+    },
+    {
+      "stationName": "홍도",
+      "sidoName": "전남",
+      "lat": 34.6913934,
+      "lng": 125.2003143
+    },
+    {
+      "stationName": "가거도",
+      "sidoName": "전남",
+      "lat": 34.0719678,
+      "lng": 125.1071352
+    },
+    {
+      "stationName": "무안읍",
+      "sidoName": "전남",
+      "lat": 34.99148,
+      "lng": 126.47
+    },
+    {
+      "stationName": "강진읍",
+      "sidoName": "전남",
+      "lat": 34.63266,
+      "lng": 126.75378
+    },
+    {
+      "stationName": "곡성읍",
+      "sidoName": "전남",
+      "lat": 35.28015,
+      "lng": 127.28443
+    },
+    {
+      "stationName": "구례읍",
+      "sidoName": "전남",
+      "lat": 35.2085428,
+      "lng": 127.4633373
+    },
+    {
+      "stationName": "벌교읍",
+      "sidoName": "전남",
+      "lat": 34.84372,
+      "lng": 127.33979
+    },
+    {
+      "stationName": "보성읍",
+      "sidoName": "전남",
+      "lat": 34.7686929,
+      "lng": 127.07984
+    },
+    {
+      "stationName": "목포항",
+      "sidoName": "전남",
+      "lat": 34.8029157,
+      "lng": 126.3571611
+    },
+    {
+      "stationName": "광양항",
+      "sidoName": "전남",
+      "lat": 34.9230008,
+      "lng": 127.6857364
+    },
+    {
+      "stationName": "여수항",
+      "sidoName": "전남",
+      "lat": 34.7391461,
+      "lng": 127.7511844
+    },
+    {
+      "stationName": "광양 중마",
+      "sidoName": "전남",
+      "lat": 34.9360093,
+      "lng": 127.6994814
+    },
+    {
+      "stationName": "용당동",
+      "sidoName": "전남",
+      "lat": 34.972136,
+      "lng": 127.4972758
+    },
+    {
+      "stationName": "부흥동",
+      "sidoName": "전남",
+      "lat": 34.8042975,
+      "lng": 126.4345396
+    },
+    {
+      "stationName": "서강동",
+      "sidoName": "전남",
+      "lat": 34.7411506,
+      "lng": 127.7258884
+    },
+    {
+      "stationName": "월내동",
+      "sidoName": "전남",
+      "lat": 34.8481132,
+      "lng": 127.7281086
+    },
+    {
+      "stationName": "여천동(여수)",
+      "sidoName": "전남",
+      "lat": 34.7769625,
+      "lng": 127.6675869
+    },
+    {
+      "stationName": "덕충동",
+      "sidoName": "전남",
+      "lat": 34.7572654,
+      "lng": 127.742328
+    },
+    {
+      "stationName": "장천동",
+      "sidoName": "전남",
+      "lat": 34.9495792,
+      "lng": 127.4893804
+    },
+    {
+      "stationName": "연향동",
+      "sidoName": "전남",
+      "lat": 34.9420457,
+      "lng": 127.5216039
+    },
+    {
+      "stationName": "순천만",
+      "sidoName": "전남",
+      "lat": 34.8773032,
+      "lng": 127.5162133
+    },
+    {
+      "stationName": "호두리",
+      "sidoName": "전남",
+      "lat": 34.8958,
+      "lng": 127.57048
+    },
+    {
+      "stationName": "신대",
+      "sidoName": "전남",
+      "lat": 34.9335823,
+      "lng": 127.5601744
+    },
+    {
+      "stationName": "빛가람동",
+      "sidoName": "전남",
+      "lat": 35.0199894,
+      "lng": 126.7894723
+    },
+    {
+      "stationName": "담양읍",
+      "sidoName": "전남",
+      "lat": 35.31819,
+      "lng": 126.98236
+    },
+    {
+      "stationName": "장성읍",
+      "sidoName": "전남",
+      "lat": 35.33415,
+      "lng": 126.81244
+    },
+    {
+      "stationName": "화양면",
+      "sidoName": "전남",
+      "lat": 34.69456,
+      "lng": 127.59725
+    },
+    {
+      "stationName": "율촌면",
+      "sidoName": "전남",
+      "lat": 34.84934,
+      "lng": 127.57213
+    },
+    {
+      "stationName": "삼일동",
+      "sidoName": "전남",
+      "lat": 34.8240093,
+      "lng": 127.712727
+    },
+    {
+      "stationName": "중동",
+      "sidoName": "전남",
+      "lat": 34.9379939,
+      "lng": 127.6923994
+    },
+    {
+      "stationName": "태인동",
+      "sidoName": "전남",
+      "lat": 34.9447526,
+      "lng": 127.7558823
+    },
+    {
+      "stationName": "광양읍",
+      "sidoName": "전남",
+      "lat": 34.9732493,
+      "lng": 127.5810068
+    },
+    {
+      "stationName": "봉강면",
+      "sidoName": "전남",
+      "lat": 35.02673,
+      "lng": 127.57056
+    },
+    {
+      "stationName": "진월면",
+      "sidoName": "전남",
+      "lat": 35.0009,
+      "lng": 127.75334
+    },
+    {
+      "stationName": "해남읍",
+      "sidoName": "전남",
+      "lat": 34.5721308,
+      "lng": 126.5984155
+    },
+    {
+      "stationName": "대불",
+      "sidoName": "전남",
+      "lat": 34.7736968,
+      "lng": 126.4188335
+    },
+    {
+      "stationName": "영암읍",
+      "sidoName": "전남",
+      "lat": 34.79441,
+      "lng": 126.71277
+    },
+    {
+      "stationName": "우현동",
+      "sidoName": "경북",
+      "lat": 36.05889,
+      "lng": 129.35545
+    },
+    {
+      "stationName": "장흥동",
+      "sidoName": "경북",
+      "lat": 35.98134,
+      "lng": 129.37512
+    },
+    {
+      "stationName": "장량동",
+      "sidoName": "경북",
+      "lat": 36.0811357,
+      "lng": 129.3847334
+    },
+    {
+      "stationName": "대도동",
+      "sidoName": "경북",
+      "lat": 36.0167,
+      "lng": 129.36265
+    },
+    {
+      "stationName": "대송면",
+      "sidoName": "경북",
+      "lat": 35.9681745,
+      "lng": 129.3627856
+    },
+    {
+      "stationName": "3공단",
+      "sidoName": "경북",
+      "lat": 36.1082444,
+      "lng": 128.4022931
+    },
+    {
+      "stationName": "송도동",
+      "sidoName": "경북",
+      "lat": 36.03623,
+      "lng": 129.37521
+    },
+    {
+      "stationName": "오천읍",
+      "sidoName": "경북",
+      "lat": 35.9631562,
+      "lng": 129.4147285
+    },
+    {
+      "stationName": "청림동",
+      "sidoName": "경북",
+      "lat": 36.00265,
+      "lng": 129.41235
+    },
+    {
+      "stationName": "연일읍",
+      "sidoName": "경북",
+      "lat": 35.9916279,
+      "lng": 129.3441331
+    },
+    {
+      "stationName": "제철동",
+      "sidoName": "경북",
+      "lat": 36.0064836,
+      "lng": 129.3885036
+    },
+    {
+      "stationName": "성건동",
+      "sidoName": "경북",
+      "lat": 35.8557092,
+      "lng": 129.1936629
+    },
+    {
+      "stationName": "보덕동",
+      "sidoName": "경북",
+      "lat": 35.8490481,
+      "lng": 129.3167056
+    },
+    {
+      "stationName": "안강읍",
+      "sidoName": "경북",
+      "lat": 35.9910535,
+      "lng": 129.2205418
+    },
+    {
+      "stationName": "외동읍",
+      "sidoName": "경북",
+      "lat": 35.7123241,
+      "lng": 129.3248572
+    },
+    {
+      "stationName": "양덕동",
+      "sidoName": "경북",
+      "lat": 36.0867807,
+      "lng": 129.3987415
+    },
+    {
+      "stationName": "평화남산동",
+      "sidoName": "경북",
+      "lat": 36.1205964,
+      "lng": 128.1161363
+    },
+    {
+      "stationName": "대광동",
+      "sidoName": "경북",
+      "lat": 36.1455382,
+      "lng": 128.1428019
+    },
+    {
+      "stationName": "율곡동",
+      "sidoName": "경북",
+      "lat": 36.1244755,
+      "lng": 128.1862108
+    },
+    {
+      "stationName": "명륜동",
+      "sidoName": "경북",
+      "lat": 36.57282,
+      "lng": 128.73457
+    },
+    {
+      "stationName": "공단동",
+      "sidoName": "경북",
+      "lat": 36.09788,
+      "lng": 128.38148
+    },
+    {
+      "stationName": "원평동",
+      "sidoName": "경북",
+      "lat": 36.12686,
+      "lng": 128.34196
+    },
+    {
+      "stationName": "형곡동",
+      "sidoName": "경북",
+      "lat": 36.10584,
+      "lng": 128.33474
+    },
+    {
+      "stationName": "4공단",
+      "sidoName": "경북",
+      "lat": 36.1418503,
+      "lng": 128.4463936
+    },
+    {
+      "stationName": "진미동",
+      "sidoName": "경북",
+      "lat": 36.1060429,
+      "lng": 128.4187493
+    },
+    {
+      "stationName": "가흥동",
+      "sidoName": "경북",
+      "lat": 36.82641,
+      "lng": 128.59634
+    },
+    {
+      "stationName": "영주동",
+      "sidoName": "경북",
+      "lat": 36.82851,
+      "lng": 128.62089
+    },
+    {
+      "stationName": "중방동",
+      "sidoName": "경북",
+      "lat": 35.8293127,
+      "lng": 128.7348543
+    },
+    {
+      "stationName": "하양읍",
+      "sidoName": "경북",
+      "lat": 35.9166162,
+      "lng": 128.8066711
+    },
+    {
+      "stationName": "진량읍",
+      "sidoName": "경북",
+      "lat": 35.87092,
+      "lng": 128.83302
+    },
+    {
+      "stationName": "상주시",
+      "sidoName": "경북",
+      "lat": 36.4104478,
+      "lng": 128.1590614
+    },
+    {
+      "stationName": "칠곡군",
+      "sidoName": "경북",
+      "lat": 35.995,
+      "lng": 128.4017
+    },
+    {
+      "stationName": "영덕읍",
+      "sidoName": "경북",
+      "lat": 36.42963,
+      "lng": 129.39175
+    },
+    {
+      "stationName": "강구면",
+      "sidoName": "경북",
+      "lat": 36.37562,
+      "lng": 129.37399
+    },
+    {
+      "stationName": "영해면",
+      "sidoName": "경북",
+      "lat": 36.53718,
+      "lng": 129.38777
+    },
+    {
+      "stationName": "문경시",
+      "sidoName": "경북",
+      "lat": 36.5858541,
+      "lng": 128.1870612
+    },
+    {
+      "stationName": "성주군",
+      "sidoName": "경북",
+      "lat": 35.9190065,
+      "lng": 128.283486
+    },
+    {
+      "stationName": "화북면",
+      "sidoName": "경북",
+      "lat": 36.13107,
+      "lng": 128.93835
+    },
+    {
+      "stationName": "영천시",
+      "sidoName": "경북",
+      "lat": 35.98842,
+      "lng": 128.942
+    },
+    {
+      "stationName": "의성읍",
+      "sidoName": "경북",
+      "lat": 36.34389,
+      "lng": 128.70155
+    },
+    {
+      "stationName": "안계면",
+      "sidoName": "경북",
+      "lat": 36.39097,
+      "lng": 128.46185
+    },
+    {
+      "stationName": "울진군",
+      "sidoName": "경북",
+      "lat": 36.993,
+      "lng": 129.4006
+    },
+    {
+      "stationName": "석포면",
+      "sidoName": "경북",
+      "lat": 37.04191,
+      "lng": 129.05038
+    },
+    {
+      "stationName": "봉화군청",
+      "sidoName": "경북",
+      "lat": 36.8931284,
+      "lng": 128.732492
+    },
+    {
+      "stationName": "태하리",
+      "sidoName": "경북",
+      "lat": 37.5066649,
+      "lng": 130.8234273
+    },
+    {
+      "stationName": "울릉읍",
+      "sidoName": "경북",
+      "lat": 37.4848739,
+      "lng": 130.9036484
+    },
+    {
+      "stationName": "대가야읍",
+      "sidoName": "경북",
+      "lat": 35.73209,
+      "lng": 128.25741
+    },
+    {
+      "stationName": "영양군",
+      "sidoName": "경북",
+      "lat": 36.666404,
+      "lng": 129.1127454
+    },
+    {
+      "stationName": "예천군",
+      "sidoName": "경북",
+      "lat": 36.6462999,
+      "lng": 128.4376
+    },
+    {
+      "stationName": "화양읍",
+      "sidoName": "경북",
+      "lat": 35.66089,
+      "lng": 128.71693
+    },
+    {
+      "stationName": "청송읍",
+      "sidoName": "경북",
+      "lat": 36.41994,
+      "lng": 129.09199
+    },
+    {
+      "stationName": "경화동",
+      "sidoName": "경남",
+      "lat": 35.15998,
+      "lng": 128.69073
+    },
+    {
+      "stationName": "월영동",
+      "sidoName": "경남",
+      "lat": 35.17524,
+      "lng": 128.5572
+    },
+    {
+      "stationName": "하동읍",
+      "sidoName": "경남",
+      "lat": 35.0762976,
+      "lng": 127.7456884
+    },
+    {
+      "stationName": "금성면",
+      "sidoName": "경남",
+      "lat": 34.96354,
+      "lng": 127.79293
+    },
+    {
+      "stationName": "동상동",
+      "sidoName": "경남",
+      "lat": 35.2432584,
+      "lng": 128.8869575
+    },
+    {
+      "stationName": "삼방동",
+      "sidoName": "경남",
+      "lat": 35.25167,
+      "lng": 128.90759
+    },
+    {
+      "stationName": "장유동",
+      "sidoName": "경남",
+      "lat": 35.1661,
+      "lng": 128.83287
+    },
+    {
+      "stationName": "진영읍",
+      "sidoName": "경남",
+      "lat": 35.3043216,
+      "lng": 128.7331206
+    },
+    {
+      "stationName": "김해대로",
+      "sidoName": "경남",
+      "lat": 35.2214105,
+      "lng": 128.9291446
+    },
+    {
+      "stationName": "진례면",
+      "sidoName": "경남",
+      "lat": 35.2468733,
+      "lng": 128.7545126
+    },
+    {
+      "stationName": "저구리",
+      "sidoName": "경남",
+      "lat": 34.7323975,
+      "lng": 128.6049042
+    },
+    {
+      "stationName": "아주동",
+      "sidoName": "경남",
+      "lat": 34.8686293,
+      "lng": 128.6917003
+    },
+    {
+      "stationName": "고현동",
+      "sidoName": "경남",
+      "lat": 34.889942,
+      "lng": 128.623477
+    },
+    {
+      "stationName": "사천읍",
+      "sidoName": "경남",
+      "lat": 35.08741,
+      "lng": 128.1029
+    },
+    {
+      "stationName": "향촌동",
+      "sidoName": "경남",
+      "lat": 34.9398592,
+      "lng": 128.1074036
+    },
+    {
+      "stationName": "대산면",
+      "sidoName": "경남",
+      "lat": 35.3358032,
+      "lng": 128.7076259
+    },
+    {
+      "stationName": "북부동",
+      "sidoName": "경남",
+      "lat": 35.3476186,
+      "lng": 129.0376504
+    },
+    {
+      "stationName": "삼호동",
+      "sidoName": "경남",
+      "lat": 35.4061769,
+      "lng": 129.1808571
+    },
+    {
+      "stationName": "물금읍",
+      "sidoName": "경남",
+      "lat": 35.31521,
+      "lng": 128.99928
+    },
+    {
+      "stationName": "내일동",
+      "sidoName": "경남",
+      "lat": 35.4936883,
+      "lng": 128.7542349
+    },
+    {
+      "stationName": "무전동",
+      "sidoName": "경남",
+      "lat": 34.8604366,
+      "lng": 128.4311316
+    },
+    {
+      "stationName": "고성읍",
+      "sidoName": "경남",
+      "lat": 34.977565,
+      "lng": 128.320239
+    },
+    {
+      "stationName": "거창읍",
+      "sidoName": "경남",
+      "lat": 35.6863036,
+      "lng": 127.9100451
+    },
+    {
+      "stationName": "가야읍",
+      "sidoName": "경남",
+      "lat": 35.27122,
+      "lng": 128.39564
+    },
+    {
+      "stationName": "함양읍",
+      "sidoName": "경남",
+      "lat": 35.5144,
+      "lng": 127.7199
+    },
+    {
+      "stationName": "남해읍",
+      "sidoName": "경남",
+      "lat": 34.838547,
+      "lng": 127.8936556
+    },
+    {
+      "stationName": "산청읍",
+      "sidoName": "경남",
+      "lat": 35.4135,
+      "lng": 127.90275
+    },
+    {
+      "stationName": "남상면",
+      "sidoName": "경남",
+      "lat": 35.62008,
+      "lng": 127.90981
+    },
+    {
+      "stationName": "의령읍",
+      "sidoName": "경남",
+      "lat": 35.30761,
+      "lng": 128.26817
+    },
+    {
+      "stationName": "창녕읍",
+      "sidoName": "경남",
+      "lat": 35.52993,
+      "lng": 128.49609
+    },
+    {
+      "stationName": "합천읍",
+      "sidoName": "경남",
+      "lat": 35.60789,
+      "lng": 128.14465
+    },
+    {
+      "stationName": "진해항",
+      "sidoName": "경남",
+      "lat": 35.1325296,
+      "lng": 128.6948898
+    },
+    {
+      "stationName": "회원동",
+      "sidoName": "경남",
+      "lat": 35.21944,
+      "lng": 128.55842
+    },
+    {
+      "stationName": "봉암동",
+      "sidoName": "경남",
+      "lat": 35.22655,
+      "lng": 128.60664
+    },
+    {
+      "stationName": "내서읍",
+      "sidoName": "경남",
+      "lat": 35.24015,
+      "lng": 128.51617
+    },
+    {
+      "stationName": "상봉동",
+      "sidoName": "경남",
+      "lat": 35.2034966,
+      "lng": 128.0719185
+    },
+    {
+      "stationName": "대안동",
+      "sidoName": "경남",
+      "lat": 35.1945806,
+      "lng": 128.0841113
+    },
+    {
+      "stationName": "상대동(진주)",
+      "sidoName": "경남",
+      "lat": 35.1853221,
+      "lng": 128.1116932
+    },
+    {
+      "stationName": "정촌면",
+      "sidoName": "경남",
+      "lat": 35.12398,
+      "lng": 128.11082
+    },
+    {
+      "stationName": "명서동",
+      "sidoName": "경남",
+      "lat": 35.24834,
+      "lng": 128.64666
+    },
+    {
+      "stationName": "웅남동",
+      "sidoName": "경남",
+      "lat": 35.21189,
+      "lng": 128.65585
+    },
+    {
+      "stationName": "성주동",
+      "sidoName": "경남",
+      "lat": 35.18931,
+      "lng": 128.71324
+    },
+    {
+      "stationName": "용지동",
+      "sidoName": "경남",
+      "lat": 35.236458,
+      "lng": 128.6786065
+    },
+    {
+      "stationName": "반송로",
+      "sidoName": "경남",
+      "lat": 35.2409986,
+      "lng": 128.6624394
+    },
+    {
+      "stationName": "사파동",
+      "sidoName": "경남",
+      "lat": 35.22476,
+      "lng": 128.70799
+    },
+    {
+      "stationName": "연동",
+      "sidoName": "제주",
+      "lat": 33.47575,
+      "lng": 126.49418
+    },
+    {
+      "stationName": "조천읍",
+      "sidoName": "제주",
+      "lat": 33.50888,
+      "lng": 126.66305
+    },
+    {
+      "stationName": "한림읍",
+      "sidoName": "제주",
+      "lat": 33.39344,
+      "lng": 126.26684
+    },
+    {
+      "stationName": "화북동",
+      "sidoName": "제주",
+      "lat": 33.5142719,
+      "lng": 126.5651174
+    },
+    {
+      "stationName": "애월읍",
+      "sidoName": "제주",
+      "lat": 33.45079,
+      "lng": 126.3752
+    },
+    {
+      "stationName": "동홍동",
+      "sidoName": "제주",
+      "lat": 33.26184,
+      "lng": 126.56804
+    },
+    {
+      "stationName": "성산읍",
+      "sidoName": "제주",
+      "lat": 33.41805,
+      "lng": 126.88147
+    },
+    {
+      "stationName": "남원읍",
+      "sidoName": "제주",
+      "lat": 33.3076683,
+      "lng": 126.6907475
+    },
+    {
+      "stationName": "강정동",
+      "sidoName": "제주",
+      "lat": 33.24695,
+      "lng": 126.48927
+    },
+    {
+      "stationName": "대정읍",
+      "sidoName": "제주",
+      "lat": 33.2330247,
+      "lng": 126.2495988
+    },
+    {
+      "stationName": "노형로",
+      "sidoName": "제주",
+      "lat": 33.4790135,
+      "lng": 126.4697556
+    },
+    {
+      "stationName": "고산리",
+      "sidoName": "제주",
+      "lat": 33.2912148,
+      "lng": 126.1692498
+    },
+    {
+      "stationName": "제주항",
+      "sidoName": "제주",
+      "lat": 33.524473,
+      "lng": 126.5448742
+    }
+  ]
+}

--- a/backend/src/cache-hydration/kma-forecast.util.spec.ts
+++ b/backend/src/cache-hydration/kma-forecast.util.spec.ts
@@ -1,0 +1,34 @@
+import {
+  parseForecastNumbers,
+  resolveVilageFcstBaseKst,
+  skyCodeToCloudPercent,
+} from './kma-forecast.util';
+
+describe('kma-forecast.util', () => {
+  it('skyCodeToCloudPercent maps KMA SKY codes', () => {
+    expect(skyCodeToCloudPercent(1)).toBe(15);
+    expect(skyCodeToCloudPercent(3)).toBe(65);
+    expect(skyCodeToCloudPercent(4)).toBe(90);
+  });
+
+  it('parseForecastNumbers uses nearest future slot, not first row', () => {
+    const items = [
+      { fcstDate: '20260517', fcstTime: '0600', category: 'SKY', fcstValue: '1' },
+      { fcstDate: '20260517', fcstTime: '1200', category: 'SKY', fcstValue: '4' },
+      { fcstDate: '20260517', fcstTime: '0600', category: 'REH', fcstValue: '80' },
+      { fcstDate: '20260517', fcstTime: '1200', category: 'REH', fcstValue: '55' },
+    ];
+    const now = new Date('2026-05-17T03:00:00Z'); // KST 12:00
+    const parsed = parseForecastNumbers(items, now);
+    expect(parsed.skyCode).toBe(4);
+    expect(parsed.cloud).toBe(90);
+    expect(parsed.humidity).toBe(55);
+  });
+
+  it('resolveVilageFcstBaseKst picks latest issued base before now', () => {
+    const now = new Date('2026-05-17T01:00:00Z'); // KST 10:00
+    const { baseDate, baseTime } = resolveVilageFcstBaseKst(now);
+    expect(baseDate).toBe('20260517');
+    expect(baseTime).toBe('0800');
+  });
+});

--- a/backend/src/cache-hydration/kma-forecast.util.ts
+++ b/backend/src/cache-hydration/kma-forecast.util.ts
@@ -1,0 +1,192 @@
+/** 기상청 단기예보(getVilageFcst) item 파싱 — KST 기준 */
+
+export type VilageFcstItem = {
+  category?: string;
+  fcstDate?: string;
+  fcstTime?: string;
+  fcstValue?: string;
+};
+
+const SKY_TO_CLOUD_PCT: Record<number, number> = {
+  1: 15, // 맑음
+  2: 35,
+  3: 65, // 구름많음
+  4: 90, // 흐림
+};
+
+/** 기상청 단기예보 하늘상태(SKY) 4단계 — UI 표시용 */
+export const SKY_LABEL_KO: Record<number, string> = {
+  1: '맑음',
+  2: '구름조금',
+  3: '구름많음',
+  4: '흐림',
+};
+
+export function skyCodeToLabel(skyCode: number): string {
+  const code = Math.round(skyCode);
+  return SKY_LABEL_KO[code] ?? (code <= 1 ? '맑음' : code >= 4 ? '흐림' : '구름많음');
+}
+
+/** 운량 근사(%) → SKY 코드 — 구형 weather 캐시 호환 */
+export function cloudPercentToSkyCode(pct: number): number {
+  if (pct <= 20) return 1;
+  if (pct <= 45) return 2;
+  if (pct <= 75) return 3;
+  return 4;
+}
+
+/** 하늘상태(SKY) 코드 → 운량 근사(%) — Star-Index 점수용 */
+export function skyCodeToCloudPercent(skyCode: number): number {
+  const mapped = SKY_TO_CLOUD_PCT[Math.round(skyCode)];
+  if (mapped !== undefined) return mapped;
+  if (skyCode <= 1) return 15;
+  if (skyCode >= 4) return 90;
+  return 50;
+}
+
+/** KST 시각 문자열 (YYYYMMDDHHmm) */
+export function kstYmdHm(d = new Date()): string {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).formatToParts(d);
+  const get = (type: string) =>
+    parts.find((p) => p.type === type)?.value ?? '00';
+  return `${get('year')}${get('month')}${get('day')}${get('hour')}${get('minute')}`;
+}
+
+const VILAGE_BASE_TIMES = [
+  '2300',
+  '2000',
+  '1700',
+  '1400',
+  '1100',
+  '0800',
+  '0500',
+  '0200',
+] as const;
+
+/**
+ * 단기예보 발표 시각 중 현재 KST 이전 최신 base (발표 후 ~10분 지연은 호출 측 재시도로 보완)
+ */
+export function resolveVilageFcstBaseKst(now = new Date()): {
+  baseDate: string;
+  baseTime: string;
+} {
+  const ymdhm = kstYmdHm(now);
+  const today = ymdhm.slice(0, 8);
+  const hour = Number(ymdhm.slice(8, 10));
+  const minute = Number(ymdhm.slice(10, 12));
+  const nowHm = hour * 100 + minute;
+
+  for (const bt of VILAGE_BASE_TIMES) {
+    const baseHm = Number(bt);
+    if (nowHm >= baseHm + 15) {
+      return { baseDate: today, baseTime: bt };
+    }
+  }
+
+  const yesterday = new Date(now.getTime() - 86400000);
+  const yParts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(yesterday);
+  const yGet = (type: string) =>
+    yParts.find((p) => p.type === type)?.value ?? '01';
+  const ymd = `${yGet('year')}${yGet('month')}${yGet('day')}`;
+  return { baseDate: ymd, baseTime: '2300' };
+}
+
+function slotKey(item: VilageFcstItem): string | null {
+  if (!item.fcstDate || !item.fcstTime) return null;
+  return `${item.fcstDate}${item.fcstTime.padStart(4, '0')}`;
+}
+
+export function fcstSlotToNum(fcstDate: string, fcstTime: string): number {
+  return Number(`${fcstDate}${fcstTime.padStart(4, '0')}`);
+}
+
+export function currentKstFcstSlotNum(now = new Date()): number {
+  const hm = kstYmdHm(now);
+  return Number(`${hm.slice(0, 10)}00`);
+}
+
+/** 현재 KST 이후 가장 가까운(동일 포함) 예보 슬롯의 category 값 */
+export function pickNearestForecastValue(
+  items: VilageFcstItem[],
+  category: string,
+  now = new Date(),
+): string | undefined {
+  const targetNum = currentKstFcstSlotNum(now);
+
+  const bySlot = new Map<number, Map<string, string>>();
+  for (const item of items) {
+    if (!item.fcstDate || !item.fcstTime || !item.category || item.fcstValue === undefined) {
+      continue;
+    }
+    const slotNum = fcstSlotToNum(item.fcstDate, item.fcstTime);
+    let slot = bySlot.get(slotNum);
+    if (!slot) {
+      slot = new Map();
+      bySlot.set(slotNum, slot);
+    }
+    slot.set(item.category, item.fcstValue);
+  }
+
+  let bestNum: number | null = null;
+  let bestDiff = Number.POSITIVE_INFINITY;
+  for (const slotNum of bySlot.keys()) {
+    const diff = slotNum - targetNum;
+    if (diff < 0) continue;
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      bestNum = slotNum;
+    }
+  }
+
+  if (bestNum === null) {
+    for (const slotNum of bySlot.keys()) {
+      if (bestNum === null || slotNum > bestNum) bestNum = slotNum;
+    }
+  }
+
+  if (bestNum === null) return undefined;
+  return bySlot.get(bestNum)?.get(category);
+}
+
+export function parseForecastNumbers(
+  items: VilageFcstItem[],
+  now = new Date(),
+): {
+  skyCode: number;
+  cloud: number;
+  humidity: number;
+  windSpeed: number;
+  visibility: number;
+  temperature: number;
+  pop: number;
+} {
+  const read = (category: string, fallback: number): number => {
+    const raw = pickNearestForecastValue(items, category, now);
+    const parsed = raw ? Number(raw) : NaN;
+    return Number.isFinite(parsed) ? parsed : fallback;
+  };
+
+  const sky = read('SKY', 1);
+  return {
+    skyCode: sky,
+    cloud: skyCodeToCloudPercent(sky),
+    humidity: read('REH', 70),
+    windSpeed: read('WSD', 2),
+    visibility: read('VVV', 10),
+    temperature: read('TMP', 12),
+    pop: read('POP', 0),
+  };
+}

--- a/backend/src/cache-hydration/star-index-cache-hydration.service.ts
+++ b/backend/src/cache-hydration/star-index-cache-hydration.service.ts
@@ -2,8 +2,51 @@ import { Inject, Injectable, Logger } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
 import { ConfigService } from '@nestjs/config';
-import { SkyService } from '../sky/sky.service';
 import { getKstYmd } from '../common/kst-date';
+import type { VilageFcstItem } from './kma-forecast.util';
+import {
+  parseForecastNumbers,
+  resolveVilageFcstBaseKst,
+} from './kma-forecast.util';
+import { moonStateAtObserver } from '../sky/moon-ephemeris.util';
+import { arpltnInforUrl } from './airkorea-api.util';
+import {
+  extractAirKoreaItems,
+  pickLatestPm25Reading,
+  type AirKoreaItemsBody,
+} from './airkorea.util';
+import { loadBundledStationCatalog } from './airkorea-station-bundled.loader';
+import { findSidoByLatLng } from './airkorea-sido-bbox.util';
+import {
+  reverseGeocodeKo,
+  scoreStationNameMatch,
+  type NominatimAddress,
+} from './airkorea-geocode.util';
+import {
+  AIRKOREA_SIDO_ADDRS,
+  AIRKOREA_STATION_CATALOG_CACHE_KEY,
+  dustStationCacheKey,
+  findNearestStation,
+  haversineKm,
+  hasStationCoords,
+  parseStationCatalogFromCtprvn,
+  type AirKoreaStationCatalogEntry,
+} from './airkorea-station.util';
+import {
+  SPOT_REPOSITORY,
+  type SpotRepository,
+} from '../common/interfaces/spot.repository';
+
+const REF_LAT = 37.5665;
+const REF_LNG = 126.978;
+
+const STATION_CATALOG_TTL_MS = 7 * 24 * 3600 * 1000;
+const REVERSE_GEO_CACHE_TTL_MS = 7 * 24 * 3600 * 1000;
+const WEATHER_CACHE_TTL_MS = 3600 * 1000;
+const DUST_STATION_CACHE_TTL_MS = 3600 * 1000;
+const MOON_CACHE_TTL_MS = 86400 * 1000;
+
+const REVERSE_GEO_ROUND = 100_000;
 
 /**
  * Star-Index에 필요한 weather / dust / moon 키를 요청 시·cron 시 채움.
@@ -13,10 +56,12 @@ import { getKstYmd } from '../common/kst-date';
 export class StarIndexCacheHydrationService {
   private readonly logger = new Logger(StarIndexCacheHydrationService.name);
 
+  private catalogLoadLock: Promise<void> | null = null;
+
   constructor(
     @Inject(CACHE_MANAGER) private readonly cache: Cache,
     private readonly config: ConfigService,
-    private readonly skyService: SkyService,
+    @Inject(SPOT_REPOSITORY) private readonly spots: SpotRepository,
   ) {}
 
   latLngToGrid(lat: number, lng: number): { nx: number; ny: number } {
@@ -53,132 +98,367 @@ export class StarIndexCacheHydrationService {
     return { nx, ny };
   }
 
-  private pickForecast(
-    items: Array<{ category?: string; fcstValue?: string }>,
-  ): {
-    cloud: number;
-    humidity: number;
-    windSpeed: number;
-    visibility: number;
-    temperature: number;
-    pop: number;
-  } {
-    const findValue = (category: string, fallback: number): number => {
-      const raw = items.find((v) => v.category === category)?.fcstValue;
-      const parsed = raw ? Number(raw) : NaN;
-      return Number.isFinite(parsed) ? parsed : fallback;
-    };
-    return {
-      cloud: findValue('SKY', 5) * 25,
-      humidity: findValue('REH', 70),
-      windSpeed: findValue('WSD', 2),
-      visibility: findValue('VVV', 10),
-      temperature: findValue('TMP', 12),
-      pop: findValue('POP', 0),
-    };
+  /** 캐시된 전국 카탈로그 — 없거나 비었으면 ensureStationCatalog 후 재조회 */
+  private async getStationCatalogCached(): Promise<AirKoreaStationCatalogEntry[]> {
+    const rows = await this.cache.get<AirKoreaStationCatalogEntry[]>(
+      AIRKOREA_STATION_CATALOG_CACHE_KEY,
+    );
+    if (rows?.length) {
+      return rows;
+    }
+    await this.ensureStationCatalog();
+    const again = await this.cache.get<AirKoreaStationCatalogEntry[]>(
+      AIRKOREA_STATION_CATALOG_CACHE_KEY,
+    );
+    return Array.isArray(again) ? again : [];
   }
 
-  /** 단일 격자 기상 캐시 — 실패 시 예외 */
+  private reverseGeoCacheKey(lat: number, lng: number): string {
+    const rLat = Math.round(lat * REVERSE_GEO_ROUND);
+    const rLng = Math.round(lng * REVERSE_GEO_ROUND);
+    return `airkorea:reverse-geocode:${rLat}:${rLng}`;
+  }
+
+  private async getReverseGeocodeCached(
+    lat: number,
+    lng: number,
+  ): Promise<NominatimAddress | null> {
+    const ck = this.reverseGeoCacheKey(lat, lng);
+    const hit = await this.cache.get<NominatimAddress>(ck);
+    if (hit !== undefined && hit !== null) {
+      return hit;
+    }
+    const addr = await reverseGeocodeKo(lat, lng);
+    await this.cache.set(ck, addr, REVERSE_GEO_CACHE_TTL_MS);
+    return addr;
+  }
+
+  /**
+   * 1) 레포 포함 bundled JSON 우선
+   * 2) 없으면 17개 시도 getCtprvnRltmMesureDnstry로 stationName 목록만 수집 (좌표 없음 가능)
+   */
+  async ensureStationCatalog(): Promise<void> {
+    const existing = await this.cache.get<unknown>(AIRKOREA_STATION_CATALOG_CACHE_KEY);
+    if (Array.isArray(existing) && existing.length > 0) {
+      return;
+    }
+    if (this.catalogLoadLock) {
+      return this.catalogLoadLock;
+    }
+    this.catalogLoadLock = this.loadStationCatalogFresh().finally(() => {
+      this.catalogLoadLock = null;
+    });
+    await this.catalogLoadLock;
+  }
+
+  private mergeCatalogDedupe(
+    parts: readonly AirKoreaStationCatalogEntry[],
+  ): AirKoreaStationCatalogEntry[] {
+    const map = new Map<string, AirKoreaStationCatalogEntry>();
+    for (const e of parts) {
+      const key = `${e.sidoName}\u0000${e.stationName}`;
+      const prev = map.get(key);
+      if (!prev) {
+        map.set(key, { ...e });
+        continue;
+      }
+      const coords = hasStationCoords(e)
+        ? e
+        : hasStationCoords(prev)
+          ? prev
+          : e;
+      map.set(key, {
+        stationName: e.stationName,
+        sidoName: e.sidoName || prev.sidoName,
+        lat: coords.lat,
+        lng: coords.lng,
+        addr: e.addr ?? prev.addr,
+      });
+    }
+    return [...map.values()];
+  }
+
+  private async loadStationCatalogFresh(): Promise<void> {
+    const bundled = loadBundledStationCatalog();
+    if (bundled?.length) {
+      await this.cache.set(
+        AIRKOREA_STATION_CATALOG_CACHE_KEY,
+        bundled,
+        STATION_CATALOG_TTL_MS,
+      );
+      this.logger.log(
+        `에어코리아 측정소 카탈로그(번들 JSON) 저장 — ${bundled.length}곳`,
+      );
+      return;
+    }
+
+    const serviceKey = this.config.get<string>('AIRKOREA_API_KEY');
+    if (!serviceKey) {
+      this.logger.warn('AIRKOREA_API_KEY 없음 — 카탈로그 API 폴백 생략');
+      await this.cache.set(AIRKOREA_STATION_CATALOG_CACHE_KEY, [], STATION_CATALOG_TTL_MS);
+      return;
+    }
+
+    const merged: AirKoreaStationCatalogEntry[] = [];
+    for (const sidoName of AIRKOREA_SIDO_ADDRS) {
+      try {
+        const url = arpltnInforUrl('getCtprvnRltmMesureDnsty', {
+          serviceKey,
+          returnType: 'json',
+          numOfRows: '500',
+          pageNo: '1',
+          sidoName,
+          ver: '1.0',
+        });
+        const res = await fetch(url);
+        const text = await res.text();
+        if (!res.ok) {
+          this.logger.warn(
+            `getCtprvnRltmMesureDnsty 실패 sido=${sidoName} HTTP ${res.status}`,
+          );
+          continue;
+        }
+        let body: unknown;
+        try {
+          body = JSON.parse(text) as {
+            response?: { body?: { items?: unknown } };
+          };
+        } catch {
+          this.logger.warn(`getCtprvnRltmMesureDnsty JSON 파싱 실패 sido=${sidoName}`);
+          continue;
+        }
+        const rows = extractAirKoreaItems(
+          (body as { response?: { body?: AirKoreaItemsBody } }).response?.body,
+        );
+        merged.push(...parseStationCatalogFromCtprvn(rows, sidoName));
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        this.logger.warn(`getCtprvnRltmMesureDnsty sido=${sidoName} 예외: ${msg}`);
+      }
+    }
+
+    const catalog = this.mergeCatalogDedupe(merged);
+    await this.cache.set(
+      AIRKOREA_STATION_CATALOG_CACHE_KEY,
+      catalog,
+      STATION_CATALOG_TTL_MS,
+    );
+    this.logger.log(
+      `에어코리아 측정소 카탈로그(API 폴백) 저장 — ${catalog.length}곳`,
+    );
+  }
+
+  /**
+   * 시도 bbox → 같은 sido 항목·좌표 있는 측정소만 두고 역지오코딩 스코어로 정렬 가능 시 보정 후 최근접.
+   */
+  async resolveNearestStation(
+    lat: number,
+    lng: number,
+  ): Promise<AirKoreaStationCatalogEntry> {
+    const catalog = await this.getStationCatalogCached();
+    const sidoName = findSidoByLatLng(lat, lng);
+    let withCoords = catalog.filter(
+      (e) => e.sidoName === sidoName && hasStationCoords(e),
+    );
+    if (!withCoords.length) {
+      withCoords = catalog.filter(hasStationCoords);
+    }
+    if (!withCoords.length) {
+      throw new Error(
+        '좌표가 있는 에어코리아 측정소가 없습니다. 번들 airkorea-stations.json 또는 API 결과를 확인하세요.',
+      );
+    }
+
+    let address: NominatimAddress | null = null;
+    try {
+      address = await this.getReverseGeocodeCached(lat, lng);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.logger.debug(`역지오코딩 생략 (${msg})`);
+    }
+
+    if (address && Object.keys(address).length > 0) {
+      type Scored = { entry: AirKoreaStationCatalogEntry; rank: number; d: number };
+      const ranked: Scored[] = withCoords.map((entry) => {
+        const score = scoreStationNameMatch(entry.stationName, address ?? {});
+        const d = haversineKm(lat, lng, entry.lat, entry.lng);
+        const rank =
+          score * 1_000_000 - Math.min(d, 9_999) * 100;
+        return { entry, rank, d };
+      });
+      ranked.sort((a, b) => {
+        if (b.rank !== a.rank) return b.rank - a.rank;
+        return a.d - b.d;
+      });
+      return ranked[0].entry;
+    }
+
+    return findNearestStation(withCoords, lat, lng);
+  }
+
+  /** Star-Index·Cron 공통 — 해당 좌표의 미세먼지 캐시 키 */
+  async resolveDustCacheKey(lat: number, lng: number): Promise<string> {
+    await this.ensureStationCatalog();
+    const nearest = await this.resolveNearestStation(lat, lng);
+    return dustStationCacheKey(nearest.stationName);
+  }
+
+  /** 단일 격자 기상 캐시 — KMA base 시각 해석 후 parseForecastNumbers */
   async fetchAndStoreWeatherGrid(nx: number, ny: number): Promise<void> {
     const serviceKey = this.config.get<string>('KMA_API_KEY');
     if (!serviceKey) {
       throw new Error('KMA_API_KEY 없음');
     }
     const cacheKey = `weather:${nx}:${ny}`;
-    const now = new Date();
-    const baseDate = now.toISOString().slice(0, 10).replace(/-/g, '');
+    const { baseDate, baseTime } = resolveVilageFcstBaseKst(new Date());
+
     const url =
       'https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst' +
-      `?serviceKey=${serviceKey}&numOfRows=200&pageNo=1&dataType=JSON` +
-      `&base_date=${baseDate}&base_time=0500&nx=${nx}&ny=${ny}`;
+      `?serviceKey=${encodeURIComponent(serviceKey)}&numOfRows=300&pageNo=1&dataType=JSON` +
+      `&base_date=${baseDate}&base_time=${baseTime}&nx=${nx}&ny=${ny}`;
     const response = await fetch(url);
-    const data = (await response.json()) as {
+    const rawText = await response.text();
+
+    if (!response.ok) {
+      throw new Error(`기상청 HTTP ${response.status}: ${rawText.slice(0, 240)}`);
+    }
+
+    let data: {
       response?: {
-        body?: { items?: { item?: Array<{ category?: string; fcstValue?: string }> } };
+        header?: { resultCode?: string; resultMsg?: string };
+        body?: { items?: { item?: VilageFcstItem | VilageFcstItem[] } };
       };
     };
-    const items = data.response?.body?.items?.item ?? [];
-    if (!items.length) {
-      throw new Error('기상청 응답 item이 비어 있습니다.');
+    try {
+      data = JSON.parse(rawText) as typeof data;
+    } catch {
+      throw new Error(`기상청 JSON 파싱 실패: ${rawText.slice(0, 160)}`);
     }
-    const payload = {
-      ...this.pickForecast(items),
-      collectedAt: new Date().toISOString(),
-    };
-    await this.cache.set(cacheKey, payload, 3600 * 1000);
+
+    const hdr = data.response?.header;
+    if (hdr && hdr.resultCode !== undefined && hdr.resultCode !== '00') {
+      throw new Error(
+        `기상청 API 코드 ${hdr.resultCode}: ${hdr.resultMsg ?? ''}`.trim(),
+      );
+    }
+
+    const rawItems = data.response?.body?.items?.item ?? [];
+    const items: VilageFcstItem[] = Array.isArray(rawItems) ? rawItems : [rawItems];
+
+    if (!items.length) {
+      throw new Error(
+        `기상 단기예보 item 비어 있음 (${nx}, ${ny}) base=${baseDate} ${baseTime}`,
+      );
+    }
+
+    const nums = parseForecastNumbers(items, new Date());
+    await this.cache.set(
+      cacheKey,
+      {
+        skyCode: nums.skyCode,
+        cloud: nums.cloud,
+        humidity: nums.humidity,
+        windSpeed: nums.windSpeed,
+        visibility: nums.visibility,
+        temperature: nums.temperature,
+        pop: nums.pop,
+        collectedAt: new Date().toISOString(),
+      },
+      WEATHER_CACHE_TTL_MS,
+    );
     this.logger.log(`weather 캐시 저장: ${cacheKey}`);
   }
 
-  async fetchAndStoreDustSeoul(): Promise<void> {
-    const sido = '서울';
-    const cacheKey = `dust:${sido}`;
+  /** 측정소별 실시간 농도 — getMsrstnAcctoRltmMesureDnsty */
+  async fetchAndStoreDustForStation(stationName: string): Promise<void> {
     const serviceKey = this.config.get<string>('AIRKOREA_API_KEY');
     if (!serviceKey) {
       throw new Error('AIRKOREA_API_KEY 없음');
     }
-    const url =
-      'https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty' +
-      `?serviceKey=${serviceKey}&returnType=json&numOfRows=10&pageNo=1&sidoName=${encodeURIComponent(
-        sido,
-      )}&ver=1.0`;
+    const cacheKey = dustStationCacheKey(stationName);
+
+    const url = arpltnInforUrl('getMsrstnAcctoRltmMesureDnsty', {
+      serviceKey,
+      returnType: 'json',
+      numOfRows: '300',
+      pageNo: '1',
+      stationName,
+      ver: '1.0',
+      dataTerm: 'DAILY',
+    });
+
     const response = await fetch(url);
     const rawText = await response.text();
     if (!response.ok) {
-      throw new Error(`HTTP ${response.status} — ${rawText.slice(0, 200)}`);
+      throw new Error(`dust station HTTP ${response.status}: ${rawText.slice(0, 180)}`);
     }
-    let parsed: { response?: { body?: { items?: Array<{ pm25Value?: string }> } } };
+
+    let parsed: {
+      response?: {
+        body?: AirKoreaItemsBody;
+      };
+    };
     try {
       parsed = JSON.parse(rawText) as typeof parsed;
     } catch {
+      throw new Error(`dust station JSON 파싱 실패: ${rawText.slice(0, 120)}`);
+    }
+
+    const items = extractAirKoreaItems(parsed.response?.body);
+    const picked = pickLatestPm25Reading(items);
+    if (!picked) {
       throw new Error(
-        `JSON 파싱 실패: ${rawText.slice(0, 120)}`,
+        `${stationName} 측정소 유효 PM2.5가 없음 — 응답 ${items.length}행`,
       );
     }
-    const items = parsed.response?.body?.items ?? [];
-    const pm25 =
-      items
-        .map((v) => Number(v.pm25Value))
-        .find((v) => Number.isFinite(v) && v >= 0) ?? 20;
+
     await this.cache.set(
       cacheKey,
-      { pm25, collectedAt: new Date().toISOString() },
-      3600 * 1000,
+      { pm25: picked.pm25, collectedAt: new Date().toISOString() },
+      DUST_STATION_CACHE_TTL_MS,
     );
-    this.logger.log(`dust 캐시 저장: ${cacheKey}`);
+    this.logger.log(`dust station 캐시 저장: ${cacheKey}`);
   }
 
-  /** KST 달력 기준 moon:YYYYMMDD — Star-Index와 동일 키 */
-  async fetchAndStoreMoonKstToday(): Promise<void> {
+  /** KST 날짜 키 moon:YYYYMMDD — 기본 서울시청 근처 REF 좌표 (astronomy-engine) */
+  async fetchAndStoreMoonKstToday(
+    observerLat?: number,
+    observerLng?: number,
+  ): Promise<void> {
     const ymd = getKstYmd().replace(/-/g, '');
     const cacheKey = `moon:${ymd}`;
-    const moon = await this.skyService.getMoonData(ymd);
+    const latDeg = observerLat ?? REF_LAT;
+    const lngDeg = observerLng ?? REF_LNG;
+    const moon = moonStateAtObserver(latDeg, lngDeg, new Date());
     await this.cache.set(
       cacheKey,
       {
-        phase: moon.lunPhase,
-        altitude: moon.moonAltitude,
+        phase: moon.phase,
+        altitude: moon.altitude,
         moonAltitudeKnown: moon.moonAltitudeKnown,
-        moonrise: moon.moonrise,
-        moonset: moon.moonset,
         collectedAt: new Date().toISOString(),
       },
-      86400 * 1000,
+      MOON_CACHE_TTL_MS,
     );
     this.logger.log(`moon 캐시 저장: ${cacheKey}`);
   }
 
-  /**
-   * GET /star-index 직전: 비어 있는 입력 캐시만 외부 API로 채움.
-   */
+  /** GET /star-index 직전: 비어 있는 입력 캐시만 외부 API로 채움 */
   async ensureForStarIndexRequest(lat: number, lng: number): Promise<void> {
     const { nx, ny } = this.latLngToGrid(lat, lng);
     const weatherKey = `weather:${nx}:${ny}`;
-    const dustKey = 'dust:서울';
+    let dustKey = '';
+    try {
+      dustKey = await this.resolveDustCacheKey(lat, lng);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.logger.warn(`dust 캐시 키 결정 실패: ${msg}`);
+    }
     const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
 
     const [w, d, m] = await Promise.all([
       this.cache.get(weatherKey),
-      this.cache.get(dustKey),
+      dustKey ? this.cache.get(dustKey) : Promise.resolve(undefined),
       this.cache.get(moonKey),
     ]);
 
@@ -190,20 +470,60 @@ export class StarIndexCacheHydrationService {
         this.logger.warn(`ensure weather 실패 ${weatherKey}: ${msg}`);
       }
     }
-    if (!d) {
+    if (dustKey && !d) {
       try {
-        await this.fetchAndStoreDustSeoul();
+        const station =
+          dustKey.startsWith('dust:st:') ? dustKey.slice('dust:st:'.length) : '';
+        if (station) {
+          await this.fetchAndStoreDustForStation(station);
+        }
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        this.logger.warn(`ensure dust 실패: ${msg}`);
+        this.logger.warn(`ensure dust 실패 ${dustKey}: ${msg}`);
       }
     }
     if (!m) {
       try {
-        await this.fetchAndStoreMoonKstToday();
+        await this.fetchAndStoreMoonKstToday(REF_LAT, REF_LNG);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         this.logger.warn(`ensure moon 실패: ${msg}`);
+      }
+    }
+  }
+
+  /** Cron: 명소별로 필요한 서로 다른 dust:st:* 키만 중복 없이 수집 */
+  async fetchAndStoreDustForAllSpots(): Promise<void> {
+    const serviceKey = this.config.get<string>('AIRKOREA_API_KEY');
+    if (!serviceKey) {
+      throw new Error('AIRKOREA_API_KEY 없음');
+    }
+
+    await this.ensureStationCatalog();
+    const spots = await this.spots.findAll();
+    if (!spots.length) {
+      this.logger.warn('명소 없음 — dust 일괄 수집 생략');
+      return;
+    }
+
+    const keys = new Set<string>();
+    for (const s of spots) {
+      try {
+        keys.add(await this.resolveDustCacheKey(s.lat, s.lng));
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        this.logger.warn(`명소 dust 키 생략 spot=${s.id}: ${msg}`);
+      }
+    }
+
+    for (const key of keys) {
+      const name = key.startsWith('dust:st:') ? key.slice('dust:st:'.length) : '';
+      if (!name) continue;
+      try {
+        await this.fetchAndStoreDustForStation(name);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        this.logger.warn(`dust 수집 실패(건너뜀) ${key}: ${msg}`);
       }
     }
   }

--- a/backend/src/common/interfaces/weather-snapshot.ts
+++ b/backend/src/common/interfaces/weather-snapshot.ts
@@ -32,6 +32,14 @@ export interface WeatherSnapshot {
   moon_altitude_known?: boolean;
   /** 달 위상 0~1 — DB 필수 키 아님 */
   lun_phase?: number;
+
+  /** UI·카드 표시용 선택 필드(DB 제약 비대상) */
+  cloud_sky_code?: number;
+  cloud_sky_label?: string;
+  cloud_cover_pct?: number;
+  pm25_ug_m3?: number;
+  pm25_label?: string;
+  pm25_station_name?: string;
 }
 
 /** DB CHECK 및 Observation 저장 시 반드시 존재해야 하는 10개 점수 키 */
@@ -119,6 +127,24 @@ export function normalizeWeatherSnapshotForStorage(
   }
   if (raw.lun_phase !== undefined) {
     base.lun_phase = raw.lun_phase;
+  }
+  if (raw.cloud_sky_code !== undefined) {
+    base.cloud_sky_code = raw.cloud_sky_code;
+  }
+  if (raw.cloud_sky_label !== undefined) {
+    base.cloud_sky_label = raw.cloud_sky_label;
+  }
+  if (raw.cloud_cover_pct !== undefined) {
+    base.cloud_cover_pct = raw.cloud_cover_pct;
+  }
+  if (raw.pm25_ug_m3 !== undefined) {
+    base.pm25_ug_m3 = raw.pm25_ug_m3;
+  }
+  if (raw.pm25_label !== undefined) {
+    base.pm25_label = raw.pm25_label;
+  }
+  if (raw.pm25_station_name !== undefined) {
+    base.pm25_station_name = raw.pm25_station_name;
   }
   return base;
 }

--- a/backend/src/common/resolve-bundled-asset.util.spec.ts
+++ b/backend/src/common/resolve-bundled-asset.util.spec.ts
@@ -1,0 +1,34 @@
+import * as path from 'path';
+import { resolveBundledAssetPath } from './resolve-bundled-asset.util';
+
+describe('resolveBundledAssetPath', () => {
+  it('watch 출력(dist/src/…)에서 dist/{module}/data JSON을 찾는다', () => {
+    const watchModuleDir = path.join(
+      process.cwd(),
+      'dist',
+      'src',
+      'cache-hydration',
+    );
+    const resolved = resolveBundledAssetPath(
+      watchModuleDir,
+      'cache-hydration',
+      'airkorea-stations.json',
+    );
+    expect(resolved).toBeTruthy();
+    expect(resolved).toMatch(/airkorea-stations\.json$/);
+  });
+
+  it('소스 트리(src/…)에서도 찾는다', () => {
+    const srcModuleDir = path.join(
+      process.cwd(),
+      'src',
+      'cache-hydration',
+    );
+    const resolved = resolveBundledAssetPath(
+      srcModuleDir,
+      'cache-hydration',
+      'airkorea-stations.json',
+    );
+    expect(resolved).toBeTruthy();
+  });
+});

--- a/backend/src/common/resolve-bundled-asset.util.ts
+++ b/backend/src/common/resolve-bundled-asset.util.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Nest `nest build` → dist/{module}/data
+ * `nest start --watch` (rootDir 미지정 시) → dist/src/{module}/data 가 아닌 dist/{module}/data 에 asset 복사
+ * 두 레이아웃 모두에서 JSON 번들을 찾는다.
+ */
+export function resolveBundledAssetPath(
+  moduleDirname: string,
+  /** sourceRoot 기준 폴더명 (예: cache-hydration, sky) */
+  moduleSegment: string,
+  fileName: string,
+): string | null {
+  const candidates = [
+    path.join(moduleDirname, 'data', fileName),
+    path.join(moduleDirname, '..', '..', moduleSegment, 'data', fileName),
+    path.join(process.cwd(), 'dist', moduleSegment, 'data', fileName),
+    path.join(process.cwd(), 'src', moduleSegment, 'data', fileName),
+  ];
+
+  for (const candidate of candidates) {
+    const resolved = path.normalize(candidate);
+    if (fs.existsSync(resolved)) {
+      return resolved;
+    }
+  }
+  return null;
+}

--- a/backend/src/common/weather-snapshot-display.util.spec.ts
+++ b/backend/src/common/weather-snapshot-display.util.spec.ts
@@ -1,0 +1,85 @@
+import {
+  buildStarIndexCardDisplay,
+  enrichWeatherSnapshotForDisplay,
+  formatCloudDisplay,
+  formatPm25Display,
+  normalizeDustCacheEntry,
+  normalizeWeatherCacheEntry,
+} from './weather-snapshot-display.util';
+import type { WeatherSnapshot } from './interfaces/weather-snapshot';
+
+describe('weather-snapshot-display.util', () => {
+  it('normalizeWeatherCacheEntry derives skyCode from legacy cloud percent', () => {
+    const w = normalizeWeatherCacheEntry({ cloud: 15, humidity: 60 });
+    expect(w?.skyCode).toBe(1);
+    expect(w?.cloud).toBe(15);
+  });
+
+  it('normalizeDustCacheEntry parses numeric pm25', () => {
+    const d = normalizeDustCacheEntry({
+      pm25: '22',
+      pm25Label: '보통',
+      stationName: '칠곡군',
+    });
+    expect(d?.pm25).toBe(22);
+  });
+
+  it('formatCloudDisplay uses SKY label not percent', () => {
+    const snap: WeatherSnapshot = {
+      cloud_score: 85,
+      pm25_score: 75,
+      light_pollution_score: 50,
+      moon_effect_score: 100,
+      humidity_score: 80,
+      elevation_score: 60,
+      wind_score: 90,
+      visibility_score: 70,
+      temperature_score: 85,
+      correction_score: 100,
+      cloud_cover_pct: 15,
+    };
+    expect(formatCloudDisplay(enrichWeatherSnapshotForDisplay(snap))).toBe(
+      '맑음',
+    );
+  });
+
+  it('formatPm25Display prefers concentration over grade', () => {
+    const snap: WeatherSnapshot = {
+      cloud_score: 85,
+      pm25_score: 75,
+      light_pollution_score: 50,
+      moon_effect_score: 100,
+      humidity_score: 80,
+      elevation_score: 60,
+      wind_score: 90,
+      visibility_score: 70,
+      temperature_score: 85,
+      correction_score: 100,
+      pm25_ug_m3: 22,
+      pm25_label: '보통',
+      pm25_station_name: '칠곡군',
+    };
+    expect(formatPm25Display(snap)).toBe('22㎍/㎥·칠곡군');
+  });
+
+  it('buildStarIndexCardDisplay bundles cloud and pm25 strings', () => {
+    const snap: WeatherSnapshot = {
+      cloud_score: 35,
+      pm25_score: 100,
+      light_pollution_score: 50,
+      moon_effect_score: 100,
+      humidity_score: 80,
+      elevation_score: 60,
+      wind_score: 90,
+      visibility_score: 70,
+      temperature_score: 85,
+      correction_score: 100,
+      cloud_sky_code: 3,
+      pm25_ug_m3: 8,
+    };
+    expect(buildStarIndexCardDisplay(snap)).toEqual({
+      cloud: '구름많음',
+      pm25: '8㎍/㎥',
+    });
+  });
+});

--- a/backend/src/common/weather-snapshot-display.util.ts
+++ b/backend/src/common/weather-snapshot-display.util.ts
@@ -1,0 +1,131 @@
+import {
+  cloudPercentToSkyCode,
+  skyCodeToLabel,
+} from '../cache-hydration/kma-forecast.util';
+import type { WeatherSnapshot } from './interfaces/weather-snapshot';
+
+export type LegacyWeatherCache = {
+  skyCode?: number;
+  cloud?: number;
+  humidity?: number;
+  windSpeed?: number;
+  visibility?: number;
+  temperature?: number;
+  pop?: number;
+};
+export type NormalizedWeatherCache = {
+  skyCode: number;
+  cloud: number;
+};
+
+export function normalizeWeatherCacheEntry(
+  e: unknown,
+): NormalizedWeatherCache | null {
+  if (e === null || typeof e !== 'object') return null;
+  const o = e as LegacyWeatherCache;
+  const cloudNum = Number(o.cloud);
+  const skyRaw = Number(o.skyCode);
+  const skyCode = Number.isFinite(skyRaw)
+    ? skyRaw
+    : Number.isFinite(cloudNum)
+      ? cloudPercentToSkyCode(cloudNum)
+      : NaN;
+  const cloud = Number.isFinite(cloudNum) ? cloudNum : NaN;
+  if (!Number.isFinite(skyCode) || !Number.isFinite(cloud)) return null;
+  return { skyCode, cloud };
+}
+
+export type LegacyDustCache = {
+  pm25?: string | number;
+  pm25Label?: string;
+  stationName?: string;
+};
+export type NormalizedDustCache = {
+  pm25?: number;
+  pm25Label?: string;
+  stationName?: string;
+};
+
+export function normalizeDustCacheEntry(e: unknown): NormalizedDustCache | null {
+  if (e === null || typeof e !== 'object') return null;
+  const d = e as LegacyDustCache;
+  const raw =
+    typeof d.pm25 === 'number' ? d.pm25 : Number(String(d.pm25 ?? '').trim());
+  if (!Number.isFinite(raw) || raw < 0) return null;
+  return {
+    pm25: raw,
+    pm25Label: d.pm25Label,
+    stationName: d.stationName,
+  };
+}
+
+/** Star-Index 카드 CLOUD / PM2.5 문구 */
+export type StarIndexCardDisplay = {
+  cloud: string;
+  pm25: string;
+};
+
+export function enrichWeatherSnapshotForDisplay(
+  snap: WeatherSnapshot,
+): WeatherSnapshot {
+  const out: WeatherSnapshot = { ...snap };
+
+  let skyCode = out.cloud_sky_code;
+  if (skyCode === undefined && out.cloud_cover_pct !== undefined) {
+    skyCode = cloudPercentToSkyCode(out.cloud_cover_pct);
+  }
+  if (skyCode === undefined && out.cloud_score !== undefined) {
+    skyCode = cloudPercentToSkyCode(Math.max(0, 100 - out.cloud_score));
+  }
+  if (skyCode !== undefined) {
+    out.cloud_sky_code = skyCode;
+    out.cloud_sky_label = skyCodeToLabel(skyCode);
+  }
+
+  const pm25 = Number(out.pm25_ug_m3);
+  if (Number.isFinite(pm25)) {
+    out.pm25_ug_m3 = pm25;
+  }
+
+  return out;
+}
+
+export function formatCloudDisplay(snap: WeatherSnapshot): string {
+  const label = snap.cloud_sky_label?.trim();
+  if (label) return label;
+  if (snap.cloud_sky_code !== undefined) {
+    return skyCodeToLabel(snap.cloud_sky_code);
+  }
+  if (snap.cloud_cover_pct !== undefined) {
+    return skyCodeToLabel(cloudPercentToSkyCode(snap.cloud_cover_pct));
+  }
+  return skyCodeToLabel(cloudPercentToSkyCode(Math.max(0, 100 - snap.cloud_score)));
+}
+
+export function formatPm25Display(snap: WeatherSnapshot): string {
+  const station = snap.pm25_station_name?.trim();
+  const pm25 = Number(snap.pm25_ug_m3);
+  if (Number.isFinite(pm25)) {
+    const value =
+      Math.abs(pm25 - Math.round(pm25)) < 0.05
+        ? `${Math.round(pm25)}`
+        : pm25.toFixed(1);
+    const core = `${value}㎍/㎥`;
+    return station ? `${core}·${station}` : core;
+  }
+  const grade = snap.pm25_label?.trim();
+  if (grade) {
+    return station ? `${grade}·${station}` : grade;
+  }
+  return station ?? '—';
+}
+
+export function buildStarIndexCardDisplay(
+  snap: WeatherSnapshot,
+): StarIndexCardDisplay {
+  const enriched = enrichWeatherSnapshotForDisplay(snap);
+  return {
+    cloud: formatCloudDisplay(enriched),
+    pm25: formatPm25Display(enriched),
+  };
+}

--- a/backend/src/cron/cron.service.ts
+++ b/backend/src/cron/cron.service.ts
@@ -74,7 +74,7 @@ export class CronService {
     }
 
     try {
-      await this.hydration.fetchAndStoreDustSeoul();
+      await this.hydration.fetchAndStoreDustForAllSpots();
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       this.logger.warn(`dust 수집 실패(기존 캐시 유지): ${msg}`);
@@ -136,7 +136,7 @@ export class CronService {
   }> {
     const { nx, ny } = this.hydration.latLngToGrid(lat, lng);
     const weatherKey = `weather:${nx}:${ny}`;
-    const dustKey = 'dust:서울';
+    const dustKey = await this.hydration.resolveDustCacheKey(lat, lng);
     const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
 
     const [weather, dust, moon] = await Promise.all([

--- a/backend/src/sky/moon-ephemeris.util.spec.ts
+++ b/backend/src/sky/moon-ephemeris.util.spec.ts
@@ -1,0 +1,12 @@
+import { moonStateAtObserver } from './moon-ephemeris.util';
+
+describe('moon-ephemeris.util', () => {
+  it('returns finite altitude and phase in 0..1', () => {
+    const at = new Date('2026-05-17T12:00:00Z');
+    const r = moonStateAtObserver(37.5665, 126.978, at);
+    expect(r.moonAltitudeKnown).toBe(true);
+    expect(Number.isFinite(r.altitude)).toBe(true);
+    expect(r.phase).toBeGreaterThanOrEqual(0);
+    expect(r.phase).toBeLessThanOrEqual(1);
+  });
+});

--- a/backend/src/sky/moon-ephemeris.util.ts
+++ b/backend/src/sky/moon-ephemeris.util.ts
@@ -1,0 +1,20 @@
+import * as Astronomy from 'astronomy-engine';
+
+/** 관측지 기준 달 고도·위상 — KASI RiseSet에 고도가 없을 때 Star-Index·캐시용 */
+export function moonStateAtObserver(
+  latDeg: number,
+  lngDeg: number,
+  atUtc = new Date(),
+): {
+  altitude: number;
+  phase: number;
+  moonAltitudeKnown: true;
+} {
+  const observer = new Astronomy.Observer(latDeg, lngDeg, 0);
+  const eq = Astronomy.Equator(Astronomy.Body.Moon, atUtc, observer, true, true);
+  const hor = Astronomy.Horizon(atUtc, observer, eq.ra, eq.dec, 'normal');
+  const ill = Astronomy.Illumination(Astronomy.Body.Moon, atUtc);
+  const altitude = Math.round(hor.altitude * 10) / 10;
+  const phase = Math.min(1, Math.max(0, ill.phase_fraction));
+  return { altitude, phase, moonAltitudeKnown: true };
+}

--- a/backend/src/sky/sky.service.ts
+++ b/backend/src/sky/sky.service.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { Injectable, Logger } from '@nestjs/common';
+import { resolveBundledAssetPath } from '../common/resolve-bundled-asset.util';
 import { ConfigService } from '@nestjs/config';
 import * as Astronomy from 'astronomy-engine';
 import axios from 'axios';
@@ -150,9 +151,8 @@ export class SkyService {
       const result = kasiToInternalMapper(moonData, phaseData);
 
       if (!result.moonAltitudeKnown) {
-        this.logger.warn(
-          `[KASI] RiseSet item에 고도 필드 없음 — moonAltitude=${result.moonAltitude}(센티넬). ` +
-            `실측 고도는 별도 API/필드 합의 후 kasi.mapper 확장 필요. date=${date}`,
+        this.logger.debug(
+          `[KASI] RiseSet 고도 필드 없음 — astronomy-engine으로 보정. date=${date}`,
         );
       } else {
         this.logger.log(
@@ -183,7 +183,9 @@ export class SkyService {
   private loadBrightCatalog(): CatalogRow[] {
     if (this.catalogCache) return this.catalogCache;
     try {
-      const p = path.join(__dirname, 'data', 'hip-bright-subset.json');
+      const p =
+        resolveBundledAssetPath(__dirname, 'sky', 'hip-bright-subset.json') ??
+        path.join(__dirname, 'data', 'hip-bright-subset.json');
       const raw = fs.readFileSync(p, 'utf8');
       const rows = JSON.parse(raw) as CatalogRow[];
       this.catalogCache = rows;
@@ -396,7 +398,12 @@ export class SkyService {
   getConstellationLines(): ConstellationLinesResponseDto {
     if (this.constellationLinesCache) return this.constellationLinesCache;
     try {
-      const p = path.join(__dirname, 'data', 'constellation-lines-mvp.json');
+      const p =
+        resolveBundledAssetPath(
+          __dirname,
+          'sky',
+          'constellation-lines-mvp.json',
+        ) ?? path.join(__dirname, 'data', 'constellation-lines-mvp.json');
       const raw = fs.readFileSync(p, 'utf8');
       const parsed = JSON.parse(raw) as ConstellationLinesResponseDto;
       this.constellationLinesCache = parsed;

--- a/backend/src/star-index/star-index.controller.ts
+++ b/backend/src/star-index/star-index.controller.ts
@@ -21,6 +21,7 @@ import {
   SPOT_REPOSITORY,
   type SpotRepository,
 } from '../common/interfaces/spot.repository';
+import { buildStarIndexCardDisplay } from '../common/weather-snapshot-display.util';
 import { StarIndexService } from './star-index.service';
 
 @ApiTags('star-index')
@@ -99,6 +100,7 @@ export class StarIndexController {
       }
       const { score, weatherSnapshot, cacheKeys } =
         await this.starIndexService.calculateForSpotFromCache(spot);
+      const display = buildStarIndexCardDisplay(weatherSnapshot);
       return {
         spotId: spot.id,
         name: spot.name,
@@ -108,6 +110,7 @@ export class StarIndexController {
         bortleClass: spot.bortleClass,
         score,
         weatherSnapshot,
+        display,
         cacheKeys,
         message:
           '캐시(weather/dust/moon) 기반 Star-Index 계산 완료 — weather_snapshot 10키 합의 스키마',
@@ -130,6 +133,7 @@ export class StarIndexController {
 
     const { score, weatherSnapshot, cacheKeys, nearestSpot, distanceKm } =
       await this.starIndexService.calculateForLatLngFromCache(lat, lng);
+    const display = buildStarIndexCardDisplay(weatherSnapshot);
 
     const detailMsg =
       nearestSpot && distanceKm != null
@@ -146,6 +150,7 @@ export class StarIndexController {
       bortleClass: nearestSpot?.bortleClass ?? 5,
       score,
       weatherSnapshot,
+      display,
       cacheKeys,
       message: detailMsg,
       requestedBy: user.email,

--- a/backend/src/star-index/star-index.service.ts
+++ b/backend/src/star-index/star-index.service.ts
@@ -12,24 +12,34 @@ import {
   type Spot,
 } from '../common/interfaces/spot.repository';
 import { MOON_ALTITUDE_MISSING_SENTINEL } from '../sky/kasi.mapper';
+import { moonStateAtObserver } from '../sky/moon-ephemeris.util';
+import { skyCodeToLabel } from '../cache-hydration/kma-forecast.util';
 import type { WeatherSnapshot } from '../common/interfaces/weather-snapshot';
 import { normalizeWeatherSnapshotForStorage } from '../common/interfaces/weather-snapshot';
+import {
+  enrichWeatherSnapshotForDisplay,
+  normalizeDustCacheEntry,
+  normalizeWeatherCacheEntry,
+} from '../common/weather-snapshot-display.util';
 import { CorrectionsService } from '../corrections/corrections.service';
 import { getKstYmd } from '../common/kst-date';
 import { StarIndexCacheHydrationService } from '../cache-hydration/star-index-cache-hydration.service';
 
 // ── 기상 데이터 타입 ─────────────────────────────────────────
 interface WeatherData {
-  cloud: number;       // 운량 (0~100%)
-  humidity: number;    // 습도 (%)
-  windSpeed: number;   // 풍속 (m/s)
-  visibility: number;  // 시정 (km)
-  temperature: number; // 기온 (℃)
-  pop: number;         // 강수확률 (%)
+  skyCode: number;
+  cloud: number;
+  humidity: number;
+  windSpeed: number;
+  visibility: number;
+  temperature: number;
+  pop: number;
 }
 
 interface DustData {
-  pm25: number;        // PM2.5 (㎍/㎥)
+  pm25: number;
+  pm25Label?: string;
+  stationName?: string;
 }
 
 interface MoonData {
@@ -71,19 +81,25 @@ export class StarIndexService {
 
     const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
     const weatherKey = `weather:${nx}:${ny}`;
-    const dustKey = 'dust:서울';
+    const dustKey = await this.cacheHydration.resolveDustCacheKey(
+      spot.lat,
+      spot.lng,
+    );
     const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
 
-    const weather = await this.cache.get<WeatherData>(weatherKey);
-    const dust = await this.cache.get<DustData>(dustKey);
-    const moon = await this.cache.get<MoonData>(moonKey);
+    const weather = this.readWeatherCache(
+      await this.cache.get(weatherKey),
+    );
+    const dust = this.readDustCache(await this.cache.get(dustKey));
+    const moonRaw = await this.cache.get<MoonData>(moonKey);
 
-    if (!weather || !dust || !moon) {
+    if (!weather || !dust || !moonRaw) {
       throw new ServiceUnavailableException(
-        '기상·미세먼지·달 데이터를 가져오지 못했습니다. KMA_API_KEY·AIRKOREA_API_KEY·KASI 키와 네트워크를 확인하세요.',
+        '기상·미세먼지·달 데이터를 가져오지 못했습니다. KMA_API_KEY·AIRKOREA_API_KEY와 네트워크를 확인하세요.',
       );
     }
 
+    const moon = this.resolveMoonAt(spot.lat, spot.lng, moonRaw);
     const correctionScore =
       await this.correctionsService.getAggregatedCorrectionScoreForSpot(spot.id);
 
@@ -118,19 +134,22 @@ export class StarIndexService {
 
     const { nx, ny } = this.latLngToGrid(lat, lng);
     const weatherKey = `weather:${nx}:${ny}`;
-    const dustKey = 'dust:서울';
+    const dustKey = await this.cacheHydration.resolveDustCacheKey(lat, lng);
     const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
 
-    const weather = await this.cache.get<WeatherData>(weatherKey);
-    const dust = await this.cache.get<DustData>(dustKey);
-    const moon = await this.cache.get<MoonData>(moonKey);
+    const weather = this.readWeatherCache(
+      await this.cache.get(weatherKey),
+    );
+    const dust = this.readDustCache(await this.cache.get(dustKey));
+    const moonRaw = await this.cache.get<MoonData>(moonKey);
 
-    if (!weather || !dust || !moon) {
+    if (!weather || !dust || !moonRaw) {
       throw new ServiceUnavailableException(
-        '기상·미세먼지·달 데이터를 가져오지 못했습니다. KMA_API_KEY·AIRKOREA_API_KEY·KASI 키와 네트워크를 확인하세요.',
+        '기상·미세먼지·달 데이터를 가져오지 못했습니다. KMA_API_KEY·AIRKOREA_API_KEY와 네트워크를 확인하세요.',
       );
     }
 
+    const moon = this.resolveMoonAt(lat, lng, moonRaw);
     const nearby = await this.spots.findNearby(lat, lng, 200_000);
     const nearest = this.pickNearestSpot(lat, lng, nearby);
     const distanceKm = nearest
@@ -204,19 +223,25 @@ export class StarIndexService {
 
     const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
     const weatherKey = `weather:${nx}:${ny}`;
-    const dustKey = 'dust:서울';
+    const dustKey = await this.cacheHydration.resolveDustCacheKey(
+      spot.lat,
+      spot.lng,
+    );
     const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
 
-    const weather = await this.cache.get<WeatherData>(weatherKey);
-    const dust = await this.cache.get<DustData>(dustKey);
-    const moon = await this.cache.get<MoonData>(moonKey);
+    const weather = this.readWeatherCache(
+      await this.cache.get(weatherKey),
+    );
+    const dust = this.readDustCache(await this.cache.get(dustKey));
+    const moonRaw = await this.cache.get<MoonData>(moonKey);
 
-    if (!weather || !dust || !moon) {
+    if (!weather || !dust || !moonRaw) {
       throw new ServiceUnavailableException(
         '기상·미세먼지·달 데이터를 가져오지 못했습니다. API 키·네트워크를 확인하세요.',
       );
     }
 
+    const moon = this.resolveMoonAt(spot.lat, spot.lng, moonRaw);
     const correctionScore =
       await this.correctionsService.getAggregatedCorrectionScoreForSpot(spot.id);
 
@@ -240,28 +265,9 @@ export class StarIndexService {
     input: StarIndexInput,
   ): Promise<{ score: number; weatherSnapshot: WeatherSnapshot }> {
     const cacheKey = `star_index:${spotId}`;
-
-    const cached = await this.cache.get<number | StarIndexCachePayload>(cacheKey);
-
-    if (cached !== undefined && cached !== null) {
-      if (typeof cached === 'number') {
-        const fresh = this.calcStarIndexWithSnapshot(input);
-        await this.cache.set(cacheKey, fresh, 3600 * 1000);
-        this.logger.log(
-          `Star-Index 레거시 캐시 교체 — spot: ${spotId}, score: ${fresh.score}`,
-        );
-        return fresh;
-      }
-      return {
-        score: cached.score,
-        weatherSnapshot: cached.weatherSnapshot,
-      };
-    }
-
     const payload = this.calcStarIndexWithSnapshot(input);
     await this.cache.set(cacheKey, payload, 3600 * 1000);
     this.logger.log(`Star-Index 계산 완료 — spot: ${spotId}, score: ${payload.score}`);
-
     return payload;
   }
 
@@ -277,7 +283,9 @@ export class StarIndexService {
    */
   calcStarIndexWithSnapshot(input: StarIndexInput): StarIndexCachePayload {
     const raw = this.buildRawWeatherSnapshot(input);
-    const weatherSnapshot = normalizeWeatherSnapshotForStorage(raw);
+    const weatherSnapshot = enrichWeatherSnapshotForDisplay(
+      normalizeWeatherSnapshotForStorage(raw),
+    );
     const score = this.aggregateScoreFromSnapshot(
       weatherSnapshot,
       input.weather.pop,
@@ -285,8 +293,44 @@ export class StarIndexService {
     return { score, weatherSnapshot };
   }
 
+  private readWeatherCache(raw: unknown): WeatherData | null {
+    const n = normalizeWeatherCacheEntry(raw);
+    if (!n || n.cloud === undefined) return null;
+    const w = raw as Record<string, unknown>;
+    const skyRaw = Number(w.skyCode);
+    return {
+      skyCode: Number.isFinite(skyRaw) ? skyRaw : (n.skyCode ?? 1),
+      cloud: n.cloud,
+      humidity: Number(w.humidity) || 70,
+      windSpeed: Number(w.windSpeed) || 2,
+      visibility: Number(w.visibility) || 10,
+      temperature: Number(w.temperature) || 12,
+      pop: Number(w.pop) || 0,
+    };
+  }
+
+  private readDustCache(raw: unknown): DustData | null {
+    const n = normalizeDustCacheEntry(raw);
+    if (n?.pm25 === undefined || !Number.isFinite(n.pm25)) return null;
+    return {
+      pm25: n.pm25,
+      pm25Label: n.pm25Label,
+      stationName: n.stationName,
+    };
+  }
+
+  private resolveMoonAt(lat: number, lng: number, cached: MoonData): MoonData {
+    const ephemeris = moonStateAtObserver(lat, lng);
+    return {
+      phase: cached.phase > 0 ? cached.phase : ephemeris.phase,
+      altitude: ephemeris.altitude,
+      moonAltitudeKnown: true,
+    };
+  }
+
   private buildRawWeatherSnapshot(input: StarIndexInput): WeatherSnapshot {
     const { weather, dust, moon, bortleClass, elevationM } = input;
+    const skyCode = weather.skyCode;
 
     return {
       cloud_score: this.calcCloudScore(weather.cloud),
@@ -307,6 +351,12 @@ export class StarIndexService {
       moon_altitude_deg: moon.altitude,
       moon_altitude_known: moon.moonAltitudeKnown,
       lun_phase: moon.phase,
+      cloud_sky_code: skyCode,
+      cloud_sky_label: skyCodeToLabel(skyCode),
+      cloud_cover_pct: weather.cloud,
+      pm25_ug_m3: dust.pm25,
+      pm25_label: dust.pm25Label,
+      pm25_station_name: dust.stationName,
     };
   }
 

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "scripts", "**/*.spec.ts"]
+}

--- a/frontend/components/map/MapSpotDetailModal.tsx
+++ b/frontend/components/map/MapSpotDetailModal.tsx
@@ -108,7 +108,7 @@ export function MapSpotDetailModal({
                   <StarIndexCard
                     bare
                     score={starProps.score}
-                    cloudCover={starProps.cloudCover}
+                    cloudLabel={starProps.cloudLabel}
                     pm25Level={starProps.pm25Level}
                     moonAltitude={starProps.moonAltitude}
                     moonAltitudeKnown={starProps.moonAltitudeKnown}

--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -160,8 +160,8 @@ export function StatefulCard({
 // ── Star-Index 숫자 카드 ──
 interface StarIndexCardProps {
   score:        number;
-  cloudCover:   number;   // % 운량
-  pm25Level:    string;   // '좋음' | '보통' | '나쁨'
+  cloudLabel:   string;   // 맑음·구름조금·구름많음·흐림
+  pm25Level:    string;   // 예: 12㎍/㎥·칠곡군
   moonAltitude: number;   // 달 고도 (도) — unknown이면 표시만 생략
   /** false면 KASI 고도 미수신 등 — MOON 칸에 미상 */
   moonAltitudeKnown?: boolean;
@@ -174,7 +174,7 @@ interface StarIndexCardProps {
 
 export function StarIndexCard({
   score,
-  cloudCover,
+  cloudLabel,
   pm25Level,
   moonAltitude,
   moonAltitudeKnown = true,
@@ -196,7 +196,7 @@ export function StarIndexCard({
     moonAltitudeKnown ? `${moonAltitude}°` : '미상';
 
   const dataItems = [
-    { key: 'CLOUD', value: `${cloudCover}%` },
+    { key: 'CLOUD', value: cloudLabel },
     { key: 'PM2.5', value: pm25Level },
     { key: 'MOON',  value: moonLabel },
   ];

--- a/frontend/lib/star-index-display.ts
+++ b/frontend/lib/star-index-display.ts
@@ -1,23 +1,86 @@
 import type { StarIndexResponseDto } from './types/api';
 
-/** cloud_score = max(0, 100 - cloud%) 역산 (표시용 근사) */
-export function approximateCloudCoverPercent(cloudScore: number): number {
+const SKY_LABEL_KO: Record<number, string> = {
+  1: '맑음',
+  2: '구름조금',
+  3: '구름많음',
+  4: '흐림',
+};
+
+function skyCodeFromCloudPercent(pct: number): number {
+  if (pct <= 20) return 1;
+  if (pct <= 45) return 2;
+  if (pct <= 75) return 3;
+  return 4;
+}
+
+function approximateCloudCoverPercent(cloudScore: number): number {
   return Math.min(100, Math.max(0, 100 - Math.round(cloudScore)));
 }
 
-export function pm25LevelFromScore(pm25Score: number): string {
-  if (pm25Score >= 75) return '좋음';
-  if (pm25Score >= 45) return '보통';
-  return '나쁨';
+function coerceFiniteNumber(value: unknown): number | undefined {
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export function formatCloudForCard(
+  snap: StarIndexResponseDto['weatherSnapshot'],
+): string {
+  const label = snap.cloud_sky_label?.trim();
+  if (label) return label;
+
+  const code = snap.cloud_sky_code;
+  if (code !== undefined && Number.isFinite(code)) {
+    const rounded = Math.round(code);
+    return SKY_LABEL_KO[rounded] ?? '구름많음';
+  }
+
+  const pct =
+    snap.cloud_cover_pct !== undefined
+      ? snap.cloud_cover_pct
+      : approximateCloudCoverPercent(snap.cloud_score);
+  return SKY_LABEL_KO[skyCodeFromCloudPercent(pct)] ?? '구름많음';
+}
+
+export function pm25LevelFromUgM3(pm25: number): string {
+  if (pm25 <= 15) return '좋음';
+  if (pm25 <= 35) return '보통';
+  if (pm25 <= 75) return '나쁨';
+  return '매우나쁨';
+}
+
+export function formatPm25ForCard(
+  snap: StarIndexResponseDto['weatherSnapshot'],
+): string {
+  const station = snap.pm25_station_name?.trim();
+  const pm25Raw = coerceFiniteNumber(snap.pm25_ug_m3);
+  if (pm25Raw !== undefined) {
+    const value =
+      Math.abs(pm25Raw - Math.round(pm25Raw)) < 0.05
+        ? `${Math.round(pm25Raw)}`
+        : pm25Raw.toFixed(1);
+    const core = `${value}㎍/㎥`;
+    return station ? `${core}·${station}` : core;
+  }
+  const grade =
+    snap.pm25_label?.trim() ||
+    pm25LevelFromUgM3(
+      snap.pm25_score >= 100 ? 10 : snap.pm25_score >= 75 ? 20 : 50,
+    );
+  return station ? `${grade}·${station}` : grade;
 }
 
 export function starIndexResponseToCardModel(d: StarIndexResponseDto) {
   const snap = d.weatherSnapshot;
+  const pm25Ug = coerceFiniteNumber(snap.pm25_ug_m3);
+  const snapForFormat =
+    pm25Ug !== undefined ? { ...snap, pm25_ug_m3: pm25Ug } : snap;
+
   return {
     score: d.score,
-    cloudCover: approximateCloudCoverPercent(snap.cloud_score),
-    pm25Level: pm25LevelFromScore(snap.pm25_score),
-    moonAltitude: snap.moon_altitude_deg ?? 0,
+    cloudLabel: d.display?.cloud?.trim() || formatCloudForCard(snapForFormat),
+    pm25Level: d.display?.pm25?.trim() || formatPm25ForCard(snapForFormat),
+    moonAltitude: Math.round(snap.moon_altitude_deg ?? 0),
     moonAltitudeKnown: snap.moon_altitude_known !== false,
   };
 }

--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -14,6 +14,17 @@ export interface WeatherSnapshotDto {
   moon_altitude_deg?: number;
   moon_altitude_known?: boolean;
   lun_phase?: number;
+  cloud_sky_code?: number;
+  cloud_sky_label?: string;
+  cloud_cover_pct?: number;
+  pm25_ug_m3?: number;
+  pm25_label?: string;
+  pm25_station_name?: string;
+}
+
+export interface StarIndexCardDisplayDto {
+  cloud: string;
+  pm25: string;
 }
 
 export interface StarIndexResponseDto {
@@ -26,6 +37,7 @@ export interface StarIndexResponseDto {
   bortleClass: number;
   score: number;
   weatherSnapshot: WeatherSnapshotDto;
+  display?: StarIndexCardDisplayDto;
   cacheKeys: { weatherKey: string; dustKey: string; moonKey: string };
   message: string;
   requestedBy: string;


### PR DESCRIPTION
## 🔎 What

Star-Index 카드 CLOUD·PM2.5·MOON 고정값 문제를 수정하고, 전국 PM2.5를 **가장 가까운 에어코리아 측정소** 기준으로 바꿉니다. 측정소 좌표는 **repo 내장 JSON**을 사용하며, 카드는 **SKY 4단계 문구**와 **㎍/㎥·측정소명**으로 표시합니다.
### 변경 사항
#### 백엔드 — 기상 (KMA)
- `kma-forecast.util.ts`: KST 발표 시각·가장 가까운 예보 슬롯, SKY → 운량 근사
- `star-index-cache-hydration.service.ts`: weather 캐시에 `skyCode` + `cloud` 등 저장
#### 백엔드 — 미세먼지 (에어코리아)
- 시도별 실시간 API로 측정소 목록, `extractAirKoreaItems` / `pickBestPm25Reading`
- `dust:st:{측정소명}` 캐시, `resolveNearestStation()` (시·도 bbox + Haversine)
- `cache-hydration/data/airkorea-stations.json` (625곳), `loadBundledStationCatalog()`
- `scripts/seed-airkorea-stations.ts`, `npm run seed:airkorea-stations`
#### 백엔드 — 달·Star-Index
- `moon-ephemeris.util.ts`: 관측 좌표 기준 고도·위상
- `star-index.service.ts`: 캐시 정규화, 스냅샷 필드 보강, 요청마다 재계산
- `star-index.controller.ts`: `display: { cloud, pm25 }`
- `weather-snapshot-display.util.ts`: 카드 문구 생성
- `cron.service.ts`: 명소별 dust 키 dedupe 수집
#### 백엔드 — 빌드
- `resolve-bundled-asset.util.ts`: watch/build 시 JSON 경로 탐색
- `nest-cli.json` (`cache-hydration/data/*.json`), `tsconfig.build.json`
#### 프론트
- `lib/star-index-display.ts`, `lib/types/api.ts` (`display`, `cloud_sky_*`, `pm25_*`)
- `components/ui/Card.tsx`: `cloudLabel`, PM2.5 농도 문자열
- `MapSpotDetailModal.tsx`: `starIndexResponseToCardModel` 연동
### 테스트
- [x] `backend`: `npm run build`, Jest (`kma-forecast`, `weather-snapshot`, `airkorea`, `moon-ephemeris`, `resolve-bundled`)
- [x] 기동 시 `측정소 카탈로그(번들 JSON) — 625곳`
- [x] `GET /star-index?lat=36.15&lng=128.34` — `display.cloud`, `display.pm25`, MOON `°`
- [x] `frontend`: `npm run typecheck`
### 참고
- KMA 단기예보는 SKY 1~4만 제공(운량 % 없음). 점수는 내부 % 근사, 카드는 맑음/구름많음 등 문구.
- cron 없이 `GET /star-index`만으로도 빈 캐시는 `ensureForStarIndexRequest`로 채울 수 있음.
- `airkorea-stations.json`은 PR에 포함 필요.

## 🔗 Issue 

- Closes: #79 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [x] `airkorea-stations.json` 포함 여부
- [ ] 최소 1명의 리뷰를 받았나요?
