### PR TITLE
fix: normalize Star-Index blend weights to sum 1.0

### DIFF
--- a/backend/src/star-index/star-index-scoring.util.ts
+++ b/backend/src/star-index/star-index-scoring.util.ts
@@ -33,17 +33,18 @@ export type StarIndexAggregateInput = {
   visibilityKnown: boolean;
 };
 
+/** blend 합계 = 1.0 (시정 미수신 시 visibility → cloud로 이전) */
 const BLEND_WEIGHTS = {
-  cloud: 0.3,
-  light: 0.26,
-  moon: 0.16,
-  pm25: 0.11,
-  precip: 0.08,
-  wind: 0.04,
-  elevation: 0.03,
-  humidity: 0.02,
-  visibility: 0.02,
-  correction: 0.08,
+  cloud: 0.273,
+  light: 0.236,
+  moon: 0.145,
+  pm25: 0.1,
+  precip: 0.073,
+  wind: 0.036,
+  elevation: 0.027,
+  humidity: 0.018,
+  visibility: 0.018,
+  correction: 0.074,
 } as const;
 
 function clamp0to100(n: number): number {


### PR DESCRIPTION
## Summary
- Blend 가중치 합이 110%였던 것을 상대 비중 유지한 채 **합 1.0**으로 정규화
- 시정 미수신 시 visibility 비중은 기존처럼 cloud로 이전

## Why
- blend만 놓으면 100을 넘어 점수가 부풀릴 수 있음 (노션/문서와 코드 불일치)

## Test plan
- [x] `cd backend && npm test -- --testPathPattern=star-index-scoring`