### PR TITLE
feat: DIARY 탭 분할 및 Star-Index·지도·PM2.5 수집 경로 개선

### DIFF
--- a/backend/src/cache-hydration/airkorea-station-bundled.loader.ts
+++ b/backend/src/cache-hydration/airkorea-station-bundled.loader.ts
@@ -1,6 +1,10 @@
 import * as fs from 'fs';
 import { resolveBundledAssetPath } from '../common/resolve-bundled-asset.util';
-import type { AirKoreaStationCatalogEntry } from './airkorea-station.util';
+import {
+  pickRepresentativeStations,
+  REPRESENTATIVE_STATIONS_PER_SIDO,
+  type AirKoreaStationCatalogEntry,
+} from './airkorea-station.util';
 
 export type BundledStationCatalogFile = {
   version: number;
@@ -36,7 +40,10 @@ export function loadBundledStationCatalog(): AirKoreaStationCatalogEntry[] | nul
     if (!stations?.length) {
       return null;
     }
-    bundledCache = stations;
+    bundledCache = pickRepresentativeStations(
+      stations,
+      REPRESENTATIVE_STATIONS_PER_SIDO,
+    );
     return bundledCache;
   } catch {
     return null;

--- a/backend/src/cache-hydration/airkorea-station.util.spec.ts
+++ b/backend/src/cache-hydration/airkorea-station.util.spec.ts
@@ -1,7 +1,9 @@
 import { findSidoByLatLng } from './airkorea-sido-bbox.util';
 import {
+  findDustStationInCatalog,
   findNearestStation,
   parseStationCatalogFromCtprvn,
+  pickRepresentativeStations,
   withStationCoords,
 } from './airkorea-station.util';
 
@@ -12,6 +14,22 @@ describe('airkorea-station.util', () => {
     expect(rows[0].stationName).toBe('청송읍');
     expect(rows[0].sidoName).toBe('경북');
     expect(Number.isNaN(rows[0].lat)).toBe(true);
+  });
+
+  it('findDustStationInCatalog matches findNearestStation in same sido', () => {
+    const catalog = [
+      withStationCoords(
+        parseStationCatalogFromCtprvn([{ stationName: 'A' }], '경북')[0],
+        36.0,
+        128.0,
+      ),
+      withStationCoords(
+        parseStationCatalogFromCtprvn([{ stationName: 'B' }], '경북')[0],
+        37.0,
+        129.0,
+      ),
+    ];
+    expect(findDustStationInCatalog(catalog, 36.05, 128.05).stationName).toBe('A');
   });
 
   it('findNearestStation uses geocoded entries', () => {
@@ -33,5 +51,35 @@ describe('airkorea-station.util', () => {
 
   it('findSidoByLatLng resolves 구미 to 경북', () => {
     expect(findSidoByLatLng(36.152673, 128.3432401)).toBe('경북');
+  });
+
+  it('pickRepresentativeStations keeps at most 2 per sido', () => {
+    const catalog = [
+      withStationCoords(
+        parseStationCatalogFromCtprvn([{ stationName: '북' }], '강원')[0],
+        38.0,
+        128.0,
+      ),
+      withStationCoords(
+        parseStationCatalogFromCtprvn([{ stationName: '중' }], '강원')[0],
+        37.5,
+        128.5,
+      ),
+      withStationCoords(
+        parseStationCatalogFromCtprvn([{ stationName: '남' }], '강원')[0],
+        37.0,
+        129.0,
+      ),
+      withStationCoords(
+        parseStationCatalogFromCtprvn([{ stationName: '서울A' }], '서울')[0],
+        37.56,
+        126.98,
+      ),
+    ];
+    const reps = pickRepresentativeStations(catalog, 2);
+    const gangwon = reps.filter((s) => s.sidoName === '강원');
+    expect(gangwon.length).toBe(2);
+    expect(gangwon.map((s) => s.stationName).sort()).toEqual(['남', '북']);
+    expect(reps.filter((s) => s.sidoName === '서울').length).toBe(1);
   });
 });

--- a/backend/src/cache-hydration/airkorea-station.util.ts
+++ b/backend/src/cache-hydration/airkorea-station.util.ts
@@ -1,5 +1,6 @@
 /** 에어코리아 측정소 카탈로그·캐시 키·최근접 측정소 선택 */
 
+import { findSidoByLatLng } from './airkorea-sido-bbox.util';
 import type { AirKoreaStationRow } from './airkorea.util';
 
 export type AirKoreaStationCatalogEntry = {
@@ -32,6 +33,9 @@ export const AIRKOREA_SIDO_ADDRS = [
 ] as const;
 
 export const AIRKOREA_STATION_CATALOG_CACHE_KEY = 'airkorea:station-catalog';
+
+/** 시도당 대표 측정소 수 — Star-Index·cron API 부하 절감 (전국 625곳 → 약 34곳) */
+export const REPRESENTATIVE_STATIONS_PER_SIDO = 2;
 
 /** 측정소별 PM2.5 캐시 — stationName은 에어코리아 공식 명칭 */
 export function dustStationCacheKey(stationName: string): string {
@@ -118,6 +122,27 @@ export function parseStationCatalogRow(
   };
 }
 
+/**
+ * 대표 측정소 카탈로그에서 PM2.5용 최근접 측정소 (역지오코딩 없음 — DIARY·지도·시드 공통)
+ */
+export function findDustStationInCatalog(
+  catalog: readonly AirKoreaStationCatalogEntry[],
+  lat: number,
+  lng: number,
+): AirKoreaStationCatalogEntry {
+  const sidoName = findSidoByLatLng(lat, lng);
+  let withCoords = catalog.filter(
+    (e) => e.sidoName === sidoName && hasStationCoords(e),
+  );
+  if (!withCoords.length) {
+    withCoords = catalog.filter(hasStationCoords);
+  }
+  if (!withCoords.length) {
+    throw new Error('에어코리아 대표 측정소 카탈로그가 비어 있습니다.');
+  }
+  return findNearestStation(withCoords, lat, lng);
+}
+
 /** 카탈로그에서 Haversine 최근접 측정소 (좌표 유효 항목만 전달할 것) */
 export function findNearestStation(
   catalog: AirKoreaStationCatalogEntry[],
@@ -138,4 +163,63 @@ export function findNearestStation(
     }
   }
   return best;
+}
+
+/**
+ * 시도별 대표 측정소만 남김(위도 최북·최남, 동일 시 경도로 2번째).
+ * 근처 명소는 이 소수 측정소로 PM2.5를 공유 — dust:st:* 캐시·API 호출 수 대폭 감소.
+ */
+export function pickRepresentativeStations(
+  catalog: readonly AirKoreaStationCatalogEntry[],
+  maxPerSido = REPRESENTATIVE_STATIONS_PER_SIDO,
+): AirKoreaStationCatalogEntry[] {
+  const cap = Math.max(1, maxPerSido);
+  const bySido = new Map<string, AirKoreaStationCatalogEntry[]>();
+
+  for (const entry of catalog) {
+    if (!hasStationCoords(entry)) continue;
+    const list = bySido.get(entry.sidoName) ?? [];
+    list.push(entry);
+    bySido.set(entry.sidoName, list);
+  }
+
+  const out: AirKoreaStationCatalogEntry[] = [];
+
+  for (const list of bySido.values()) {
+    if (list.length <= cap) {
+      out.push(...list);
+      continue;
+    }
+
+    let north = list[0];
+    let south = list[0];
+    for (const s of list) {
+      if (s.lat > north.lat) north = s;
+      if (s.lat < south.lat) south = s;
+    }
+
+    const picked = new Map<string, AirKoreaStationCatalogEntry>();
+    picked.set(north.stationName, north);
+    if (south.stationName !== north.stationName) {
+      picked.set(south.stationName, south);
+    }
+
+    if (picked.size < cap) {
+      let far = list[0];
+      let bestD = -1;
+      for (const s of list) {
+        if (picked.has(s.stationName)) continue;
+        const d = haversineKm(north.lat, north.lng, s.lat, s.lng);
+        if (d > bestD) {
+          bestD = d;
+          far = s;
+        }
+      }
+      picked.set(far.stationName, far);
+    }
+
+    out.push(...picked.values());
+  }
+
+  return out;
 }

--- a/backend/src/cache-hydration/airkorea.util.ts
+++ b/backend/src/cache-hydration/airkorea.util.ts
@@ -100,3 +100,19 @@ export function pickLatestPm25Reading(rows: AirKoreaStationRow[]): {
   });
   return pickBestPm25Reading(sorted);
 }
+
+/** 시도별 일괄 응답에서 특정 측정소명 PM2.5 추출 */
+export function pickPm25ForStationName(
+  rows: readonly AirKoreaStationRow[],
+  stationName: string,
+): {
+  pm25: number;
+  pm25Grade: number;
+  pm25Label: string;
+  stationName: string | null;
+} | null {
+  const target = stationName.trim();
+  if (!target) return null;
+  const matched = rows.filter((r) => r.stationName?.trim() === target);
+  return pickLatestPm25Reading(matched);
+}

--- a/backend/src/cache-hydration/star-index-cache-hydration.service.ts
+++ b/backend/src/cache-hydration/star-index-cache-hydration.service.ts
@@ -12,7 +12,7 @@ import { moonStateAtObserver } from '../sky/moon-ephemeris.util';
 import { arpltnInforUrl } from './airkorea-api.util';
 import {
   extractAirKoreaItems,
-  pickLatestPm25Reading,
+  pickPm25ForStationName,
   type AirKoreaItemsBody,
 } from './airkorea.util';
 import { loadBundledStationCatalog } from './airkorea-station-bundled.loader';
@@ -26,10 +26,13 @@ import {
   AIRKOREA_SIDO_ADDRS,
   AIRKOREA_STATION_CATALOG_CACHE_KEY,
   dustStationCacheKey,
+  findDustStationInCatalog,
   findNearestStation,
   haversineKm,
   hasStationCoords,
   parseStationCatalogFromCtprvn,
+  pickRepresentativeStations,
+  REPRESENTATIVE_STATIONS_PER_SIDO,
   type AirKoreaStationCatalogEntry,
 } from './airkorea-station.util';
 import {
@@ -99,11 +102,26 @@ export class StarIndexCacheHydrationService {
   }
 
   /** 캐시된 전국 카탈로그 — 없거나 비었으면 ensureStationCatalog 후 재조회 */
-  private async getStationCatalogCached(): Promise<AirKoreaStationCatalogEntry[]> {
+  async getStationCatalogCached(): Promise<AirKoreaStationCatalogEntry[]> {
     const rows = await this.cache.get<AirKoreaStationCatalogEntry[]>(
       AIRKOREA_STATION_CATALOG_CACHE_KEY,
     );
     if (rows?.length) {
+      if (rows.length > AIRKOREA_SIDO_ADDRS.length * REPRESENTATIVE_STATIONS_PER_SIDO + 4) {
+        const slim = pickRepresentativeStations(
+          rows.filter(hasStationCoords),
+          REPRESENTATIVE_STATIONS_PER_SIDO,
+        );
+        await this.cache.set(
+          AIRKOREA_STATION_CATALOG_CACHE_KEY,
+          slim,
+          STATION_CATALOG_TTL_MS,
+        );
+        this.logger.log(
+          `측정소 카탈로그 슬림화 — ${rows.length}곳 → ${slim.length}곳`,
+        );
+        return slim;
+      }
       return rows;
     }
     await this.ensureStationCatalog();
@@ -237,14 +255,18 @@ export class StarIndexCacheHydrationService {
       }
     }
 
-    const catalog = this.mergeCatalogDedupe(merged);
+    const mergedCatalog = this.mergeCatalogDedupe(merged);
+    const catalog = pickRepresentativeStations(
+      mergedCatalog.filter(hasStationCoords),
+      REPRESENTATIVE_STATIONS_PER_SIDO,
+    );
     await this.cache.set(
       AIRKOREA_STATION_CATALOG_CACHE_KEY,
       catalog,
       STATION_CATALOG_TTL_MS,
     );
     this.logger.log(
-      `에어코리아 측정소 카탈로그(API 폴백) 저장 — ${catalog.length}곳`,
+      `에어코리아 측정소 카탈로그(API 폴백) 저장 — ${catalog.length}곳 (대표 ${REPRESENTATIVE_STATIONS_PER_SIDO}/시도)`,
     );
   }
 
@@ -296,11 +318,108 @@ export class StarIndexCacheHydrationService {
     return findNearestStation(withCoords, lat, lng);
   }
 
-  /** Star-Index·Cron 공통 — 해당 좌표의 미세먼지 캐시 키 */
-  async resolveDustCacheKey(lat: number, lng: number): Promise<string> {
+  /**
+   * 배치·지도 목록용 — 역지오코딩(Nominatim) 없이 시도 bbox + 최근접 측정소만 사용
+   */
+  resolveNearestStationFast(
+    lat: number,
+    lng: number,
+    catalog: AirKoreaStationCatalogEntry[],
+  ): AirKoreaStationCatalogEntry {
+    return findDustStationInCatalog(catalog, lat, lng);
+  }
+
+  /**
+   * Star-Index·Cron — dust:st:{측정소} 캐시 키
+   * @param fixedStationName spots.dust_station_name (시드 고정 시 역지오/탐색 생략)
+   */
+  async resolveDustCacheKey(
+    lat: number,
+    lng: number,
+    fixedStationName?: string | null,
+  ): Promise<string> {
+    if (fixedStationName?.trim()) {
+      return dustStationCacheKey(fixedStationName.trim());
+    }
     await this.ensureStationCatalog();
-    const nearest = await this.resolveNearestStation(lat, lng);
+    const catalog = await this.getStationCatalogCached();
+    const nearest = findDustStationInCatalog(catalog, lat, lng);
     return dustStationCacheKey(nearest.stationName);
+  }
+
+  /**
+   * 여러 좌표의 입력 캐시(weather/dust/moon)를 격자·측정소 단위로 dedupe 후 병렬 채움
+   */
+  async ensureForStarIndexBatch(
+    locations: {
+      lat: number;
+      lng: number;
+      dustStationName?: string | null;
+    }[],
+  ): Promise<void> {
+    if (!locations.length) {
+      return;
+    }
+
+    await this.ensureStationCatalog();
+    const catalog = await this.getStationCatalogCached();
+    const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
+
+    const grids = new Map<string, { nx: number; ny: number }>();
+    const dustStationNames = new Set<string>();
+
+    for (const loc of locations) {
+      const { lat, lng, dustStationName } = loc;
+      const { nx, ny } = this.latLngToGrid(lat, lng);
+      grids.set(`${nx}:${ny}`, { nx, ny });
+      if (dustStationName?.trim()) {
+        dustStationNames.add(dustStationName.trim());
+        continue;
+      }
+      try {
+        const nearest = findDustStationInCatalog(catalog, lat, lng);
+        dustStationNames.add(nearest.stationName);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        this.logger.warn(`배치 dust 측정소 결정 생략 lat=${lat}: ${msg}`);
+      }
+    }
+
+    const moonRaw = await this.cache.get(moonKey);
+
+    const tasks: Promise<void>[] = [];
+
+    for (const { nx, ny } of grids.values()) {
+      const weatherKey = `weather:${nx}:${ny}`;
+      tasks.push(
+        (async () => {
+          const hit = await this.cache.get(weatherKey);
+          if (!hit) {
+            await this.fetchAndStoreWeatherGrid(nx, ny);
+          }
+        })(),
+      );
+    }
+
+    const sidosNeedingDust = new Set<string>();
+    for (const stationName of dustStationNames) {
+      const dustKey = dustStationCacheKey(stationName);
+      const hit = await this.cache.get(dustKey);
+      if (hit) continue;
+      const entry = catalog.find((c) => c.stationName === stationName);
+      if (entry) {
+        sidosNeedingDust.add(entry.sidoName);
+      }
+    }
+    for (const sidoName of sidosNeedingDust) {
+      tasks.push(this.fetchAndStoreDustForSido(sidoName));
+    }
+
+    if (!moonRaw) {
+      tasks.push(this.fetchAndStoreMoonKstToday(REF_LAT, REF_LNG));
+    }
+
+    await Promise.all(tasks);
   }
 
   /** 단일 격자 기상 캐시 — KMA base 시각 해석 후 parseForecastNumbers */
@@ -372,55 +491,93 @@ export class StarIndexCacheHydrationService {
     this.logger.log(`weather 캐시 저장: ${cacheKey}`);
   }
 
-  /** 측정소별 실시간 농도 — getMsrstnAcctoRltmMesureDnsty */
-  async fetchAndStoreDustForStation(stationName: string): Promise<void> {
+  /** 시도별 실시간 농도 일괄 — getCtprvnRltmMesureDnsty 1회로 대표 측정소 PM2.5 저장 */
+  async fetchAndStoreDustForSido(sidoName: string): Promise<void> {
     const serviceKey = this.config.get<string>('AIRKOREA_API_KEY');
     if (!serviceKey) {
       throw new Error('AIRKOREA_API_KEY 없음');
     }
-    const cacheKey = dustStationCacheKey(stationName);
 
-    const url = arpltnInforUrl('getMsrstnAcctoRltmMesureDnsty', {
+    await this.ensureStationCatalog();
+    const catalog = await this.getStationCatalogCached();
+    const reps = catalog.filter(
+      (e) => e.sidoName === sidoName && hasStationCoords(e),
+    );
+    if (!reps.length) {
+      this.logger.warn(`dust 시도 수집 생략 — 대표 측정소 없음: ${sidoName}`);
+      return;
+    }
+
+    const items = await this.fetchCtprvnRowsForSido(sidoName, serviceKey);
+    const collectedAt = new Date().toISOString();
+    let saved = 0;
+
+    for (const rep of reps) {
+      const picked = pickPm25ForStationName(items, rep.stationName);
+      if (!picked) {
+        this.logger.warn(
+          `dust PM2.5 없음 — sido=${sidoName} station=${rep.stationName}`,
+        );
+        continue;
+      }
+      await this.cache.set(
+        dustStationCacheKey(rep.stationName),
+        {
+          pm25: picked.pm25,
+          pm25Label: picked.pm25Label,
+          stationName: rep.stationName,
+          collectedAt,
+        },
+        DUST_STATION_CACHE_TTL_MS,
+      );
+      saved += 1;
+    }
+
+    this.logger.log(
+      `dust 시도 캐시 저장 — ${sidoName} 대표 ${saved}/${reps.length}곳 (API 1회)`,
+    );
+  }
+
+  /** 단일 측정소 — 해당 시도 일괄 수집으로 위임 (레거시 per-station API 제거) */
+  async fetchAndStoreDustForStation(stationName: string): Promise<void> {
+    await this.ensureStationCatalog();
+    const catalog = await this.getStationCatalogCached();
+    const entry = catalog.find((c) => c.stationName === stationName);
+    if (entry) {
+      await this.fetchAndStoreDustForSido(entry.sidoName);
+      return;
+    }
+    throw new Error(
+      `대표 측정소 카탈로그에 없음: ${stationName} — 시도 일괄 수집만 지원합니다.`,
+    );
+  }
+
+  private async fetchCtprvnRowsForSido(
+    sidoName: string,
+    serviceKey: string,
+  ): Promise<ReturnType<typeof extractAirKoreaItems>> {
+    const url = arpltnInforUrl('getCtprvnRltmMesureDnsty', {
       serviceKey,
       returnType: 'json',
-      numOfRows: '300',
+      numOfRows: '500',
       pageNo: '1',
-      stationName,
+      sidoName,
       ver: '1.0',
-      dataTerm: 'DAILY',
     });
-
     const response = await fetch(url);
     const rawText = await response.text();
     if (!response.ok) {
-      throw new Error(`dust station HTTP ${response.status}: ${rawText.slice(0, 180)}`);
-    }
-
-    let parsed: {
-      response?: {
-        body?: AirKoreaItemsBody;
-      };
-    };
-    try {
-      parsed = JSON.parse(rawText) as typeof parsed;
-    } catch {
-      throw new Error(`dust station JSON 파싱 실패: ${rawText.slice(0, 120)}`);
-    }
-
-    const items = extractAirKoreaItems(parsed.response?.body);
-    const picked = pickLatestPm25Reading(items);
-    if (!picked) {
       throw new Error(
-        `${stationName} 측정소 유효 PM2.5가 없음 — 응답 ${items.length}행`,
+        `dust sido HTTP ${response.status} ${sidoName}: ${rawText.slice(0, 180)}`,
       );
     }
-
-    await this.cache.set(
-      cacheKey,
-      { pm25: picked.pm25, collectedAt: new Date().toISOString() },
-      DUST_STATION_CACHE_TTL_MS,
-    );
-    this.logger.log(`dust station 캐시 저장: ${cacheKey}`);
+    let body: { response?: { body?: AirKoreaItemsBody } };
+    try {
+      body = JSON.parse(rawText) as typeof body;
+    } catch {
+      throw new Error(`dust sido JSON 파싱 실패: ${sidoName}`);
+    }
+    return extractAirKoreaItems(body.response?.body);
   }
 
   /** KST 날짜 키 moon:YYYYMMDD — 기본 서울시청 근처 REF 좌표 (astronomy-engine) */
@@ -447,12 +604,16 @@ export class StarIndexCacheHydrationService {
   }
 
   /** GET /star-index 직전: 비어 있는 입력 캐시만 외부 API로 채움 */
-  async ensureForStarIndexRequest(lat: number, lng: number): Promise<void> {
+  async ensureForStarIndexRequest(
+    lat: number,
+    lng: number,
+    fixedDustStationName?: string | null,
+  ): Promise<void> {
     const { nx, ny } = this.latLngToGrid(lat, lng);
     const weatherKey = `weather:${nx}:${ny}`;
     let dustKey = '';
     try {
-      dustKey = await this.resolveDustCacheKey(lat, lng);
+      dustKey = await this.resolveDustCacheKey(lat, lng, fixedDustStationName);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       this.logger.warn(`dust 캐시 키 결정 실패: ${msg}`);
@@ -495,38 +656,20 @@ export class StarIndexCacheHydrationService {
     }
   }
 
-  /** Cron: 명소별로 필요한 서로 다른 dust:st:* 키만 중복 없이 수집 */
+  /** Cron: 시도 17회 API로 전국 대표 측정소 PM2.5 수집 (명소 수·625측정소와 무관) */
   async fetchAndStoreDustForAllSpots(): Promise<void> {
-    const serviceKey = this.config.get<string>('AIRKOREA_API_KEY');
-    if (!serviceKey) {
+    if (!this.config.get<string>('AIRKOREA_API_KEY')) {
       throw new Error('AIRKOREA_API_KEY 없음');
     }
 
     await this.ensureStationCatalog();
-    const spots = await this.spots.findAll();
-    if (!spots.length) {
-      this.logger.warn('명소 없음 — dust 일괄 수집 생략');
-      return;
-    }
 
-    const keys = new Set<string>();
-    for (const s of spots) {
+    for (const sidoName of AIRKOREA_SIDO_ADDRS) {
       try {
-        keys.add(await this.resolveDustCacheKey(s.lat, s.lng));
+        await this.fetchAndStoreDustForSido(sidoName);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        this.logger.warn(`명소 dust 키 생략 spot=${s.id}: ${msg}`);
-      }
-    }
-
-    for (const key of keys) {
-      const name = key.startsWith('dust:st:') ? key.slice('dust:st:'.length) : '';
-      if (!name) continue;
-      try {
-        await this.fetchAndStoreDustForStation(name);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        this.logger.warn(`dust 수집 실패(건너뜀) ${key}: ${msg}`);
+        this.logger.warn(`dust 시도 수집 실패(건너뜀) ${sidoName}: ${msg}`);
       }
     }
   }

--- a/backend/src/common/interfaces/spot.repository.ts
+++ b/backend/src/common/interfaces/spot.repository.ts
@@ -13,6 +13,8 @@ export interface Spot {
   hasParking: boolean;
   hasToilet: boolean;
   locationRadiusM: number;
+  /** 시드 시 고정 — PM2.5 dust:st:* 캐시 키 결정용 (에어코리아 측정소명) */
+  dustStationName?: string | null;
 }
 
 // SpotRepository 인터페이스 — 서비스는 이것만 바라봄

--- a/backend/src/corrections/corrections.service.ts
+++ b/backend/src/corrections/corrections.service.ts
@@ -34,14 +34,47 @@ export class CorrectionsService {
    * 제보가 없으면 100(중립, 기존 가중치와 동일 효과).
    */
   async getAggregatedCorrectionScoreForSpot(spotId: string): Promise<number> {
-    const rows = await this.repo.find({
-      where: { spotId },
-      order: { createdAt: 'DESC' },
-      take: AGGREGATION_WINDOW,
-    });
-    if (rows.length === 0) return 100;
-    const sum = rows.reduce((acc, r) => acc + r.perceivedQuality, 0);
-    return Math.round(Math.min(100, Math.max(0, sum / rows.length)));
+    const map = await this.getAggregatedCorrectionScoresForSpots([spotId]);
+    return map.get(spotId) ?? 100;
+  }
+
+  /** 지도 클러스터 배치 — 명소 N곳 correction_score 1회 조회 */
+  async getAggregatedCorrectionScoresForSpots(
+    spotIds: string[],
+  ): Promise<Map<string, number>> {
+    const out = new Map<string, number>();
+    const unique = [...new Set(spotIds.filter(Boolean))];
+    for (const id of unique) {
+      out.set(id, 100);
+    }
+    if (!unique.length) {
+      return out;
+    }
+
+    const rows = (await this.repo.query(
+      `
+      SELECT spot_id, ROUND(AVG(perceived_quality))::int AS score
+      FROM (
+        SELECT
+          spot_id,
+          perceived_quality,
+          ROW_NUMBER() OVER (PARTITION BY spot_id ORDER BY created_at DESC) AS rn
+        FROM star_index_correction_submissions
+        WHERE spot_id = ANY($1::uuid[])
+      ) ranked
+      WHERE rn <= $2
+      GROUP BY spot_id
+      `,
+      [unique, AGGREGATION_WINDOW],
+    )) as { spot_id: string; score: number }[];
+
+    for (const row of rows) {
+      const score = Number(row.score);
+      if (Number.isFinite(score)) {
+        out.set(String(row.spot_id), Math.min(100, Math.max(0, score)));
+      }
+    }
+    return out;
   }
 
   async create(userId: string, dto: CreateCorrectionSubmissionDto) {

--- a/backend/src/migrations/1750000000000-add-spots-dust-station-name.ts
+++ b/backend/src/migrations/1750000000000-add-spots-dust-station-name.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * 명소별 PM2.5 대표 측정소 고정 — Star-Index 요청 시 역지오/최근접 탐색 생략
+ */
+export class AddSpotsDustStationName1750000000000 implements MigrationInterface {
+  name = 'AddSpotsDustStationName1750000000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE spots
+      ADD COLUMN IF NOT EXISTS dust_station_name varchar(100) NULL
+    `);
+    await queryRunner.query(`
+      COMMENT ON COLUMN spots.dust_station_name IS
+        '에어코리아 PM2.5 대표 측정소명 — dust:st:{name} 캐시 키 (시드·슬림 카탈로그 기준)'
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE spots DROP COLUMN IF EXISTS dust_station_name
+    `);
+  }
+}

--- a/backend/src/seeds/spots.seed.ts
+++ b/backend/src/seeds/spots.seed.ts
@@ -1,5 +1,7 @@
 import dataSource from '../database/data-source';
 import { Logger } from '@nestjs/common';
+import { loadBundledStationCatalog } from '../cache-hydration/airkorea-station-bundled.loader';
+import { findDustStationInCatalog } from '../cache-hydration/airkorea-station.util';
 
 type SpotSeedRow = {
   name: string;
@@ -526,9 +528,25 @@ const SPOT_NAME_RENAMES: Array<{ from: string; to: string }> = [
   { from: '영월 별마로 천문대', to: '강원 영월 별마로 천문대' },
 ];
 
+function resolveDustStationNameForSeed(
+  lat: number,
+  lng: number,
+  catalog: ReturnType<typeof loadBundledStationCatalog>,
+): string | null {
+  if (!catalog?.length) {
+    return null;
+  }
+  try {
+    return findDustStationInCatalog(catalog, lat, lng).stationName;
+  } catch {
+    return null;
+  }
+}
+
 async function seedSpots(): Promise<void> {
   const logger = new Logger('SpotsSeed');
   await dataSource.initialize();
+  const dustCatalog = loadBundledStationCatalog();
 
   try {
     for (const { from, to } of SPOT_NAME_RENAMES) {
@@ -546,10 +564,16 @@ async function seedSpots(): Promise<void> {
     }
 
     for (const spot of spotsSeedData) {
+      const dustStationName = resolveDustStationNameForSeed(
+        spot.lat,
+        spot.lng,
+        dustCatalog,
+      );
       await dataSource.query(
         `
         INSERT INTO spots (
-          name, location, bortle_class, elevation_m, has_parking, has_toilet, location_radius_m
+          name, location, bortle_class, elevation_m, has_parking, has_toilet,
+          location_radius_m, dust_station_name
         )
         SELECT
           $1::varchar,
@@ -558,7 +582,8 @@ async function seedSpots(): Promise<void> {
           $5::int,
           $6::boolean,
           $7::boolean,
-          $8::int
+          $8::int,
+          $9::varchar
         WHERE NOT EXISTS (
           SELECT 1 FROM spots WHERE name = $1::varchar
         )
@@ -572,8 +597,36 @@ async function seedSpots(): Promise<void> {
           spot.hasParking,
           spot.hasToilet,
           spot.locationRadiusM,
+          dustStationName,
         ],
       );
+    }
+
+    if (dustCatalog?.length) {
+      const missing = (await dataSource.query(
+        `
+        SELECT
+          id,
+          ST_Y(location::geometry) AS lat,
+          ST_X(location::geometry) AS lng
+        FROM spots
+        WHERE dust_station_name IS NULL OR TRIM(dust_station_name) = ''
+        `,
+      )) as Array<{ id: string; lat: number; lng: number }>;
+
+      for (const row of missing) {
+        const name = resolveDustStationNameForSeed(
+          Number(row.lat),
+          Number(row.lng),
+          dustCatalog,
+        );
+        if (!name) continue;
+        await dataSource.query(
+          `UPDATE spots SET dust_station_name = $2::varchar WHERE id = $1::uuid`,
+          [row.id, name],
+        );
+      }
+      logger.log(`dust_station_name 백필 — ${missing.length}건 처리 시도`);
     }
 
     const countRows = (await dataSource.query(

--- a/backend/src/spots/spot.entity.ts
+++ b/backend/src/spots/spot.entity.ts
@@ -32,6 +32,9 @@ export class SpotEntity {
   @Column({ name: 'location_radius_m', type: 'int', nullable: true })
   locationRadiusM: number | null;
 
+  @Column({ name: 'dust_station_name', type: 'varchar', length: 100, nullable: true })
+  dustStationName: string | null;
+
   @Column({ name: 'search_vector', type: 'tsvector', nullable: true, select: false })
   searchVector: string | null;
 

--- a/backend/src/spots/typeorm-spot.repository.ts
+++ b/backend/src/spots/typeorm-spot.repository.ts
@@ -26,7 +26,8 @@ export class TypeOrmSpotRepository implements SpotRepository {
         elevation_m,
         has_parking,
         has_toilet,
-        location_radius_m
+        location_radius_m,
+        dust_station_name
       FROM spots
       WHERE id = $1::uuid
       `,
@@ -49,7 +50,8 @@ export class TypeOrmSpotRepository implements SpotRepository {
         elevation_m,
         has_parking,
         has_toilet,
-        location_radius_m
+        location_radius_m,
+        dust_station_name
       FROM spots
       WHERE ST_DWithin(
         location::geography,
@@ -79,7 +81,8 @@ export class TypeOrmSpotRepository implements SpotRepository {
         elevation_m,
         has_parking,
         has_toilet,
-        location_radius_m
+        location_radius_m,
+        dust_station_name
       FROM spots
       ORDER BY name
       `,
@@ -105,7 +108,8 @@ export class TypeOrmSpotRepository implements SpotRepository {
         elevation_m,
         has_parking,
         has_toilet,
-        location_radius_m
+        location_radius_m,
+        dust_station_name
       FROM spots
       WHERE
         search_vector @@ plainto_tsquery('simple', $1)
@@ -136,6 +140,10 @@ export class TypeOrmSpotRepository implements SpotRepository {
       hasParking: row.has_parking === true,
       hasToilet: row.has_toilet === true,
       locationRadiusM: Number(row.location_radius_m ?? 0),
+      dustStationName:
+        row.dust_station_name != null && String(row.dust_station_name).trim() !== ''
+          ? String(row.dust_station_name)
+          : null,
     };
   }
 }

--- a/backend/src/star-index/star-index.controller.ts
+++ b/backend/src/star-index/star-index.controller.ts
@@ -56,19 +56,11 @@ export class StarIndexController {
       .filter(Boolean)
       .slice(0, 40);
 
-    const items: { spotId: string; score: number }[] = [];
+    const spots = (
+      await Promise.all(ids.map((id) => this.spots.findById(id)))
+    ).filter((s): s is NonNullable<typeof s> => s != null);
 
-    for (const id of ids) {
-      const spot = await this.spots.findById(id);
-      if (!spot) continue;
-      try {
-        const { score } =
-          await this.starIndexService.calculateForSpotFromCache(spot);
-        items.push({ spotId: spot.id, score });
-      } catch {
-        /* 개별 실패는 건너뜀 */
-      }
-    }
+    const items = await this.starIndexService.calculateSpotScoresBatch(spots);
 
     return {
       items,
@@ -107,9 +99,9 @@ export class StarIndexController {
       if (!spot) {
         throw new NotFoundException('해당 spotId의 명소가 없습니다.');
       }
-      const { score, weatherSnapshot, cacheKeys } =
+      const result =
         await this.starIndexService.calculateForSpotFromCache(spot, atUtc);
-      const display = buildStarIndexCardDisplay(weatherSnapshot);
+      const display = buildStarIndexCardDisplay(result.weatherSnapshot);
       return {
         spotId: spot.id,
         name: spot.name,
@@ -117,12 +109,16 @@ export class StarIndexController {
         lng: spot.lng,
         elevationM: spot.elevationM,
         bortleClass: spot.bortleClass,
-        score,
-        weatherSnapshot,
+        score: result.score,
+        weatherSnapshot: result.weatherSnapshot,
         display,
-        cacheKeys,
-        message:
-          '캐시(weather/dust/moon) 기반 Star-Index 계산 완료 — weather_snapshot 10키 합의 스키마',
+        cacheKeys: result.cacheKeys,
+        isStale: result.isStale ?? false,
+        cachedAt: result.cachedAt,
+        source: result.isStale ? 'stale_cache' : 'live',
+        message: result.isStale
+          ? '실시간 기상 캐시가 없어 직전 계산값을 표시합니다.'
+          : '캐시(weather/dust/moon) 기반 Star-Index 계산 완료 — weather_snapshot 10키 합의 스키마',
         requestedBy: user.email,
       };
     }
@@ -140,14 +136,21 @@ export class StarIndexController {
       throw new BadRequestException('lat·lng 범위가 올바르지 않습니다.');
     }
 
-    const { score, weatherSnapshot, cacheKeys, nearestSpot, distanceKm } =
-      await this.starIndexService.calculateForLatLngFromCache(lat, lng, atUtc);
-    const display = buildStarIndexCardDisplay(weatherSnapshot);
+    const result = await this.starIndexService.calculateForLatLngFromCache(
+      lat,
+      lng,
+      atUtc,
+    );
+    const display = buildStarIndexCardDisplay(result.weatherSnapshot);
 
-    const detailMsg =
+    const { nearestSpot, distanceKm } = result;
+    let detailMsg =
       nearestSpot && distanceKm != null
         ? `격자 기상 + 주변 참고: ${nearestSpot.name} (약 ${distanceKm.toFixed(1)}km) — 앱에서 행정구역 이름은 역지오코딩으로 표시합니다.`
         : '격자 기상 + 기본 광공해·고도';
+    if (result.isStale && nearestSpot) {
+      detailMsg = `실시간 캐시 없음 — ${nearestSpot.name} 직전 계산값 참고 (약 ${distanceKm?.toFixed(1) ?? '?'}km)`;
+    }
 
     return {
       spotId: nearestSpot?.id,
@@ -157,10 +160,13 @@ export class StarIndexController {
       lng,
       elevationM: nearestSpot?.elevationM ?? 100,
       bortleClass: nearestSpot?.bortleClass ?? 5,
-      score,
-      weatherSnapshot,
+      score: result.score,
+      weatherSnapshot: result.weatherSnapshot,
       display,
-      cacheKeys,
+      cacheKeys: result.cacheKeys,
+      isStale: result.isStale ?? false,
+      cachedAt: result.cachedAt,
+      source: result.isStale ? 'stale_cache' : 'live',
       message: detailMsg,
       requestedBy: user.email,
     };

--- a/backend/src/star-index/star-index.module.ts
+++ b/backend/src/star-index/star-index.module.ts
@@ -4,15 +4,23 @@
 // ──────────────────────────────────────────────────────────────
 
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { CorrectionsModule } from '../corrections/corrections.module';
 import { SpotsModule } from '../spots/spots.module';
 import { CacheHydrationModule } from '../cache-hydration/cache-hydration.module';
+import { SpotStarIndexDailyEntity } from '../weekly-top3/spot-star-index-daily.entity';
 import { StarIndexController } from './star-index.controller';
 import { StarIndexService } from './star-index.service';
 
 @Module({
-  imports: [AuthModule, SpotsModule, CorrectionsModule, CacheHydrationModule],
+  imports: [
+    TypeOrmModule.forFeature([SpotStarIndexDailyEntity]),
+    AuthModule,
+    SpotsModule,
+    CorrectionsModule,
+    CacheHydrationModule,
+  ],
   controllers: [StarIndexController],
   providers: [StarIndexService],
   exports: [StarIndexService],

--- a/backend/src/star-index/star-index.service.ts
+++ b/backend/src/star-index/star-index.service.ts
@@ -6,6 +6,8 @@ import {
 } from '@nestjs/common';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { Cache } from 'cache-manager';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import {
   SPOT_REPOSITORY,
   type SpotRepository,
@@ -41,8 +43,13 @@ import {
   normalizeWeatherCacheEntry,
 } from '../common/weather-snapshot-display.util';
 import { CorrectionsService } from '../corrections/corrections.service';
-import { getKstYmd } from '../common/kst-date';
+import { addDaysKst, getKstYmd } from '../common/kst-date';
+import {
+  dustStationCacheKey,
+  findDustStationInCatalog,
+} from '../cache-hydration/airkorea-station.util';
 import { StarIndexCacheHydrationService } from '../cache-hydration/star-index-cache-hydration.service';
+import { SpotStarIndexDailyEntity } from '../weekly-top3/spot-star-index-daily.entity';
 
 // ── 기상 데이터 타입 ─────────────────────────────────────────
 interface WeatherData {
@@ -83,8 +90,20 @@ interface StarIndexInput {
   correctionScore?: number;
 }
 
-/** star_index:{spotId} 캐시 페이로드 — 레거시 number 캐시는 재계산 시 교체 */
-type StarIndexCachePayload = { score: number; weatherSnapshot: WeatherSnapshot };
+/** star_index:{spotId} 캐시 페이로드 — 레거시 number 캐시는 스냅샷 폴백 불가 */
+type StarIndexCachePayload = {
+  score: number;
+  weatherSnapshot: WeatherSnapshot;
+  cachedAt?: string;
+};
+
+export type StarIndexFromCacheResult = {
+  score: number;
+  weatherSnapshot: WeatherSnapshot;
+  cacheKeys: { weatherKey: string; dustKey: string; moonKey: string };
+  isStale?: boolean;
+  cachedAt?: string;
+};
 
 @Injectable()
 export class StarIndexService {
@@ -95,63 +114,41 @@ export class StarIndexService {
     @Inject(SPOT_REPOSITORY) private readonly spots: SpotRepository,
     private readonly correctionsService: CorrectionsService,
     private readonly cacheHydration: StarIndexCacheHydrationService,
+    @InjectRepository(SpotStarIndexDailyEntity)
+    private readonly dailyRepo: Repository<SpotStarIndexDailyEntity>,
   ) {}
 
   async calculateForSpotFromCache(
     spot: Spot,
     atUtc?: Date,
-  ): Promise<{
-    score: number;
-    weatherSnapshot: WeatherSnapshot;
-    cacheKeys: { weatherKey: string; dustKey: string; moonKey: string };
-  }> {
-    await this.cacheHydration.ensureForStarIndexRequest(spot.lat, spot.lng);
-
-    const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
-    const weatherKey = `weather:${nx}:${ny}`;
-    const dustKey = await this.cacheHydration.resolveDustCacheKey(
+  ): Promise<StarIndexFromCacheResult> {
+    const cacheKeys = await this.resolveInputCacheKeys(
       spot.lat,
       spot.lng,
+      spot.dustStationName,
     );
-    const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
 
-    const weather = this.readWeatherCache(
-      await this.cache.get(weatherKey),
-      atUtc,
-    );
-    const dust = this.readDustCache(await this.cache.get(dustKey));
-    const moonRaw = await this.cache.get<MoonData>(moonKey);
-
-    if (!weather || !dust || !moonRaw) {
-      throw new ServiceUnavailableException(
-        '기상·미세먼지·달 데이터를 가져오지 못했습니다. KMA_API_KEY·AIRKOREA_API_KEY와 네트워크를 확인하세요.',
+    try {
+      return await this.calculateSpotFresh(spot, cacheKeys, atUtc);
+    } catch (e) {
+      if (!(e instanceof ServiceUnavailableException)) {
+        throw e;
+      }
+      const stale = await this.readStarIndexSpotCache(spot.id);
+      if (!stale) {
+        throw e;
+      }
+      this.logger.warn(
+        `Star-Index stale fallback — spot: ${spot.id}, cachedAt: ${stale.cachedAt ?? 'unknown'}`,
       );
+      return {
+        score: stale.score,
+        weatherSnapshot: stale.weatherSnapshot,
+        cacheKeys,
+        isStale: true,
+        cachedAt: stale.cachedAt,
+      };
     }
-
-    const moon = this.resolveMoonAt(spot.lat, spot.lng, moonRaw, atUtc);
-    const correctionScore =
-      await this.correctionsService.getAggregatedCorrectionScoreForSpot(spot.id);
-
-    const { score, weatherSnapshot } = await this.getStarIndexBySpotId(
-      spot.id,
-      {
-        weather,
-        dust,
-        moon,
-        bortleClass: spot.bortleClass,
-        elevationM: spot.elevationM,
-        lat: spot.lat,
-        lng: spot.lng,
-        atUtc,
-        correctionScore,
-      },
-    );
-
-    return {
-      score,
-      weatherSnapshot,
-      cacheKeys: { weatherKey, dustKey, moonKey },
-    };
   }
 
   /**
@@ -162,19 +159,14 @@ export class StarIndexService {
     lat: number,
     lng: number,
     atUtc?: Date,
-  ): Promise<{
-    score: number;
-    weatherSnapshot: WeatherSnapshot;
-    cacheKeys: { weatherKey: string; dustKey: string; moonKey: string };
-    nearestSpot: Spot | null;
-    distanceKm: number | null;
-  }> {
-    await this.cacheHydration.ensureForStarIndexRequest(lat, lng);
-
-    const { nx, ny } = this.latLngToGrid(lat, lng);
-    const weatherKey = `weather:${nx}:${ny}`;
-    const dustKey = await this.cacheHydration.resolveDustCacheKey(lat, lng);
-    const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
+  ): Promise<
+    StarIndexFromCacheResult & {
+      nearestSpot: Spot | null;
+      distanceKm: number | null;
+    }
+  > {
+    const cacheKeys = await this.resolveInputCacheKeys(lat, lng);
+    const { weatherKey, dustKey, moonKey } = cacheKeys;
 
     const weather = this.readWeatherCache(
       await this.cache.get(weatherKey),
@@ -183,25 +175,41 @@ export class StarIndexService {
     const dust = this.readDustCache(await this.cache.get(dustKey));
     const moonRaw = await this.cache.get<MoonData>(moonKey);
 
-    if (!weather || !dust || !moonRaw) {
-      throw new ServiceUnavailableException(
-        '기상·미세먼지·달 데이터를 가져오지 못했습니다. KMA_API_KEY·AIRKOREA_API_KEY와 네트워크를 확인하세요.',
-      );
-    }
-
-    const moon = this.resolveMoonAt(lat, lng, moonRaw, atUtc);
     const nearby = await this.spots.findNearby(lat, lng, 200_000);
     const nearest = this.pickNearestSpot(lat, lng, nearby);
     const distanceKm = nearest
       ? this.haversineKm(lat, lng, nearest.lat, nearest.lng)
       : null;
 
+    if (!weather || !dust || !moonRaw) {
+      if (nearest) {
+        const stale = await this.readStarIndexSpotCache(nearest.id);
+        if (stale) {
+          this.logger.warn(
+            `Star-Index GPS stale fallback — nearest: ${nearest.id}, cachedAt: ${stale.cachedAt ?? 'unknown'}`,
+          );
+          return {
+            score: stale.score,
+            weatherSnapshot: stale.weatherSnapshot,
+            cacheKeys,
+            nearestSpot: nearest,
+            distanceKm,
+            isStale: true,
+            cachedAt: stale.cachedAt,
+          };
+        }
+      }
+      throw new ServiceUnavailableException(
+        '기상·미세먼지·달 데이터를 가져오지 못했습니다. KMA_API_KEY·AIRKOREA_API_KEY와 네트워크를 확인하세요.',
+      );
+    }
+
+    const moon = this.resolveMoonAt(lat, lng, moonRaw, atUtc);
+
     const bortleClass = nearest?.bortleClass ?? 5;
     const elevationM = nearest?.elevationM ?? 100;
     const correctionScore = nearest
-      ? await this.correctionsService.getAggregatedCorrectionScoreForSpot(
-          nearest.id,
-        )
+      ? await this.correctionScoreForSpot(nearest.id)
       : 100;
 
     const { score, weatherSnapshot } = this.calcStarIndexWithSnapshot({
@@ -219,10 +227,153 @@ export class StarIndexService {
     return {
       score,
       weatherSnapshot,
-      cacheKeys: { weatherKey, dustKey, moonKey },
+      cacheKeys,
       nearestSpot: nearest,
       distanceKm,
     };
+  }
+
+  /**
+   * 지도 클러스터 시트 — 메모리 캐시 → DB 일별 점수 → 배치 실시간 계산
+   */
+  async calculateSpotScoresBatch(
+    spots: Spot[],
+  ): Promise<{ spotId: string; score: number }[]> {
+    if (!spots.length) return [];
+
+    const scoreById = new Map<string, number>();
+    const pending: Spot[] = [];
+
+    const memCached = await Promise.all(
+      spots.map(async (spot) => ({
+        spot,
+        score: await this.readCachedSpotScoreOnly(spot.id),
+      })),
+    );
+    for (const row of memCached) {
+      if (row.score != null) {
+        scoreById.set(row.spot.id, row.score);
+      } else {
+        pending.push(row.spot);
+      }
+    }
+
+    if (pending.length) {
+      const daily = await this.fetchDailyScoresForSpots(
+        pending.map((s) => s.id),
+      );
+      const stillPending: Spot[] = [];
+      for (const spot of pending) {
+        const dayScore = daily.get(spot.id);
+        if (dayScore != null) {
+          scoreById.set(spot.id, dayScore);
+        } else {
+          stillPending.push(spot);
+        }
+      }
+      if (daily.size) {
+        void this.warmSpotScoreCaches(daily);
+      }
+      pending.length = 0;
+      pending.push(...stillPending);
+    }
+
+    if (!pending.length) {
+      return this.spotScoresMapToItems(scoreById);
+    }
+
+    await this.cacheHydration.ensureForStarIndexBatch(
+      pending.map((s) => ({
+        lat: s.lat,
+        lng: s.lng,
+        dustStationName: s.dustStationName,
+      })),
+    );
+
+    const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
+    const moonRaw = await this.cache.get<MoonData>(moonKey);
+
+    const weatherByGrid = new Map<string, WeatherData | null>();
+    const dustByKey = new Map<string, DustData | null>();
+    const spotDustKeys = new Map<string, string>();
+
+    const gridKeys = new Set<string>();
+    const catalog = await this.cacheHydration.getStationCatalogCached();
+    for (const spot of pending) {
+      const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
+      gridKeys.add(`${nx}:${ny}`);
+      if (spot.dustStationName?.trim()) {
+        spotDustKeys.set(spot.id, dustStationCacheKey(spot.dustStationName.trim()));
+        continue;
+      }
+      try {
+        const nearest = findDustStationInCatalog(catalog, spot.lat, spot.lng);
+        spotDustKeys.set(spot.id, dustStationCacheKey(nearest.stationName));
+      } catch {
+        /* dust 없으면 아래에서 stale/스킵 */
+      }
+    }
+
+    await Promise.all(
+      [...gridKeys].map(async (gridKey) => {
+        const [nx, ny] = gridKey.split(':').map(Number);
+        const raw = await this.cache.get(`weather:${nx}:${ny}`);
+        weatherByGrid.set(gridKey, this.readWeatherCache(raw));
+      }),
+    );
+
+    const uniqueDustKeys = [...new Set(spotDustKeys.values())];
+    await Promise.all(
+      uniqueDustKeys.map(async (dustKey) => {
+        dustByKey.set(dustKey, this.readDustCache(await this.cache.get(dustKey)));
+      }),
+    );
+
+    const correctionById = await this.correctionScoreForSpots(
+      pending.map((s) => s.id),
+    );
+
+    await Promise.all(
+      pending.map(async (spot) => {
+        if (scoreById.has(spot.id)) {
+          return;
+        }
+        try {
+          const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
+          const gridKey = `${nx}:${ny}`;
+          const weather = weatherByGrid.get(gridKey);
+          const dustKey = spotDustKeys.get(spot.id);
+          const dust = dustKey ? dustByKey.get(dustKey) : null;
+          if (!weather || !dust || !moonRaw) {
+            const stale = await this.readStarIndexSpotCache(spot.id);
+            if (stale) {
+              scoreById.set(spot.id, stale.score);
+            }
+            return;
+          }
+          const moon = this.resolveMoonAt(spot.lat, spot.lng, moonRaw);
+          const { score } = this.calcStarIndexWithSnapshot({
+            weather,
+            dust,
+            moon,
+            bortleClass: spot.bortleClass,
+            elevationM: spot.elevationM,
+            lat: spot.lat,
+            lng: spot.lng,
+            correctionScore: correctionById.get(spot.id) ?? 100,
+          });
+          scoreById.set(spot.id, score);
+          await this.writeSpotScoreCache(spot.id, score);
+        } catch {
+          const stale = await this.readStarIndexSpotCache(spot.id);
+          if (stale) {
+            scoreById.set(spot.id, stale.score);
+          }
+        }
+      }),
+    );
+
+    return this.spotScoresMapToItems(scoreById);
   }
 
   private pickNearestSpot(lat: number, lng: number, spots: Spot[]): Spot | null {
@@ -262,13 +413,18 @@ export class StarIndexService {
    * 일별 스냅샷·주간 TOP3 집계 등 배치용.
    */
   async computeFreshScoreFromCache(spot: Spot): Promise<number> {
-    await this.cacheHydration.ensureForStarIndexRequest(spot.lat, spot.lng);
+    await this.cacheHydration.ensureForStarIndexRequest(
+      spot.lat,
+      spot.lng,
+      spot.dustStationName,
+    );
 
     const { nx, ny } = this.latLngToGrid(spot.lat, spot.lng);
     const weatherKey = `weather:${nx}:${ny}`;
     const dustKey = await this.cacheHydration.resolveDustCacheKey(
       spot.lat,
       spot.lng,
+      spot.dustStationName,
     );
     const moonKey = `moon:${getKstYmd().replace(/-/g, '')}`;
 
@@ -285,8 +441,7 @@ export class StarIndexService {
     }
 
     const moon = this.resolveMoonAt(spot.lat, spot.lng, moonRaw);
-    const correctionScore =
-      await this.correctionsService.getAggregatedCorrectionScoreForSpot(spot.id);
+    const correctionScore = await this.correctionScoreForSpot(spot.id);
 
     const { score } = this.calcStarIndexWithSnapshot({
       weather,
@@ -308,12 +463,198 @@ export class StarIndexService {
   async getStarIndexBySpotId(
     spotId: string,
     input: StarIndexInput,
-  ): Promise<{ score: number; weatherSnapshot: WeatherSnapshot }> {
-    const cacheKey = `star_index:${spotId}`;
-    const payload = this.calcStarIndexWithSnapshot(input);
+  ): Promise<StarIndexCachePayload> {
+    const cacheKey = this.spotIndexCacheKey(spotId);
+    const computed = this.calcStarIndexWithSnapshot(input);
+    const payload: StarIndexCachePayload = {
+      ...computed,
+      cachedAt: new Date().toISOString(),
+    };
     await this.cache.set(cacheKey, payload, 3600 * 1000);
     this.logger.log(`Star-Index 계산 완료 — spot: ${spotId}, score: ${payload.score}`);
     return payload;
+  }
+
+  private spotIndexCacheKey(spotId: string): string {
+    return `star_index:${spotId}`;
+  }
+
+  /** correction_score — 지도·DIARY·GPS 동일 배치 SQL 경로 */
+  private correctionScoreForSpots(
+    spotIds: string[],
+  ): Promise<Map<string, number>> {
+    return this.correctionsService.getAggregatedCorrectionScoresForSpots(spotIds);
+  }
+
+  private async correctionScoreForSpot(spotId: string): Promise<number> {
+    const map = await this.correctionScoreForSpots([spotId]);
+    return map.get(spotId) ?? 100;
+  }
+
+  private async resolveInputCacheKeys(
+    lat: number,
+    lng: number,
+    dustStationName?: string | null,
+  ): Promise<{ weatherKey: string; dustKey: string; moonKey: string }> {
+    await this.cacheHydration.ensureForStarIndexRequest(
+      lat,
+      lng,
+      dustStationName,
+    );
+    const { nx, ny } = this.latLngToGrid(lat, lng);
+    const dustKey = await this.cacheHydration.resolveDustCacheKey(
+      lat,
+      lng,
+      dustStationName,
+    );
+    return {
+      weatherKey: `weather:${nx}:${ny}`,
+      dustKey,
+      moonKey: `moon:${getKstYmd().replace(/-/g, '')}`,
+    };
+  }
+
+  private async calculateSpotFresh(
+    spot: Spot,
+    cacheKeys: { weatherKey: string; dustKey: string; moonKey: string },
+    atUtc?: Date,
+  ): Promise<StarIndexFromCacheResult> {
+    const weather = this.readWeatherCache(
+      await this.cache.get(cacheKeys.weatherKey),
+      atUtc,
+    );
+    const dust = this.readDustCache(await this.cache.get(cacheKeys.dustKey));
+    const moonRaw = await this.cache.get<MoonData>(cacheKeys.moonKey);
+
+    if (!weather || !dust || !moonRaw) {
+      throw new ServiceUnavailableException(
+        '기상·미세먼지·달 데이터를 가져오지 못했습니다. KMA_API_KEY·AIRKOREA_API_KEY와 네트워크를 확인하세요.',
+      );
+    }
+
+    const moon = this.resolveMoonAt(spot.lat, spot.lng, moonRaw, atUtc);
+    const correctionScore = await this.correctionScoreForSpot(spot.id);
+
+    const { score, weatherSnapshot } = await this.getStarIndexBySpotId(
+      spot.id,
+      {
+        weather,
+        dust,
+        moon,
+        bortleClass: spot.bortleClass,
+        elevationM: spot.elevationM,
+        lat: spot.lat,
+        lng: spot.lng,
+        atUtc,
+        correctionScore,
+      },
+    );
+
+    return { score, weatherSnapshot, cacheKeys };
+  }
+
+  /** 지도 목록용 — 점수만 필요 */
+  private async readCachedSpotScoreOnly(spotId: string): Promise<number | null> {
+    const raw = await this.cache.get(this.spotIndexCacheKey(spotId));
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+      return raw;
+    }
+    if (raw && typeof raw === 'object') {
+      const score = Number((raw as StarIndexCachePayload).score);
+      return Number.isFinite(score) ? score : null;
+    }
+    return null;
+  }
+
+  /** DIARY·상세용 — weather_snapshot 포함 stale 폴백 */
+  private async readStarIndexSpotCache(
+    spotId: string,
+  ): Promise<StarIndexCachePayload | null> {
+    const raw = await this.cache.get(this.spotIndexCacheKey(spotId));
+    if (raw == null || typeof raw === 'number') {
+      return null;
+    }
+    const o = raw as Record<string, unknown>;
+    const score = Number(o.score);
+    const wsRaw = o.weatherSnapshot;
+    if (!Number.isFinite(score) || !wsRaw || typeof wsRaw !== 'object') {
+      return null;
+    }
+    try {
+      const weatherSnapshot = enrichWeatherSnapshotForDisplay(
+        normalizeWeatherSnapshotForStorage(wsRaw as WeatherSnapshot),
+      );
+      return {
+        score,
+        weatherSnapshot,
+        cachedAt: typeof o.cachedAt === 'string' ? o.cachedAt : undefined,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  /** spot_star_index_daily — 오늘·어제 중 최신 점수 (지도 첫 조회용) */
+  private async fetchDailyScoresForSpots(
+    spotIds: string[],
+  ): Promise<Map<string, number>> {
+    const out = new Map<string, number>();
+    const unique = [...new Set(spotIds.filter(Boolean))];
+    if (!unique.length) {
+      return out;
+    }
+
+    const today = getKstYmd();
+    const yesterday = addDaysKst(today, -1);
+    const rows = await this.dailyRepo
+      .createQueryBuilder('d')
+      .where('d.spotId IN (:...ids)', { ids: unique })
+      .andWhere('d.day IN (:...days)', { days: [today, yesterday] })
+      .orderBy('d.day', 'DESC')
+      .addOrderBy('d.spotId', 'ASC')
+      .getMany();
+
+    for (const row of rows) {
+      if (!out.has(row.spotId)) {
+        const score = Number(row.score);
+        if (Number.isFinite(score)) {
+          out.set(row.spotId, score);
+        }
+      }
+    }
+    return out;
+  }
+
+  /** DB 일별 점수 → 메모리 star_index 캐시 (다음 요청 가속) */
+  private async warmSpotScoreCaches(scores: Map<string, number>): Promise<void> {
+    const cachedAt = new Date().toISOString();
+    await Promise.all(
+      [...scores.entries()].map(([spotId, score]) =>
+        this.cache.set(
+          this.spotIndexCacheKey(spotId),
+          { score, cachedAt },
+          3600 * 1000,
+        ),
+      ),
+    );
+  }
+
+  /** 지도 배치 — 전체 스냅샷 없이 점수만 캐시 */
+  private async writeSpotScoreCache(spotId: string, score: number): Promise<void> {
+    await this.cache.set(
+      this.spotIndexCacheKey(spotId),
+      { score, cachedAt: new Date().toISOString() },
+      3600 * 1000,
+    );
+  }
+
+  private spotScoresMapToItems(
+    scoreById: Map<string, number>,
+  ): { spotId: string; score: number }[] {
+    return [...scoreById.entries()].map(([spotId, score]) => ({
+      spotId,
+      score,
+    }));
   }
 
   /** 최종 점수만 필요할 때 */

--- a/backend/src/star-index/star-index.service.ts
+++ b/backend/src/star-index/star-index.service.ts
@@ -91,6 +91,9 @@ interface StarIndexInput {
 }
 
 /** star_index:{spotId} 캐시 페이로드 — 레거시 number 캐시는 스냅샷 폴백 불가 */
+/** FE star-index-display.ts 와 동일 — 이 미만이면 UI 「측정불가」 */
+const STAR_INDEX_DISPLAY_MIN_SCORE = 50;
+
 type StarIndexCachePayload = {
   score: number;
   weatherSnapshot: WeatherSnapshot;
@@ -142,7 +145,12 @@ export class StarIndexService {
         `Star-Index stale fallback — spot: ${spot.id}, cachedAt: ${stale.cachedAt ?? 'unknown'}`,
       );
       return {
-        score: stale.score,
+        score: this.recalcScoreFromWeatherSnapshot(
+          stale.weatherSnapshot,
+          spot.lat,
+          spot.lng,
+          atUtc,
+        ),
         weatherSnapshot: stale.weatherSnapshot,
         cacheKeys,
         isStale: true,
@@ -189,7 +197,12 @@ export class StarIndexService {
             `Star-Index GPS stale fallback — nearest: ${nearest.id}, cachedAt: ${stale.cachedAt ?? 'unknown'}`,
           );
           return {
-            score: stale.score,
+            score: this.recalcScoreFromWeatherSnapshot(
+              stale.weatherSnapshot,
+              lat,
+              lng,
+              atUtc,
+            ),
             weatherSnapshot: stale.weatherSnapshot,
             cacheKeys,
             nearestSpot: nearest,
@@ -247,7 +260,7 @@ export class StarIndexService {
     const memCached = await Promise.all(
       spots.map(async (spot) => ({
         spot,
-        score: await this.readCachedSpotScoreOnly(spot.id),
+        score: await this.readCachedSpotScoreForMap(spot),
       })),
     );
     for (const row of memCached) {
@@ -265,14 +278,11 @@ export class StarIndexService {
       const stillPending: Spot[] = [];
       for (const spot of pending) {
         const dayScore = daily.get(spot.id);
-        if (dayScore != null) {
+        if (dayScore != null && !this.shouldSkipDailyScoreForMap(spot, dayScore)) {
           scoreById.set(spot.id, dayScore);
         } else {
           stillPending.push(spot);
         }
-      }
-      if (daily.size) {
-        void this.warmSpotScoreCaches(daily);
       }
       pending.length = 0;
       pending.push(...stillPending);
@@ -347,12 +357,19 @@ export class StarIndexService {
           if (!weather || !dust || !moonRaw) {
             const stale = await this.readStarIndexSpotCache(spot.id);
             if (stale) {
-              scoreById.set(spot.id, stale.score);
+              scoreById.set(
+                spot.id,
+                this.recalcScoreFromWeatherSnapshot(
+                  stale.weatherSnapshot,
+                  spot.lat,
+                  spot.lng,
+                ),
+              );
             }
             return;
           }
           const moon = this.resolveMoonAt(spot.lat, spot.lng, moonRaw);
-          const { score } = this.calcStarIndexWithSnapshot({
+          const payload = this.calcStarIndexWithSnapshot({
             weather,
             dust,
             moon,
@@ -362,12 +379,19 @@ export class StarIndexService {
             lng: spot.lng,
             correctionScore: correctionById.get(spot.id) ?? 100,
           });
-          scoreById.set(spot.id, score);
-          await this.writeSpotScoreCache(spot.id, score);
+          scoreById.set(spot.id, payload.score);
+          await this.writeSpotScoreCache(spot.id, payload);
         } catch {
           const stale = await this.readStarIndexSpotCache(spot.id);
           if (stale) {
-            scoreById.set(spot.id, stale.score);
+            scoreById.set(
+              spot.id,
+              this.recalcScoreFromWeatherSnapshot(
+                stale.weatherSnapshot,
+                spot.lat,
+                spot.lng,
+              ),
+            );
           }
         }
       }),
@@ -412,7 +436,11 @@ export class StarIndexService {
    * `star_index:{spotId}` 캐시를 보지 않고, 현재 weather/dust/moon 캐시만으로 점수 계산.
    * 일별 스냅샷·주간 TOP3 집계 등 배치용.
    */
-  async computeFreshScoreFromCache(spot: Spot): Promise<number> {
+  /**
+   * 일별 스냅샷·알림·TOP3 집계용 — weather_snapshot 포함 캐시 저장
+   * (score만 저장하면 지도 읽기 시 태양 고도 재반영 불가)
+   */
+  async computeFreshPayloadFromCache(spot: Spot): Promise<StarIndexCachePayload> {
     await this.cacheHydration.ensureForStarIndexRequest(
       spot.lat,
       spot.lng,
@@ -443,7 +471,7 @@ export class StarIndexService {
     const moon = this.resolveMoonAt(spot.lat, spot.lng, moonRaw);
     const correctionScore = await this.correctionScoreForSpot(spot.id);
 
-    const { score } = this.calcStarIndexWithSnapshot({
+    const payload = this.calcStarIndexWithSnapshot({
       weather,
       dust,
       moon,
@@ -453,7 +481,12 @@ export class StarIndexService {
       lng: spot.lng,
       correctionScore,
     });
-    return score;
+    await this.writeSpotScoreCache(spot.id, payload);
+    return { ...payload, cachedAt: new Date().toISOString() };
+  }
+
+  async computeFreshScoreFromCache(spot: Spot): Promise<number> {
+    return (await this.computeFreshPayloadFromCache(spot)).score;
   }
 
   /**
@@ -553,17 +586,64 @@ export class StarIndexService {
     return { score, weatherSnapshot, cacheKeys };
   }
 
-  /** 지도 목록용 — 점수만 필요 */
-  private async readCachedSpotScoreOnly(spotId: string): Promise<number | null> {
-    const raw = await this.cache.get(this.spotIndexCacheKey(spotId));
+  /**
+   * 지도 목록용 — weather_snapshot 이 있으면 현재 시각 태양 고도로 재합산
+   * (낮에 저장된 점수만 쓰면 밤에도 측정불가로 보이는 문제 방지)
+   */
+  private async readCachedSpotScoreForMap(spot: Spot): Promise<number | null> {
+    const stale = await this.readStarIndexSpotCache(spot.id);
+    if (stale?.weatherSnapshot) {
+      return this.recalcScoreFromWeatherSnapshot(
+        stale.weatherSnapshot,
+        spot.lat,
+        spot.lng,
+      );
+    }
+    const raw = await this.cache.get(this.spotIndexCacheKey(spot.id));
     if (typeof raw === 'number' && Number.isFinite(raw)) {
-      return raw;
+      return null;
     }
     if (raw && typeof raw === 'object') {
-      const score = Number((raw as StarIndexCachePayload).score);
-      return Number.isFinite(score) ? score : null;
+      const o = raw as Record<string, unknown>;
+      if (o.weatherSnapshot && typeof o.weatherSnapshot === 'object') {
+        return null;
+      }
+      const score = Number(o.score);
+      if (Number.isFinite(score)) {
+        return null;
+      }
     }
     return null;
+  }
+
+  /** 일별 DB 점수 — 밤인데 낮 기준 측정불가면 실시간 계산으로 넘김 */
+  private shouldSkipDailyScoreForMap(spot: Spot, dayScore: number): boolean {
+    if (dayScore >= STAR_INDEX_DISPLAY_MIN_SCORE) {
+      return false;
+    }
+    const sunAlt = sunAltitudeAtObserver(spot.lat, spot.lng, new Date());
+    return sunAlt < -12;
+  }
+
+  /** 캐시된 10변수 스냅샷 + 현재 태양 고도로 최종 점수 재계산 */
+  private recalcScoreFromWeatherSnapshot(
+    snapshot: WeatherSnapshot,
+    lat: number,
+    lng: number,
+    atUtc?: Date,
+  ): number {
+    const sunAltDeg = sunAltitudeAtObserver(lat, lng, atUtc ?? new Date());
+    const cloudPercent =
+      snapshot.cloud_cover_pct ??
+      Math.min(100, Math.max(0, 100 - Math.round(snapshot.cloud_score)));
+    return aggregateStarIndexScore({
+      components: snapshot,
+      cloudPercent,
+      sunAltitudeDeg: sunAltDeg,
+      pop: snapshot.precipitation_probability ?? 0,
+      pty: snapshot.precipitation_type ?? 0,
+      visibilityKnown: snapshot.visibility_known === true,
+    });
   }
 
   /** DIARY·상세용 — weather_snapshot 포함 stale 폴백 */
@@ -625,25 +705,14 @@ export class StarIndexService {
     return out;
   }
 
-  /** DB 일별 점수 → 메모리 star_index 캐시 (다음 요청 가속) */
-  private async warmSpotScoreCaches(scores: Map<string, number>): Promise<void> {
-    const cachedAt = new Date().toISOString();
-    await Promise.all(
-      [...scores.entries()].map(([spotId, score]) =>
-        this.cache.set(
-          this.spotIndexCacheKey(spotId),
-          { score, cachedAt },
-          3600 * 1000,
-        ),
-      ),
-    );
-  }
-
-  /** 지도 배치 — 전체 스냅샷 없이 점수만 캐시 */
-  private async writeSpotScoreCache(spotId: string, score: number): Promise<void> {
+  /** 지도 배치 — weather_snapshot 포함 저장 (읽을 때 태양 고도 재반영) */
+  private async writeSpotScoreCache(
+    spotId: string,
+    payload: StarIndexCachePayload,
+  ): Promise<void> {
     await this.cache.set(
       this.spotIndexCacheKey(spotId),
-      { score, cachedAt: new Date().toISOString() },
+      { ...payload, cachedAt: new Date().toISOString() },
       3600 * 1000,
     );
   }

--- a/backend/src/weekly-top3/weekly-top3-aggregation.service.ts
+++ b/backend/src/weekly-top3/weekly-top3-aggregation.service.ts
@@ -47,15 +47,10 @@ export class WeeklyTop3AggregationService {
 
     for (const spot of all) {
       try {
-        const score = await this.starIndex.computeFreshScoreFromCache(spot);
+        const payload = await this.starIndex.computeFreshPayloadFromCache(spot);
         await this.dailyRepo.upsert(
-          { spotId: spot.id, day, score },
+          { spotId: spot.id, day, score: payload.score },
           ['spotId', 'day'],
-        );
-        await this.cache.set(
-          `star_index:${spot.id}`,
-          { score, cachedAt: new Date().toISOString() },
-          3600 * 1000,
         );
         ok++;
       } catch (e) {

--- a/backend/src/weekly-top3/weekly-top3-aggregation.service.ts
+++ b/backend/src/weekly-top3/weekly-top3-aggregation.service.ts
@@ -52,6 +52,11 @@ export class WeeklyTop3AggregationService {
           { spotId: spot.id, day, score },
           ['spotId', 'day'],
         );
+        await this.cache.set(
+          `star_index:${spot.id}`,
+          { score, cachedAt: new Date().toISOString() },
+          3600 * 1000,
+        );
         ok++;
       } catch (e) {
         failed++;

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -513,7 +513,7 @@ function AppContent({ onResetOnboarding }: { onResetOnboarding: () => void }) {
             items={[
               { key: 'sky', label: 'SKY', icon: 'sky', redIcon: '◉' },
               { key: 'map', label: 'MAP', icon: 'map', redIcon: '◈' },
-              { key: 'records', label: 'LOG', icon: 'log', redIcon: '≡' },
+              { key: 'records', label: 'DIARY', icon: 'log', redIcon: '≡' },
               { key: 'profile', label: 'ME', icon: 'me', redIcon: '○' },
             ]}
           />

--- a/frontend/components/records/DiarySegmentTabs.tsx
+++ b/frontend/components/records/DiarySegmentTabs.tsx
@@ -1,0 +1,117 @@
+/**
+ * DIARY 화면 — 작성 | 펼쳐보기 | 명소 등록 (구분선 탭)
+ */
+
+import React, { Fragment } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { spacing } from '../../themes/design-tokens';
+import { useTheme } from '../../themes/ThemeContext';
+
+export type DiarySectionKey = 'write' | 'browse' | 'register-spot';
+
+interface DiarySegmentTabsProps {
+  active: DiarySectionKey;
+  onChange: (key: DiarySectionKey) => void;
+}
+
+const SECTIONS: { key: DiarySectionKey; label: string; accessibilityLabel: string }[] = [
+  { key: 'write', label: 'DIARY 작성', accessibilityLabel: 'DIARY 작성' },
+  { key: 'browse', label: '펼쳐보기', accessibilityLabel: 'DIARY 펼쳐보기' },
+  { key: 'register-spot', label: '명소 등록', accessibilityLabel: '명소 등록하기' },
+];
+
+export function DiarySegmentTabs({ active, onChange }: DiarySegmentTabsProps) {
+  const { theme } = useTheme();
+
+  return (
+    <View style={[styles.bar, { borderBottomColor: theme.cardBorder }]}>
+      {SECTIONS.map((section, index) => {
+        const isActive = active === section.key;
+        return (
+          <Fragment key={section.key}>
+            {index > 0 ? (
+              <Text style={[styles.pipe, { color: theme.cardBorder }]}>|</Text>
+            ) : null}
+            <Pressable
+              onPress={() => onChange(section.key)}
+              style={({ pressed }) => [styles.tab, pressed && styles.tabPressed]}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: isActive }}
+              accessibilityLabel={section.accessibilityLabel}
+            >
+              <Text
+                style={[
+                  styles.label,
+                  {
+                    color: isActive ? theme.primaryGlow : theme.mutedForeground,
+                    fontWeight: isActive ? '600' : '500',
+                  },
+                ]}
+                numberOfLines={2}
+              >
+                {section.label}
+              </Text>
+              {isActive ? (
+                <View
+                  style={[
+                    styles.activeLine,
+                    {
+                      backgroundColor: theme.primaryGlow,
+                      shadowColor: theme.primaryGlow,
+                    },
+                  ]}
+                />
+              ) : null}
+            </Pressable>
+          </Fragment>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    marginBottom: spacing.lg,
+  },
+  pipe: {
+    alignSelf: 'center',
+    fontSize: 13,
+    fontWeight: '300',
+    lineHeight: 16,
+    marginHorizontal: 2,
+    opacity: 0.75,
+  },
+  tab: {
+    flex: 1,
+    minHeight: 46,
+    paddingVertical: 10,
+    paddingHorizontal: 6,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tabPressed: {
+    opacity: 0.88,
+  },
+  label: {
+    fontSize: 12,
+    textAlign: 'center',
+    lineHeight: 16,
+    letterSpacing: 0.15,
+  },
+  activeLine: {
+    position: 'absolute',
+    bottom: 0,
+    left: '14%',
+    right: '14%',
+    height: 2,
+    borderRadius: 1,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.55,
+    shadowRadius: 6,
+    elevation: 2,
+  },
+});

--- a/frontend/components/records/RecordsTabScreen.tsx
+++ b/frontend/components/records/RecordsTabScreen.tsx
@@ -14,6 +14,7 @@ import { Button, Card } from '../ui';
 import { spotNameWithoutRegionPrefix, spotRegionSubtitle } from '../../lib/spot-display-name';
 import { fetchSpotsAll } from '../../lib/spots-api';
 import type { SpotDto } from '../../lib/types/api';
+import { DiarySegmentTabs, type DiarySectionKey } from './DiarySegmentTabs';
 import { ObservationLogCard } from './ObservationLogCard';
 import {
   ApiRequestError,
@@ -26,6 +27,10 @@ import {
 } from '../../lib/api-client';
 import type { StarIndexResponseDto } from '../../lib/types/api';
 import { getStarIndexScoreDisplay } from '../../lib/star-index-display';
+import {
+  formatStarIndexStaleHint,
+  starIndexLoadErrorMessage,
+} from '../../lib/star-index-stale';
 
 interface RecordsTabScreenProps {
   /** 홈·지도와 동일한 기준 명소 UUID (없으면 기록 불가 안내) */
@@ -46,6 +51,7 @@ export function RecordsTabScreen({
   onSessionInvalidated,
 }: RecordsTabScreenProps) {
   const { theme } = useTheme();
+  const [diarySection, setDiarySection] = useState<DiarySectionKey>('write');
   const [list, setList] = useState<ObservationRowDto[]>([]);
   const [listLoading, setListLoading] = useState(true);
   const [listErr, setListErr] = useState<string | null>(null);
@@ -178,12 +184,7 @@ export function RecordsTabScreen({
         return;
       }
       if (e instanceof ApiRequestError) {
-        const base = e.message;
-        setSiErr(
-          e.status === 503
-            ? `${base} (캐시 미준비 시 Swagger → POST /cron/run-once 후 다시 시도)`
-            : base,
-        );
+        setSiErr(starIndexLoadErrorMessage(e));
       } else {
         setSiErr('Star-Index를 불러오지 못했습니다.');
       }
@@ -292,131 +293,160 @@ export function RecordsTabScreen({
         별자리 촬영 히스토리 · Star-Index 스냅샷으로 저장합니다.
       </Text>
 
-      {!canLoadStarIndex ? (
-        <Card title="위치·명소 필요" description="위치 권한을 허용하거나 지도에서 명소를 고르세요">
-          <Text style={{ color: theme.mutedForeground, fontSize: 13 }}>
-            GPS가 켜지면 현재 위치 격자로 Star-Index를 불러옵니다. 없으면 EXPO_PUBLIC_DEFAULT_SPOT_ID
-            또는 지도 마커로 명소를 정할 수 있어요.
+      <DiarySegmentTabs active={diarySection} onChange={setDiarySection} />
+
+      {diarySection === 'write' ? (
+        <>
+          {!canLoadStarIndex ? (
+            <Card title="위치·명소 필요" description="위치 권한을 허용하거나 지도에서 명소를 고르세요">
+              <Text style={{ color: theme.mutedForeground, fontSize: 13 }}>
+                GPS가 켜지면 현재 위치 격자로 Star-Index를 불러옵니다. 없으면 EXPO_PUBLIC_DEFAULT_SPOT_ID
+                또는 지도 마커로 명소를 정할 수 있어요.
+              </Text>
+            </Card>
+          ) : (
+            <Card
+              title="현재 Star-Index"
+              description={
+                siPlaceLabel
+                  ? `${siPlaceLabel} 기준`
+                  : siData?.name ?? 'GPS·격자 기준으로 불러옵니다'
+              }
+            >
+              {siLoading ? (
+                <ActivityIndicator color={theme.primaryGlow} />
+              ) : siErr ? (
+                <Text style={{ color: theme.destructive }}>{siErr}</Text>
+              ) : siData ? (
+                <View>
+                  {(() => {
+                    const si = getStarIndexScoreDisplay(siData.score);
+                    return (
+                      <Text
+                        style={{
+                          color: si.measurable ? theme.primaryGlow : theme.destructive,
+                          fontSize: si.measurable ? 28 : 20,
+                          fontWeight: '300',
+                        }}
+                      >
+                        {si.label}
+                      </Text>
+                    );
+                  })()}
+                  <Text style={{ color: theme.mutedForeground, fontSize: 12, marginTop: 6 }}>
+                    {(siPlaceLabel ?? siData.name) +
+                      ` · 구름 ${siData.weatherSnapshot.cloud_score}`}
+                  </Text>
+                  {siData.isStale ? (
+                    <Text
+                      style={{
+                        color: theme.primaryGlow,
+                        fontSize: 11,
+                        marginTop: 8,
+                        lineHeight: 16,
+                      }}
+                    >
+                      {formatStarIndexStaleHint(siData.cachedAt)}
+                    </Text>
+                  ) : null}
+                </View>
+              ) : null}
+              <View style={{ marginTop: 8 }}>
+                <Button
+                  label="다시 불러오기"
+                  variant="outline"
+                  size="sm"
+                  onPress={() => void loadSi()}
+                  disabled={siLoading}
+                />
+              </View>
+            </Card>
+          )}
+
+          <Card
+            title="새 기록"
+            description={
+              siData?.isStale
+                ? '참고 점수·스냅샷으로 저장 (실시간 기상 캐시 없음)'
+                : '결과 선택 후 저장'
+            }
+          >
+            <View style={styles.row}>
+              {(
+                [
+                  ['success', '성공'],
+                  ['partial', '부분'],
+                  ['fail', '실패'],
+                ] as const
+              ).map(([key, label]) => (
+                <Button
+                  key={key}
+                  label={label}
+                  variant={result === key ? 'primary' : 'outline'}
+                  size="sm"
+                  onPress={() => setResult(key)}
+                />
+              ))}
+            </View>
+            <View style={{ marginTop: 12 }}>
+              <Button
+                label="이 스냅샷으로 저장"
+                fullWidth
+                loading={saveBusy}
+                disabled={!siData || saveBusy}
+                onPress={() => void onSave()}
+              />
+            </View>
+            {saveMsg ? (
+              <Text style={{ color: theme.mutedForeground, marginTop: 8, fontSize: 12 }}>
+                {saveMsg}
+              </Text>
+            ) : null}
+          </Card>
+        </>
+      ) : null}
+
+      {diarySection === 'register-spot' ? (
+        <Card
+          title="명소가 목록에 없나요?"
+          description="추후 GPS 또는 지역 선택으로 새 명소를 제안·등록할 수 있게 준비 중입니다."
+        >
+          <Text style={{ color: theme.mutedForeground, fontSize: 13, lineHeight: 19 }}>
+            DB에 없는 관측지도 커뮤니티와 함께 채워 나갈 예정이에요.
           </Text>
         </Card>
-      ) : (
-        <Card
-          title="현재 Star-Index"
-          description={
-            siPlaceLabel
-              ? `${siPlaceLabel} 기준`
-              : siData?.name ?? 'GPS·격자 기준으로 불러옵니다'
-          }
-        >
-          {siLoading ? (
+      ) : null}
+
+      {diarySection === 'browse' ? (
+        <Card title="내 기록" description={listLoading ? '불러오는 중…' : `${list.length}건`}>
+          {listLoading ? (
             <ActivityIndicator color={theme.primaryGlow} />
-          ) : siErr ? (
-            <Text style={{ color: theme.destructive }}>{siErr}</Text>
-          ) : siData ? (
-            <View>
-              {(() => {
-                const si = getStarIndexScoreDisplay(siData.score);
+          ) : listErr ? (
+            <Text style={{ color: theme.destructive }}>{listErr}</Text>
+          ) : list.length === 0 ? (
+            <Text style={{ color: theme.mutedForeground, fontSize: 13 }}>기록이 없습니다.</Text>
+          ) : (
+            <View style={styles.logList}>
+              {list.map((row) => {
+                const labels = resolveLogCardLabels(row);
                 return (
-                  <Text
-                    style={{
-                      color: si.measurable ? theme.primaryGlow : theme.destructive,
-                      fontSize: si.measurable ? 28 : 20,
-                      fontWeight: '300',
-                    }}
-                  >
-                    {si.label}
-                  </Text>
+                  <ObservationLogCard
+                    key={row.id}
+                    row={row}
+                    title={labels.title}
+                    regionSubtitle={labels.regionSubtitle}
+                  />
                 );
-              })()}
-              <Text style={{ color: theme.mutedForeground, fontSize: 12, marginTop: 6 }}>
-                {(siPlaceLabel ?? siData.name) +
-                  ` · 구름 ${siData.weatherSnapshot.cloud_score}`}
-              </Text>
+              })}
+            </View>
+          )}
+          {!listLoading ? (
+            <View style={{ marginTop: 8 }}>
+              <Button label="목록 새로고침" variant="ghost" size="sm" onPress={() => void loadList()} />
             </View>
           ) : null}
-          <View style={{ marginTop: 8 }}>
-            <Button
-              label="다시 불러오기"
-              variant="outline"
-              size="sm"
-              onPress={() => void loadSi()}
-              disabled={siLoading}
-            />
-          </View>
         </Card>
-      )}
-
-      <Card title="새 기록" description="결과 선택 후 저장">
-        <View style={styles.row}>
-          {(
-            [
-              ['success', '성공'],
-              ['partial', '부분'],
-              ['fail', '실패'],
-            ] as const
-          ).map(([key, label]) => (
-            <Button
-              key={key}
-              label={label}
-              variant={result === key ? 'primary' : 'outline'}
-              size="sm"
-              onPress={() => setResult(key)}
-            />
-          ))}
-        </View>
-        <View style={{ marginTop: 12 }}>
-          <Button
-            label="이 스냅샷으로 저장"
-            fullWidth
-            loading={saveBusy}
-            disabled={!siData || saveBusy}
-            onPress={() => void onSave()}
-          />
-        </View>
-        {saveMsg ? (
-          <Text style={{ color: theme.mutedForeground, marginTop: 8, fontSize: 12 }}>
-            {saveMsg}
-          </Text>
-        ) : null}
-      </Card>
-
-      <Card
-        title="명소가 목록에 없나요?"
-        description="추후 GPS 또는 지역 선택으로 새 명소를 제안·등록할 수 있게 준비 중입니다."
-      >
-        <Text style={{ color: theme.mutedForeground, fontSize: 13, lineHeight: 19 }}>
-          DB에 없는 관측지도 커뮤니티와 함께 채워 나갈 예정이에요.
-        </Text>
-      </Card>
-
-      <Card title="내 기록" description={listLoading ? '불러오는 중…' : `${list.length}건`}>
-        {listLoading ? (
-          <ActivityIndicator color={theme.primaryGlow} />
-        ) : listErr ? (
-          <Text style={{ color: theme.destructive }}>{listErr}</Text>
-        ) : list.length === 0 ? (
-          <Text style={{ color: theme.mutedForeground, fontSize: 13 }}>기록이 없습니다.</Text>
-        ) : (
-          <View style={styles.logList}>
-            {list.map((row) => {
-              const labels = resolveLogCardLabels(row);
-              return (
-                <ObservationLogCard
-                  key={row.id}
-                  row={row}
-                  title={labels.title}
-                  regionSubtitle={labels.regionSubtitle}
-                />
-              );
-            })}
-          </View>
-        )}
-        {!listLoading ? (
-          <View style={{ marginTop: 8 }}>
-            <Button label="목록 새로고침" variant="ghost" size="sm" onPress={() => void loadList()} />
-          </View>
-        ) : null}
-      </Card>
+      ) : null}
     </ScrollView>
   );
 }

--- a/frontend/lib/star-index-stale.ts
+++ b/frontend/lib/star-index-stale.ts
@@ -1,0 +1,32 @@
+/** Star-Index stale(직전 캐시) 표시 문구 */
+
+export function formatStarIndexStaleHint(cachedAt?: string): string {
+  if (!cachedAt?.trim()) {
+    return '참고 · 직전 계산값 (실시간 기상 캐시 없음)';
+  }
+  const t = Date.parse(cachedAt);
+  if (!Number.isFinite(t)) {
+    return '참고 · 직전 계산값';
+  }
+  const mins = Math.max(1, Math.round((Date.now() - t) / 60_000));
+  if (mins < 60) {
+    return `참고 · ${mins}분 전 계산값`;
+  }
+  const hours = Math.round(mins / 60);
+  if (hours < 24) {
+    return `참고 · 약 ${hours}시간 전 계산값`;
+  }
+  return '참고 · 직전 계산값';
+}
+
+export function starIndexLoadErrorMessage(e: unknown): string {
+  if (e && typeof e === 'object' && 'status' in e && 'message' in e) {
+    const status = (e as { status: number }).status;
+    const message = String((e as { message: string }).message);
+    if (status === 503) {
+      return '실시간 기상 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.';
+    }
+    return message;
+  }
+  return 'Star-Index를 불러오지 못했습니다.';
+}

--- a/frontend/lib/types/api.ts
+++ b/frontend/lib/types/api.ts
@@ -41,6 +41,10 @@ export interface StarIndexResponseDto {
   cacheKeys: { weatherKey: string; dustKey: string; moonKey: string };
   message: string;
   requestedBy: string;
+  /** 실시간 캐시 실패 시 직전 star_index:{spotId} 폴백 */
+  isStale?: boolean;
+  cachedAt?: string;
+  source?: 'live' | 'stale_cache';
 }
 
 export interface UserProfileDto {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "StarChaser",
+  "name": "starchaser",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}


### PR DESCRIPTION
## 🔎 What

**Frontend**
- 하단 탭 LOG → DIARY
- RecordsTabScreen: 세그먼트 DIARY 작성 | 펼쳐보기 | 명소 등록 (`DiarySegmentTabs`)
- Star-Index stale 표시 (`isStale`, `cachedAt`, 참고 문구) 및 503 사용자 메시지 정리
- `StarIndexResponseDto`에 `isStale`, `source` 등 필드 추가

**Backend — Star-Index**
- 실시간 캐시 실패 시 `star_index:{spotId}` stale 폴백 (GPS는 최근접 명소 캐시)
- `calculateSpotScoresBatch`: 메모리 캐시 → `spot_star_index_daily` → 배치 계산
- **지도 캐시 읽기**: `weather_snapshot` 있으면 **현재 태양 고도로 재합산** (낮 점수가 밤에도 측정불가로 남던 문제)
- **일별 DB**: 밤 + 점수 &lt; 50이면 일별 점수 건너뛰고 실시간 계산
- **레거시 score-only 캐시**는 재합산 불가 → 실시간/일별 경로로 우회
- 지도·배치 캐시 저장 시 `weather_snapshot` 포함 (`writeSpotScoreCache`)

**Backend — PM2.5 / dust**
- 측정소 카탈로그 시도당 대표 2곳 (`pickRepresentativeStations`)
- dust 수집: `getCtprvnRltmMesureDnsty` 시도당 1회 (`fetchAndStoreDustForSido`)
- `findDustStationInCatalog` (역지오 없음, 지도·DIARY·시드 공통)
- `spots.dust_station_name` 컬럼 + 마이그레이션 `1750000000000-add-spots-dust-station-name`
- 시드·기존 명소 `dust_station_name` 백필

**Backend — 기타**
- `ensureForStarIndexBatch` / GPS `ensure` 중복 제거
- `correctionScoreForSpots`로 보정 점수 배치 SQL 통일
- TOP3/일별 cron: `computeFreshPayloadFromCache`로 **스냅샷 포함** `star_index` 캐시 저장 (score-only 덮어쓰기 제거)

## 🔗 Issue

* closes: #88

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요? (`develop`)
* [x] 제목이 이슈 제목과 동일한가요?
* [ ] 최소 1명의 리뷰를 받았나요?

## Test plan

- [ ] 마이그레이션 `1750000000000-add-spots-dust-station-name` 적용 후 `spots.seed` 백필
- [ ] 백엔드 재시작 → `POST /cron/run-once` (기상·dust·일별 스냅샷)
- [ ] DIARY 작성 탭: Star-Index 로드·stale 문구·저장
- [ ] 지도 클러스터: 밤 시간대 점수/측정불가가 격자별 구름(SKY)과 일치하는지 확인
- [ ] 구름많음 격자는 측정불가, 맑음/구름조금 격자는 숫자 표시 가능 (의도된 gate)
