### PR TITLE
feat: DIARY 일기 UX·명소 제보·불일치 제보 및 관리자 대시보드

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,7 +7,7 @@
 DATABASE_URL=postgresql://postgres:[PASSWORD]@db.[PROJECT].supabase.co:5432/postgres
 
 # Supabase Storage (프로필 사진) — Dashboard → Settings → API
-# 버킷 avatars 생성, Public bucket 체크
+# 버킷 avatars, diary-photos 생성, Public bucket 체크
 SUPABASE_URL=https://[PROJECT].supabase.co
 SUPABASE_SERVICE_ROLE_KEY=service_role_...
 
@@ -20,6 +20,9 @@ JWT_SECRET=최소_32자_이상_랜덤_문자열_입력
 JWT_REFRESH_SECRET=최소_32자_이상_다른_랜덤_문자열
 JWT_EXPIRES_IN=1h
 JWT_REFRESH_EXPIRES_IN=30d
+
+# 관리자 (불일치 제보 대시보드) — 쉼표로 여러 이메일
+ADMIN_EMAILS=you@example.com
 
 # 기상청 단기예보 API
 KMA_API_KEY=

--- a/backend/admin/observation-reports.html
+++ b/backend/admin/observation-reports.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>StarChaser — 불일치 제보 관리</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #030712;
+      --card: rgba(8, 15, 30, 0.92);
+      --border: rgba(255, 255, 255, 0.1);
+      --text: #f8fafc;
+      --muted: #94a3b8;
+      --accent: #8ddcff;
+      --danger: #ef4444;
+      --ok: #34d399;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+    }
+    .wrap { max-width: 960px; margin: 0 auto; padding: 24px 16px 48px; }
+    h1 { font-size: 22px; margin: 0 0 6px; }
+    .sub { color: var(--muted); font-size: 13px; margin-bottom: 20px; }
+    .panel {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+    label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+    input, select, textarea, button {
+      font: inherit;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: rgba(15, 23, 42, 0.6);
+      color: var(--text);
+      padding: 10px 12px;
+    }
+    input, select { width: 100%; }
+    textarea { width: 100%; min-height: 72px; resize: vertical; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+    .actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+    button {
+      cursor: pointer;
+      background: rgba(141, 220, 255, 0.12);
+      border-color: rgba(141, 220, 255, 0.35);
+    }
+    button.primary { color: var(--accent); }
+    button.danger { color: var(--danger); border-color: rgba(239,68,68,.4); background: rgba(239,68,68,.08); }
+    button:disabled { opacity: .45; cursor: not-allowed; }
+    .err { color: var(--danger); font-size: 12px; margin-top: 8px; }
+    .ok { color: var(--ok); font-size: 12px; margin-top: 8px; }
+    .report {
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px;
+      margin-bottom: 10px;
+    }
+    .report h3 { margin: 0 0 6px; font-size: 15px; }
+    .meta { font-size: 12px; color: var(--muted); }
+    .badge {
+      display: inline-block;
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      margin-right: 6px;
+    }
+    .badge.pending { color: #fbbf24; border-color: rgba(251,191,36,.4); }
+    .badge.reviewed { color: var(--ok); border-color: rgba(52,211,153,.4); }
+    .stats { display: flex; gap: 8px; flex-wrap: wrap; margin: 8px 0; }
+    .stat {
+      font-size: 12px;
+      padding: 4px 8px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+    }
+    @media (max-width: 640px) { .row { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>불일치 제보 관리</h1>
+    <p class="sub">Star-Index와 관측 결과가 맞지 않다고 사용자가 제보한 일기 목록입니다.</p>
+
+    <div class="panel" id="loginPanel">
+      <div class="row">
+        <div>
+          <label>API Base URL</label>
+          <input id="apiBase" placeholder="http://localhost:3333" />
+        </div>
+        <div>
+          <label>상태 필터</label>
+          <select id="statusFilter">
+            <option value="">전체</option>
+            <option value="pending" selected>대기</option>
+            <option value="reviewed">처리 완료</option>
+          </select>
+        </div>
+      </div>
+      <div class="row" style="margin-top:10px">
+        <div>
+          <label>관리자 이메일</label>
+          <input id="email" type="email" autocomplete="username" />
+        </div>
+        <div>
+          <label>비밀번호</label>
+          <input id="password" type="password" autocomplete="current-password" />
+        </div>
+      </div>
+      <div class="actions">
+        <button class="primary" id="loginBtn">로그인 후 불러오기</button>
+        <button id="refreshBtn" disabled>새로고침</button>
+      </div>
+      <div id="loginMsg"></div>
+    </div>
+
+    <div id="list"></div>
+  </div>
+
+  <script>
+    const STORAGE_KEY = 'starchaser_admin_token';
+    const apiBaseInput = document.getElementById('apiBase');
+    const statusFilter = document.getElementById('statusFilter');
+    const emailInput = document.getElementById('email');
+    const passwordInput = document.getElementById('password');
+    const loginBtn = document.getElementById('loginBtn');
+    const refreshBtn = document.getElementById('refreshBtn');
+    const loginMsg = document.getElementById('loginMsg');
+    const listEl = document.getElementById('list');
+
+    apiBaseInput.value = localStorage.getItem('starchaser_admin_api') || window.location.origin;
+
+    function setMsg(el, text, ok) {
+      el.textContent = text || '';
+      el.className = ok ? 'ok' : 'err';
+    }
+
+    function token() {
+      return localStorage.getItem(STORAGE_KEY);
+    }
+
+    async function login() {
+      const base = apiBaseInput.value.replace(/\/$/, '');
+      localStorage.setItem('starchaser_admin_api', base);
+      setMsg(loginMsg, '로그인 중…', true);
+      const res = await fetch(base + '/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({
+          email: emailInput.value.trim(),
+          password: passwordInput.value,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setMsg(loginMsg, body.message || '로그인 실패', false);
+        return null;
+      }
+      localStorage.setItem(STORAGE_KEY, body.accessToken);
+      refreshBtn.disabled = false;
+      setMsg(loginMsg, '로그인 성공', true);
+      return body.accessToken;
+    }
+
+    async function fetchReports() {
+      const base = apiBaseInput.value.replace(/\/$/, '');
+      let t = token();
+      if (!t) t = await login();
+      if (!t) return;
+
+      const status = statusFilter.value;
+      const qs = status ? '?status=' + encodeURIComponent(status) : '';
+      const res = await fetch(base + '/admin/observation-reports' + qs, {
+        headers: { Authorization: 'Bearer ' + t, Accept: 'application/json' },
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        listEl.innerHTML = '<div class="panel err">' + (body.message || '목록 조회 실패') + '</div>';
+        return;
+      }
+      renderList(body);
+    }
+
+    function resultLabel(r) {
+      if (r === 'success') return '성공';
+      if (r === 'partial') return '부분';
+      return '실패';
+    }
+
+    function renderList(items) {
+      if (!items.length) {
+        listEl.innerHTML = '<div class="panel meta">제보가 없습니다.</div>';
+        return;
+      }
+      listEl.innerHTML = items.map(function (item) {
+        const obs = item.observation || {};
+        return (
+          '<article class="report">' +
+          '<h3>' + escapeHtml(obs.title || '(제목 없음)') + '</h3>' +
+          '<div class="meta">' +
+          '<span class="badge ' + item.status + '">' + (item.status === 'pending' ? '대기' : '처리 완료') + '</span>' +
+          escapeHtml(item.mismatchLabel) + ' · ' + new Date(item.createdAt).toLocaleString('ko-KR') +
+          '</div>' +
+          '<div class="stats">' +
+          '<span class="stat">Star-Index ' + obs.starIndexVal + '</span>' +
+          '<span class="stat">관측 ' + resultLabel(obs.result) + '</span>' +
+          '<span class="stat">' + escapeHtml(item.user.nickname || item.user.email) + '</span>' +
+          '</div>' +
+          '<p style="font-size:13px;margin:8px 0 0">' + escapeHtml((obs.content || '').slice(0, 200)) + '</p>' +
+          (item.message ? '<p class="meta" style="margin-top:6px">제보 메모: ' + escapeHtml(item.message) + '</p>' : '') +
+          (item.status === 'pending'
+            ? '<div class="actions"><button class="primary" data-id="' + item.id + '">처리 완료</button></div>'
+            : '') +
+          '</article>'
+        );
+      }).join('');
+
+      listEl.querySelectorAll('button[data-id]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          void markReviewed(btn.getAttribute('data-id'));
+        });
+      });
+    }
+
+    async function markReviewed(id) {
+      const base = apiBaseInput.value.replace(/\/$/, '');
+      const t = token();
+      const res = await fetch(base + '/admin/observation-reports/' + id, {
+        method: 'PATCH',
+        headers: {
+          Authorization: 'Bearer ' + t,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: JSON.stringify({ status: 'reviewed' }),
+      });
+      if (!res.ok) {
+        alert('상태 변경 실패');
+        return;
+      }
+      await fetchReports();
+    }
+
+    function escapeHtml(s) {
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    loginBtn.addEventListener('click', function () { void fetchReports(); });
+    refreshBtn.addEventListener('click', function () { void fetchReports(); });
+    statusFilter.addEventListener('change', function () { if (token()) void fetchReports(); });
+
+    if (token()) {
+      refreshBtn.disabled = false;
+      void fetchReports();
+    }
+  </script>
+</body>
+</html>

--- a/backend/admin/spot-reports.html
+++ b/backend/admin/spot-reports.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>StarChaser — 명소 제보 관리</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #030712;
+      --card: rgba(8, 15, 30, 0.92);
+      --border: rgba(255, 255, 255, 0.1);
+      --text: #f8fafc;
+      --muted: #94a3b8;
+      --accent: #8ddcff;
+      --danger: #ef4444;
+      --ok: #34d399;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: var(--bg); color: var(--text); line-height: 1.5; }
+    .wrap { max-width: 960px; margin: 0 auto; padding: 24px 16px 48px; }
+    h1 { font-size: 22px; margin: 0 0 6px; }
+    .sub { color: var(--muted); font-size: 13px; margin-bottom: 20px; }
+    .panel { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 16px; margin-bottom: 16px; }
+    label { display: block; font-size: 12px; color: var(--muted); margin-bottom: 6px; }
+    input, button { font: inherit; border-radius: 10px; border: 1px solid var(--border); background: rgba(15, 23, 42, 0.6); color: var(--text); padding: 10px 12px; width: 100%; }
+    .row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+    .actions { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+    button { cursor: pointer; width: auto; background: rgba(141, 220, 255, 0.12); border-color: rgba(141, 220, 255, 0.35); color: var(--accent); }
+    button.danger { color: var(--danger); border-color: rgba(239,68,68,.4); background: rgba(239,68,68,.08); }
+    button:disabled { opacity: .45; cursor: not-allowed; }
+    .err { color: var(--danger); font-size: 12px; margin-top: 8px; }
+    .ok { color: var(--ok); font-size: 12px; margin-top: 8px; }
+    .report { border: 1px solid var(--border); border-radius: 12px; padding: 14px; margin-bottom: 10px; }
+    .report h3 { margin: 0 0 6px; font-size: 15px; white-space: pre-wrap; }
+    .meta { font-size: 12px; color: var(--muted); }
+    .stats { display: flex; gap: 8px; flex-wrap: wrap; margin: 8px 0; }
+    .stat { font-size: 12px; padding: 4px 8px; border-radius: 8px; border: 1px solid var(--border); }
+    a.map { color: var(--accent); font-size: 12px; }
+    @media (max-width: 640px) { .row { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>명소 제보 관리</h1>
+    <p class="sub">사용자가 GPS와 함께 보낸 새 관측지 제보입니다. 확인 후 DB에 명소를 직접 추가하세요.</p>
+
+    <div class="panel">
+      <div class="row">
+        <div>
+          <label>API Base URL</label>
+          <input id="apiBase" placeholder="http://localhost:3333" />
+        </div>
+        <div>
+          <label>관리자 이메일</label>
+          <input id="email" type="email" autocomplete="username" />
+        </div>
+      </div>
+      <div style="margin-top:10px">
+        <label>비밀번호</label>
+        <input id="password" type="password" autocomplete="current-password" />
+      </div>
+      <div class="actions">
+        <button id="loginBtn">로그인 후 불러오기</button>
+        <button id="refreshBtn" disabled>새로고침</button>
+      </div>
+      <div id="loginMsg"></div>
+    </div>
+
+    <div id="list"></div>
+  </div>
+
+  <script>
+    const STORAGE_KEY = 'starchaser_admin_token';
+    const apiBaseInput = document.getElementById('apiBase');
+    const emailInput = document.getElementById('email');
+    const passwordInput = document.getElementById('password');
+    const loginBtn = document.getElementById('loginBtn');
+    const refreshBtn = document.getElementById('refreshBtn');
+    const loginMsg = document.getElementById('loginMsg');
+    const listEl = document.getElementById('list');
+
+    apiBaseInput.value = localStorage.getItem('starchaser_admin_api') || window.location.origin;
+
+    function setMsg(el, text, ok) {
+      el.textContent = text || '';
+      el.className = ok ? 'ok' : 'err';
+    }
+
+    function token() {
+      return localStorage.getItem(STORAGE_KEY);
+    }
+
+    async function login() {
+      const base = apiBaseInput.value.replace(/\/$/, '');
+      localStorage.setItem('starchaser_admin_api', base);
+      setMsg(loginMsg, '로그인 중…', true);
+      const res = await fetch(base + '/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ email: emailInput.value.trim(), password: passwordInput.value }),
+      });
+      const body = await res.json().catch(function () { return {}; });
+      if (!res.ok) {
+        setMsg(loginMsg, body.message || '로그인 실패', false);
+        return null;
+      }
+      localStorage.setItem(STORAGE_KEY, body.accessToken);
+      refreshBtn.disabled = false;
+      setMsg(loginMsg, '로그인 성공', true);
+      return body.accessToken;
+    }
+
+    async function fetchReports() {
+      const base = apiBaseInput.value.replace(/\/$/, '');
+      let t = token();
+      if (!t) t = await login();
+      if (!t) return;
+
+      const res = await fetch(base + '/admin/spot-reports', {
+        headers: { Authorization: 'Bearer ' + t, Accept: 'application/json' },
+      });
+      const body = await res.json().catch(function () { return {}; });
+      if (!res.ok) {
+        listEl.innerHTML = '<div class="panel err">' + (body.message || '목록 조회 실패') + '</div>';
+        return;
+      }
+      renderList(body);
+    }
+
+    function mapsUrl(lat, lng) {
+      return 'https://www.google.com/maps?q=' + encodeURIComponent(lat + ',' + lng);
+    }
+
+    function formatStarIndexScore(val) {
+      const n = Math.round(Number(val));
+      if (!Number.isFinite(n)) return '—';
+      if (n < 50) return '측정불가 · 원점수 ' + n;
+      return n + '점';
+    }
+
+    function renderList(items) {
+      if (!items.length) {
+        listEl.innerHTML = '<div class="panel meta">제보가 없습니다.</div>';
+        return;
+      }
+      listEl.innerHTML = items.map(function (item) {
+        return (
+          '<article class="report">' +
+          '<h3>' + escapeHtml(item.message) + '</h3>' +
+          '<div class="meta">' + new Date(item.createdAt).toLocaleString('ko-KR') +
+          ' · ' + escapeHtml(item.user.nickname || item.user.email) + '</div>' +
+          '<div class="stats">' +
+          '<span class="stat">' + formatStarIndexScore(item.starIndexVal) + '</span>' +
+          '<span class="stat">GPS ' + Number(item.latitude).toFixed(5) + ', ' + Number(item.longitude).toFixed(5) + '</span>' +
+          '</div>' +
+          '<a class="map" href="' + mapsUrl(item.latitude, item.longitude) + '" target="_blank" rel="noopener">지도에서 보기 ↗</a>' +
+          '<div class="actions"><button class="danger" data-id="' + item.id + '">삭제</button></div>' +
+          '</article>'
+        );
+      }).join('');
+
+      listEl.querySelectorAll('button[data-id]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          if (!confirm('이 제보를 삭제할까요?')) return;
+          void deleteReport(btn.getAttribute('data-id'));
+        });
+      });
+    }
+
+    async function deleteReport(id) {
+      const base = apiBaseInput.value.replace(/\/$/, '');
+      const t = token();
+      const res = await fetch(base + '/admin/spot-reports/' + id, {
+        method: 'DELETE',
+        headers: { Authorization: 'Bearer ' + t, Accept: 'application/json' },
+      });
+      if (!res.ok) {
+        alert('삭제 실패');
+        return;
+      }
+      await fetchReports();
+    }
+
+    function escapeHtml(s) {
+      return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
+
+    loginBtn.addEventListener('click', function () { void fetchReports(); });
+    refreshBtn.addEventListener('click', function () { void fetchReports(); });
+    if (token()) { refreshBtn.disabled = false; void fetchReports(); }
+  </script>
+</body>
+</html>

--- a/backend/src/admin/admin-observation-reports.controller.ts
+++ b/backend/src/admin/admin-observation-reports.controller.ts
@@ -1,0 +1,39 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UpdateObservationMismatchReportStatusDto } from '../observation-reports/dto/update-observation-mismatch-report-status.dto';
+import { ObservationReportsService } from '../observation-reports/observation-reports.service';
+import type { ObservationMismatchReportStatus } from '../observation-reports/observation-mismatch-report.entity';
+
+@ApiTags('admin')
+@Controller('admin/observation-reports')
+@UseGuards(JwtAuthGuard, AdminGuard)
+@ApiBearerAuth()
+export class AdminObservationReportsController {
+  constructor(private readonly reportsService: ObservationReportsService) {}
+
+  @Get()
+  @ApiOperation({ summary: '불일치 제보 목록 (관리자)' })
+  list(@Query('status') status?: ObservationMismatchReportStatus) {
+    return this.reportsService.listForAdmin(status);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: '제보 상태 변경 (관리자)' })
+  updateStatus(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateObservationMismatchReportStatusDto,
+  ) {
+    return this.reportsService.updateStatus(id, dto.status);
+  }
+}

--- a/backend/src/admin/admin-page.controller.ts
+++ b/backend/src/admin/admin-page.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import * as fs from 'fs';
+import * as path from 'path';
+
+@Controller()
+export class AdminPageController {
+  /** 관리자 불일치 제보 — http://localhost:3333/admin/observation-reports.html */
+  @Get('admin/observation-reports.html')
+  observationReportsAdmin(@Res() res: Response) {
+    const filePath = path.resolve(
+      process.cwd(),
+      'admin',
+      'observation-reports.html',
+    );
+    const html = fs.readFileSync(filePath, 'utf8');
+    res.status(200);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    return res.end(html);
+  }
+
+  /** 관리자 명소 제보 — http://localhost:3333/admin/spot-reports.html */
+  @Get('admin/spot-reports.html')
+  spotReportsAdmin(@Res() res: Response) {
+    const filePath = path.resolve(process.cwd(), 'admin', 'spot-reports.html');
+    const html = fs.readFileSync(filePath, 'utf8');
+    res.status(200);
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    return res.end(html);
+  }
+}

--- a/backend/src/admin/admin-spot-reports.controller.ts
+++ b/backend/src/admin/admin-spot-reports.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Delete, Get, Param, ParseUUIDPipe, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { SpotReportsService } from '../spot-reports/spot-reports.service';
+
+@ApiTags('admin')
+@Controller('admin/spot-reports')
+@UseGuards(JwtAuthGuard, AdminGuard)
+@ApiBearerAuth()
+export class AdminSpotReportsController {
+  constructor(private readonly spotReportsService: SpotReportsService) {}
+
+  @Get()
+  @ApiOperation({ summary: '명소 제보 목록 (관리자)' })
+  list() {
+    return this.spotReportsService.listForAdmin();
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: '명소 제보 삭제 (관리자)' })
+  delete(@Param('id', ParseUUIDPipe) id: string) {
+    return this.spotReportsService.delete(id);
+  }
+}

--- a/backend/src/admin/admin.module.ts
+++ b/backend/src/admin/admin.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { ObservationReportsModule } from '../observation-reports/observation-reports.module';
+import { SpotReportsModule } from '../spot-reports/spot-reports.module';
+import { AdminObservationReportsController } from './admin-observation-reports.controller';
+import { AdminSpotReportsController } from './admin-spot-reports.controller';
+
+@Module({
+  imports: [AuthModule, ObservationReportsModule, SpotReportsModule],
+  controllers: [AdminObservationReportsController, AdminSpotReportsController],
+})
+export class AdminModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,10 @@ import { ViirsModule } from './viirs/viirs.module';
 import { WeeklyTop3Module } from './weekly-top3/weekly-top3.module';
 import { UsersModule } from './users/users.module';
 import { KakaoPageController } from './kakao-page.controller';
+import { ObservationReportsModule } from './observation-reports/observation-reports.module';
+import { AdminModule } from './admin/admin.module';
+import { AdminPageController } from './admin/admin-page.controller';
+import { SpotReportsModule } from './spot-reports/spot-reports.module';
 
 @Module({
   imports: [
@@ -74,8 +78,11 @@ import { KakaoPageController } from './kakao-page.controller';
     ViirsModule,
     WeeklyTop3Module,
     UsersModule,
+    ObservationReportsModule,
+    SpotReportsModule,
+    AdminModule,
   ],
-  controllers: [AppController, KakaoPageController],
+  controllers: [AppController, KakaoPageController, AdminPageController],
   providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/auth/guards/admin.guard.ts
+++ b/backend/src/auth/guards/admin.guard.ts
@@ -1,0 +1,35 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { JwtValidatedUser } from '../strategies/jwt.strategy';
+
+/** ADMIN_EMAILS(쉼표 구분)에 포함된 JWT 사용자만 허용 */
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<{ user?: JwtValidatedUser }>();
+    const user = req.user;
+    if (!user?.email) {
+      throw new ForbiddenException('관리자 권한이 필요합니다.');
+    }
+
+    const raw = this.config.get<string>('ADMIN_EMAILS') ?? '';
+    const allowed = raw
+      .split(',')
+      .map((e) => e.trim().toLowerCase())
+      .filter(Boolean);
+    if (!allowed.length) {
+      throw new ForbiddenException('ADMIN_EMAILS가 설정되지 않았습니다.');
+    }
+    if (!allowed.includes(user.email.toLowerCase())) {
+      throw new ForbiddenException('관리자 권한이 필요합니다.');
+    }
+    return true;
+  }
+}

--- a/backend/src/common/interfaces/observation.repository.ts
+++ b/backend/src/common/interfaces/observation.repository.ts
@@ -11,6 +11,8 @@ export interface Observation {
   starIndexVal: number;
   weatherSnapshot: WeatherSnapshot;
   result: 'success' | 'partial' | 'fail';
+  title: string | null;
+  content: string | null;
   observedAt: Date;
 }
 

--- a/backend/src/common/interfaces/photo.repository.ts
+++ b/backend/src/common/interfaces/photo.repository.ts
@@ -1,0 +1,19 @@
+// ──────────────────────────────────────────────────────────────
+// PhotoRepository 인터페이스
+// ──────────────────────────────────────────────────────────────
+
+export interface Photo {
+  id: string;
+  observationId: string;
+  imageUrl: string;
+  caption: string | null;
+  takenAt: Date | null;
+}
+
+export interface PhotoRepository {
+  findByObservationIds(observationIds: string[]): Promise<Photo[]>;
+  save(data: Omit<Photo, 'id'>): Promise<Photo>;
+  deleteByObservationId(observationId: string): Promise<void>;
+}
+
+export const PHOTO_REPOSITORY = 'PHOTO_REPOSITORY';

--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -7,6 +7,8 @@ import { PhotoEntity } from '../photos/photo.entity';
 import { SpotEntity } from '../spots/spot.entity';
 import { UserEntity } from '../users/user.entity';
 import { EmailVerificationEntity } from '../auth/email-verification.entity';
+import { ObservationMismatchReportEntity } from '../observation-reports/observation-mismatch-report.entity';
+import { SpotReportEntity } from '../spot-reports/spot-report.entity';
 import { config } from 'dotenv';
 
 // TypeORM CLI 실행 시에도 backend/.env를 자동 로드한다.
@@ -31,6 +33,8 @@ export default new DataSource({
     NotificationPreferenceEntity,
     StarIndexCorrectionSubmissionEntity,
     EmailVerificationEntity,
+    ObservationMismatchReportEntity,
+    SpotReportEntity,
   ],
   migrations: ['src/migrations/*.ts'],
   synchronize: false,

--- a/backend/src/migrations/1751000000000-add-observation-diary-fields.ts
+++ b/backend/src/migrations/1751000000000-add-observation-diary-fields.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddObservationDiaryFields1751000000000 implements MigrationInterface {
+  name = 'AddObservationDiaryFields1751000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE observations
+      ADD COLUMN IF NOT EXISTS title varchar(120) NULL,
+      ADD COLUMN IF NOT EXISTS content text NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE observations
+      DROP COLUMN IF EXISTS content,
+      DROP COLUMN IF EXISTS title
+    `);
+  }
+}

--- a/backend/src/migrations/1751100000000-add-observation-mismatch-reports.ts
+++ b/backend/src/migrations/1751100000000-add-observation-mismatch-reports.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddObservationMismatchReports1751100000000 implements MigrationInterface {
+  name = 'AddObservationMismatchReports1751100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS observation_mismatch_reports (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        observation_id uuid NOT NULL REFERENCES observations(id) ON DELETE CASCADE,
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        mismatch_type varchar(32) NOT NULL CHECK (
+          mismatch_type IN ('unmeasurable_but_success', 'high_score_but_fail')
+        ),
+        message text NULL,
+        status varchar(16) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'reviewed')),
+        reviewed_at timestamptz NULL,
+        created_at timestamptz NOT NULL DEFAULT now(),
+        CONSTRAINT uq_observation_mismatch_reports_observation_user
+          UNIQUE (observation_id, user_id)
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_observation_mismatch_reports_status_created
+      ON observation_mismatch_reports(status, created_at DESC)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_observation_mismatch_reports_status_created`);
+    await queryRunner.query(`DROP TABLE IF EXISTS observation_mismatch_reports`);
+  }
+}

--- a/backend/src/migrations/1751200000000-add-spot-reports.ts
+++ b/backend/src/migrations/1751200000000-add-spot-reports.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSpotReports1751200000000 implements MigrationInterface {
+  name = 'AddSpotReports1751200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS spot_reports (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        latitude double precision NOT NULL,
+        longitude double precision NOT NULL,
+        message text NOT NULL,
+        star_index_val smallint NOT NULL CHECK (star_index_val BETWEEN 0 AND 100),
+        weather_snapshot jsonb NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now()
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_spot_reports_created_at
+      ON spot_reports(created_at DESC)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_spot_reports_created_at`);
+    await queryRunner.query(`DROP TABLE IF EXISTS spot_reports`);
+  }
+}

--- a/backend/src/observation-reports/dto/create-observation-mismatch-report.dto.ts
+++ b/backend/src/observation-reports/dto/create-observation-mismatch-report.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+import type { ObservationMismatchType } from '../observation-mismatch-report.entity';
+
+export class CreateObservationMismatchReportDto {
+  @ApiProperty()
+  @IsUUID()
+  observationId: string;
+
+  @ApiProperty({ enum: ['unmeasurable_but_success', 'high_score_but_fail'] })
+  @IsIn(['unmeasurable_but_success', 'high_score_but_fail'])
+  mismatchType: ObservationMismatchType;
+
+  @ApiPropertyOptional({ maxLength: 500 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  message?: string;
+}

--- a/backend/src/observation-reports/dto/update-observation-mismatch-report-status.dto.ts
+++ b/backend/src/observation-reports/dto/update-observation-mismatch-report-status.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn } from 'class-validator';
+import type { ObservationMismatchReportStatus } from '../observation-mismatch-report.entity';
+
+export class UpdateObservationMismatchReportStatusDto {
+  @ApiProperty({ enum: ['pending', 'reviewed'] })
+  @IsIn(['pending', 'reviewed'])
+  status: ObservationMismatchReportStatus;
+}

--- a/backend/src/observation-reports/observation-mismatch-report.entity.ts
+++ b/backend/src/observation-reports/observation-mismatch-report.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export type ObservationMismatchType =
+  | 'unmeasurable_but_success'
+  | 'high_score_but_fail';
+
+export type ObservationMismatchReportStatus = 'pending' | 'reviewed';
+
+@Entity('observation_mismatch_reports')
+export class ObservationMismatchReportEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'observation_id', type: 'uuid' })
+  observationId: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({ name: 'mismatch_type', type: 'varchar', length: 32 })
+  mismatchType: ObservationMismatchType;
+
+  @Column({ type: 'text', nullable: true })
+  message: string | null;
+
+  @Column({ type: 'varchar', length: 16, default: 'pending' })
+  status: ObservationMismatchReportStatus;
+
+  @Column({ name: 'reviewed_at', type: 'timestamptz', nullable: true })
+  reviewedAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/observation-reports/observation-mismatch.util.ts
+++ b/backend/src/observation-reports/observation-mismatch.util.ts
@@ -1,0 +1,39 @@
+/** Star-Index 50 미만이면 UI상 측정불가 */
+export const STAR_INDEX_MEASURABLE_MIN = 50;
+
+/** “점수가 높음” 판정 기준 */
+export const STAR_INDEX_HIGH_SCORE_THRESHOLD = 70;
+
+export type ObservationMismatchType =
+  | 'unmeasurable_but_success'
+  | 'high_score_but_fail';
+
+export function isStarIndexMeasurable(score: number): boolean {
+  const n = Math.round(score);
+  return Number.isFinite(n) && n >= STAR_INDEX_MEASURABLE_MIN;
+}
+
+/** 일기의 Star-Index·관측 결과 불일치 여부 */
+export function detectObservationMismatch(
+  starIndexVal: number,
+  result: 'success' | 'partial' | 'fail',
+): ObservationMismatchType | null {
+  if (!isStarIndexMeasurable(starIndexVal) && result === 'success') {
+    return 'unmeasurable_but_success';
+  }
+  if (
+    isStarIndexMeasurable(starIndexVal) &&
+    starIndexVal >= STAR_INDEX_HIGH_SCORE_THRESHOLD &&
+    result === 'fail'
+  ) {
+    return 'high_score_but_fail';
+  }
+  return null;
+}
+
+export function mismatchTypeLabel(type: ObservationMismatchType): string {
+  if (type === 'unmeasurable_but_success') {
+    return '측정불가인데 관측 성공';
+  }
+  return '높은 점수인데 관측 실패';
+}

--- a/backend/src/observation-reports/observation-reports.controller.ts
+++ b/backend/src/observation-reports/observation-reports.controller.ts
@@ -1,0 +1,35 @@
+import { Body, Controller, Get, Param, ParseUUIDPipe, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { JwtValidatedUser } from '../auth/strategies/jwt.strategy';
+import { CreateObservationMismatchReportDto } from './dto/create-observation-mismatch-report.dto';
+import { ObservationReportsService } from './observation-reports.service';
+
+@ApiTags('observation-reports')
+@Controller('observation-reports')
+export class ObservationReportsController {
+  constructor(private readonly reportsService: ObservationReportsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Post()
+  @ApiOperation({ summary: 'Star-Index·관측 결과 불일치 제보' })
+  create(
+    @CurrentUser() user: JwtValidatedUser,
+    @Body() dto: CreateObservationMismatchReportDto,
+  ) {
+    return this.reportsService.create(user.userId, dto);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Get('status/:observationId')
+  @ApiOperation({ summary: '내 일기 제보 여부' })
+  status(
+    @CurrentUser() user: JwtValidatedUser,
+    @Param('observationId', ParseUUIDPipe) observationId: string,
+  ) {
+    return this.reportsService.findReportStatusForObservation(user.userId, observationId);
+  }
+}

--- a/backend/src/observation-reports/observation-reports.module.ts
+++ b/backend/src/observation-reports/observation-reports.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { ObservationsModule } from '../observations/observations.module';
+import { ObservationMismatchReportEntity } from './observation-mismatch-report.entity';
+import { ObservationReportsController } from './observation-reports.controller';
+import { ObservationReportsService } from './observation-reports.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ObservationMismatchReportEntity]),
+    AuthModule,
+    ObservationsModule,
+  ],
+  controllers: [ObservationReportsController],
+  providers: [ObservationReportsService],
+  exports: [ObservationReportsService],
+})
+export class ObservationReportsModule {}

--- a/backend/src/observation-reports/observation-reports.service.ts
+++ b/backend/src/observation-reports/observation-reports.service.ts
@@ -1,0 +1,184 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Inject,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  OBSERVATION_REPOSITORY,
+  type ObservationRepository,
+} from '../common/interfaces/observation.repository';
+import type { CreateObservationMismatchReportDto } from './dto/create-observation-mismatch-report.dto';
+import {
+  ObservationMismatchReportEntity,
+  type ObservationMismatchReportStatus,
+  type ObservationMismatchType,
+} from './observation-mismatch-report.entity';
+import {
+  detectObservationMismatch,
+  mismatchTypeLabel,
+} from './observation-mismatch.util';
+
+@Injectable()
+export class ObservationReportsService {
+  private readonly logger = new Logger(ObservationReportsService.name);
+
+  constructor(
+    @InjectRepository(ObservationMismatchReportEntity)
+    private readonly reports: Repository<ObservationMismatchReportEntity>,
+    @Inject(OBSERVATION_REPOSITORY)
+    private readonly observations: ObservationRepository,
+  ) {}
+
+  async create(userId: string, dto: CreateObservationMismatchReportDto) {
+    const observation = await this.observations.findById(dto.observationId);
+    if (!observation) {
+      throw new NotFoundException('관측 기록을 찾을 수 없습니다.');
+    }
+    if (observation.userId !== userId) {
+      throw new ForbiddenException('본인의 일기만 제보할 수 있습니다.');
+    }
+
+    const expected = detectObservationMismatch(
+      observation.starIndexVal,
+      observation.result,
+    );
+    if (!expected) {
+      throw new BadRequestException('제보 대상이 아닌 기록입니다.');
+    }
+    if (expected !== dto.mismatchType) {
+      throw new BadRequestException('불일치 유형이 일치하지 않습니다.');
+    }
+
+    const existing = await this.reports.findOne({
+      where: { observationId: dto.observationId, userId },
+    });
+    if (existing) {
+      throw new ConflictException('이미 제보한 일기입니다.');
+    }
+
+    const row = this.reports.create({
+      observationId: dto.observationId,
+      userId,
+      mismatchType: dto.mismatchType,
+      message: dto.message?.trim() || null,
+      status: 'pending',
+    });
+    const saved = await this.reports.save(row);
+    this.logger.log(
+      `불일치 제보 — id=${saved.id}, obs=${dto.observationId}, type=${dto.mismatchType}`,
+    );
+
+    return {
+      id: saved.id,
+      observationId: saved.observationId,
+      mismatchType: saved.mismatchType,
+      mismatchLabel: mismatchTypeLabel(saved.mismatchType),
+      status: saved.status,
+      createdAt: saved.createdAt.toISOString(),
+    };
+  }
+
+  async findReportStatusForObservation(userId: string, observationId: string) {
+    const row = await this.reports.findOne({
+      where: { observationId, userId },
+    });
+    return row
+      ? {
+          submitted: true,
+          status: row.status,
+          createdAt: row.createdAt.toISOString(),
+        }
+      : { submitted: false };
+  }
+
+  async listForAdmin(status?: ObservationMismatchReportStatus) {
+    const qb = this.reports
+      .createQueryBuilder('r')
+      .innerJoin('observations', 'o', 'o.id = r.observation_id')
+      .innerJoin('users', 'u', 'u.id = r.user_id')
+      .select([
+        'r.id AS id',
+        'r.observation_id AS "observationId"',
+        'r.user_id AS "userId"',
+        'r.mismatch_type AS "mismatchType"',
+        'r.message AS message',
+        'r.status AS status',
+        'r.reviewed_at AS "reviewedAt"',
+        'r.created_at AS "createdAt"',
+        'o.title AS "observationTitle"',
+        'o.content AS "observationContent"',
+        'o.result AS "observationResult"',
+        'o.star_index_val AS "starIndexVal"',
+        'o.observed_at AS "observedAt"',
+        'u.email AS "userEmail"',
+        'u.nickname AS "userNickname"',
+      ])
+      .orderBy('r.created_at', 'DESC');
+
+    if (status) {
+      qb.where('r.status = :status', { status });
+    }
+
+    const rows = await qb.getRawMany<{
+      id: string;
+      observationId: string;
+      userId: string;
+      mismatchType: ObservationMismatchType;
+      message: string | null;
+      status: ObservationMismatchReportStatus;
+      reviewedAt: Date | null;
+      createdAt: Date;
+      observationTitle: string | null;
+      observationContent: string | null;
+      observationResult: 'success' | 'partial' | 'fail';
+      starIndexVal: number;
+      observedAt: Date;
+      userEmail: string;
+      userNickname: string | null;
+    }>();
+
+    return rows.map((row) => ({
+      id: row.id,
+      observationId: row.observationId,
+      userId: row.userId,
+      mismatchType: row.mismatchType,
+      mismatchLabel: mismatchTypeLabel(row.mismatchType),
+      message: row.message,
+      status: row.status,
+      reviewedAt: row.reviewedAt?.toISOString() ?? null,
+      createdAt: row.createdAt.toISOString(),
+      observation: {
+        title: row.observationTitle,
+        content: row.observationContent,
+        result: row.observationResult,
+        starIndexVal: row.starIndexVal,
+        observedAt: row.observedAt.toISOString(),
+      },
+      user: {
+        email: row.userEmail,
+        nickname: row.userNickname,
+      },
+    }));
+  }
+
+  async updateStatus(id: string, status: ObservationMismatchReportStatus) {
+    const row = await this.reports.findOne({ where: { id } });
+    if (!row) {
+      throw new NotFoundException('제보를 찾을 수 없습니다.');
+    }
+    row.status = status;
+    row.reviewedAt = status === 'reviewed' ? new Date() : null;
+    const saved = await this.reports.save(row);
+    return {
+      id: saved.id,
+      status: saved.status,
+      reviewedAt: saved.reviewedAt?.toISOString() ?? null,
+    };
+  }
+}

--- a/backend/src/observations/dto/create-observation.dto.ts
+++ b/backend/src/observations/dto/create-observation.dto.ts
@@ -4,8 +4,10 @@ import {
   IsInt,
   IsObject,
   IsOptional,
+  IsString,
   IsUUID,
   Max,
+  MaxLength,
   Min,
 } from 'class-validator';
 
@@ -31,4 +33,16 @@ export class CreateObservationDto {
   @ApiProperty({ enum: ['success', 'partial', 'fail'] })
   @IsIn(['success', 'partial', 'fail'])
   result: 'success' | 'partial' | 'fail';
+
+  @ApiPropertyOptional({ description: '일기 제목', maxLength: 120 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  title?: string;
+
+  @ApiPropertyOptional({ description: '일기 본문' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(5000)
+  content?: string;
 }

--- a/backend/src/observations/dto/observation-response.dto.ts
+++ b/backend/src/observations/dto/observation-response.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import type { WeatherSnapshot } from '../../common/interfaces/weather-snapshot';
+
+export class ObservationPhotoDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  imageUrl: string;
+}
+
+export class ObservationResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  userId: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  spotId: string | null;
+
+  @ApiProperty()
+  starIndexVal: number;
+
+  @ApiProperty()
+  weatherSnapshot: WeatherSnapshot;
+
+  @ApiProperty({ enum: ['success', 'partial', 'fail'] })
+  result: 'success' | 'partial' | 'fail';
+
+  @ApiPropertyOptional({ nullable: true })
+  title: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  content: string | null;
+
+  @ApiProperty()
+  observedAt: string;
+
+  @ApiProperty({ type: [ObservationPhotoDto] })
+  photos: ObservationPhotoDto[];
+}

--- a/backend/src/observations/observation.entity.ts
+++ b/backend/src/observations/observation.entity.ts
@@ -26,6 +26,12 @@ export class ObservationEntity {
   @Column({ type: 'varchar', length: 16 })
   result: 'success' | 'partial' | 'fail';
 
+  @Column({ type: 'varchar', length: 120, nullable: true })
+  title: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  content: string | null;
+
   @Column({ name: 'observed_at', type: 'timestamptz', default: () => 'now()' })
   observedAt: Date;
 

--- a/backend/src/observations/observation.service.ts
+++ b/backend/src/observations/observation.service.ts
@@ -1,9 +1,12 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Injectable,
   Inject,
   Logger,
+  NotFoundException,
 } from '@nestjs/common';
+import { randomUUID } from 'crypto';
 import type { WeatherSnapshot } from '../common/interfaces/weather-snapshot';
 import {
   assertValidWeatherSnapshotScores,
@@ -12,9 +15,23 @@ import {
 } from '../common/interfaces/weather-snapshot';
 import {
   OBSERVATION_REPOSITORY,
+  type Observation,
   type ObservationRepository,
 } from '../common/interfaces/observation.repository';
+import {
+  PHOTO_REPOSITORY,
+  type PhotoRepository,
+} from '../common/interfaces/photo.repository';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
 import type { CreateObservationDto } from './dto/create-observation.dto';
+import type { ObservationResponseDto } from './dto/observation-response.dto';
+
+const ALLOWED_IMAGE_MIMES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+]);
 
 @Injectable()
 export class ObservationService {
@@ -23,13 +40,19 @@ export class ObservationService {
   constructor(
     @Inject(OBSERVATION_REPOSITORY)
     private readonly observations: ObservationRepository,
+    @Inject(PHOTO_REPOSITORY)
+    private readonly photos: PhotoRepository,
+    private readonly storage: SupabaseStorageService,
   ) {}
 
   /**
    * Observation 저장 전 weather_snapshot 10키·0~100 검증 후 정규화 저장
    * (DB CHECK와 이중 방어)
    */
-  async create(userId: string, dto: CreateObservationDto) {
+  async create(
+    userId: string,
+    dto: CreateObservationDto,
+  ): Promise<ObservationResponseDto> {
     try {
       assertValidWeatherSnapshotScores(dto.weatherSnapshot);
     } catch (e) {
@@ -49,14 +72,103 @@ export class ObservationService {
       starIndexVal: dto.starIndexVal,
       weatherSnapshot,
       result: dto.result,
+      title: dto.title?.trim() || null,
+      content: dto.content?.trim() || null,
       observedAt: new Date(),
     });
 
     this.logger.log(`Observation 저장 — id=${saved.id}, user=${userId}`);
-    return saved;
+    return this.toResponse(saved, []);
   }
 
-  async findByUserId(userId: string) {
-    return this.observations.findByUserId(userId);
+  async findByUserId(userId: string): Promise<ObservationResponseDto[]> {
+    const rows = await this.observations.findByUserId(userId);
+    const photoRows = await this.photos.findByObservationIds(rows.map((r) => r.id));
+    const photosByObs = new Map<string, typeof photoRows>();
+    for (const p of photoRows) {
+      const list = photosByObs.get(p.observationId) ?? [];
+      list.push(p);
+      photosByObs.set(p.observationId, list);
+    }
+    return rows.map((row) =>
+      this.toResponse(row, photosByObs.get(row.id) ?? []),
+    );
+  }
+
+  async uploadPhoto(
+    userId: string,
+    observationId: string,
+    file: Express.Multer.File,
+  ): Promise<ObservationResponseDto> {
+    const observation = await this.requireOwnedObservation(userId, observationId);
+    if (!file?.buffer?.length) {
+      throw new BadRequestException('업로드할 파일이 없습니다.');
+    }
+    const mime = file.mimetype?.toLowerCase() ?? '';
+    if (!ALLOWED_IMAGE_MIMES.has(mime)) {
+      throw new BadRequestException('JPEG, PNG, WebP 이미지만 업로드할 수 있습니다.');
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      throw new BadRequestException('사진은 5MB 이하만 업로드할 수 있습니다.');
+    }
+
+    const photoId = randomUUID();
+    const imageUrl = await this.storage.uploadDiaryPhoto(
+      userId,
+      observationId,
+      photoId,
+      file.buffer,
+      mime,
+    );
+    await this.photos.save({
+      observationId,
+      imageUrl,
+      caption: null,
+      takenAt: null,
+    });
+
+    const allPhotos = await this.photos.findByObservationIds([observationId]);
+    return this.toResponse(observation, allPhotos);
+  }
+
+  async delete(userId: string, observationId: string): Promise<{ message: string }> {
+    await this.requireOwnedObservation(userId, observationId);
+    await this.storage.removeDiaryPhotos(userId, observationId);
+    await this.photos.deleteByObservationId(observationId);
+    await this.observations.deleteById(observationId);
+    this.logger.log(`Observation 삭제 — id=${observationId}, user=${userId}`);
+    return { message: '삭제했습니다.' };
+  }
+
+  private async requireOwnedObservation(
+    userId: string,
+    observationId: string,
+  ): Promise<Observation> {
+    const row = await this.observations.findById(observationId);
+    if (!row) {
+      throw new NotFoundException('관측 기록을 찾을 수 없습니다.');
+    }
+    if (row.userId !== userId) {
+      throw new ForbiddenException('본인의 기록만 수정할 수 있습니다.');
+    }
+    return row;
+  }
+
+  private toResponse(
+    row: Observation,
+    photoRows: { id: string; imageUrl: string }[],
+  ): ObservationResponseDto {
+    return {
+      id: row.id,
+      userId: row.userId,
+      spotId: row.spotId,
+      starIndexVal: row.starIndexVal,
+      weatherSnapshot: row.weatherSnapshot,
+      result: row.result,
+      title: row.title,
+      content: row.content,
+      observedAt: row.observedAt.toISOString(),
+      photos: photoRows.map((p) => ({ id: p.id, imageUrl: p.imageUrl })),
+    };
   }
 }

--- a/backend/src/observations/observations.controller.ts
+++ b/backend/src/observations/observations.controller.ts
@@ -1,9 +1,29 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import type { JwtValidatedUser } from '../auth/strategies/jwt.strategy';
 import { CreateObservationDto } from './dto/create-observation.dto';
+import { ObservationResponseDto } from './dto/observation-response.dto';
 import { ObservationService } from './observation.service';
 
 @ApiTags('observations')
@@ -16,20 +36,56 @@ export class ObservationsController {
   @Post()
   @ApiOperation({
     summary:
-      '관측 기록 저장 — weather_snapshot 10 score 키 검증 후 JSONB 저장',
+      '관측 일기 저장 — weather_snapshot 10 score 키 검증 후 JSONB 저장',
   })
   create(
     @CurrentUser() user: JwtValidatedUser,
     @Body() dto: CreateObservationDto,
-  ) {
+  ): Promise<ObservationResponseDto> {
     return this.observationService.create(user.userId, dto);
   }
 
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @Get('me')
-  @ApiOperation({ summary: '내 관측 기록 목록' })
-  findMine(@CurrentUser() user: JwtValidatedUser) {
+  @ApiOperation({ summary: '내 관측 일기 목록 (사진 포함)' })
+  findMine(@CurrentUser() user: JwtValidatedUser): Promise<ObservationResponseDto[]> {
     return this.observationService.findByUserId(user.userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Post(':id/photos')
+  @ApiOperation({ summary: '관측 일기 사진 업로드 (Supabase Storage)' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+    },
+  })
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+      limits: { fileSize: 5 * 1024 * 1024 },
+    }),
+  )
+  uploadPhoto(
+    @CurrentUser() user: JwtValidatedUser,
+    @Param('id', ParseUUIDPipe) id: string,
+    @UploadedFile() file: Express.Multer.File,
+  ): Promise<ObservationResponseDto> {
+    return this.observationService.uploadPhoto(user.userId, id, file);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Delete(':id')
+  @ApiOperation({ summary: '관측 일기 삭제' })
+  delete(
+    @CurrentUser() user: JwtValidatedUser,
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<{ message: string }> {
+    return this.observationService.delete(user.userId, id);
   }
 }

--- a/backend/src/observations/observations.module.ts
+++ b/backend/src/observations/observations.module.ts
@@ -2,20 +2,33 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { OBSERVATION_REPOSITORY } from '../common/interfaces/observation.repository';
+import { PHOTO_REPOSITORY } from '../common/interfaces/photo.repository';
+import { PhotoEntity } from '../photos/photo.entity';
+import { TypeOrmPhotoRepository } from '../photos/typeorm-photo.repository';
+import { SupabaseStorageService } from '../storage/supabase-storage.service';
 import { ObservationEntity } from './observation.entity';
 import { ObservationService } from './observation.service';
 import { ObservationsController } from './observations.controller';
 import { TypeOrmObservationRepository } from './typeorm-observation.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ObservationEntity]), AuthModule],
+  imports: [
+    TypeOrmModule.forFeature([ObservationEntity, PhotoEntity]),
+    AuthModule,
+  ],
   controllers: [ObservationsController],
   providers: [
     ObservationService,
+    SupabaseStorageService,
     TypeOrmObservationRepository,
+    TypeOrmPhotoRepository,
     {
       provide: OBSERVATION_REPOSITORY,
       useExisting: TypeOrmObservationRepository,
+    },
+    {
+      provide: PHOTO_REPOSITORY,
+      useExisting: TypeOrmPhotoRepository,
     },
   ],
   exports: [ObservationService, OBSERVATION_REPOSITORY],

--- a/backend/src/observations/typeorm-observation.repository.ts
+++ b/backend/src/observations/typeorm-observation.repository.ts
@@ -31,6 +31,8 @@ export class TypeOrmObservationRepository implements ObservationRepository {
       starIndexVal: data.starIndexVal,
       weatherSnapshot: data.weatherSnapshot,
       result: data.result,
+      title: data.title,
+      content: data.content,
       observedAt: data.observedAt ?? new Date(),
     });
     const row = await this.repo.save(entity);
@@ -49,6 +51,8 @@ export class TypeOrmObservationRepository implements ObservationRepository {
       starIndexVal: row.starIndexVal,
       weatherSnapshot: row.weatherSnapshot,
       result: row.result,
+      title: row.title,
+      content: row.content,
       observedAt: row.observedAt,
     };
   }

--- a/backend/src/photos/typeorm-photo.repository.ts
+++ b/backend/src/photos/typeorm-photo.repository.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import type { Photo, PhotoRepository } from '../common/interfaces/photo.repository';
+import { PhotoEntity } from './photo.entity';
+
+@Injectable()
+export class TypeOrmPhotoRepository implements PhotoRepository {
+  constructor(
+    @InjectRepository(PhotoEntity)
+    private readonly repo: Repository<PhotoEntity>,
+  ) {}
+
+  async findByObservationIds(observationIds: string[]): Promise<Photo[]> {
+    if (observationIds.length === 0) return [];
+    const rows = await this.repo.find({
+      where: { observationId: In(observationIds) },
+      order: { createdAt: 'ASC' },
+    });
+    return rows.map((r) => this.toPhoto(r));
+  }
+
+  async save(data: Omit<Photo, 'id'>): Promise<Photo> {
+    const entity = this.repo.create({
+      observationId: data.observationId,
+      imageUrl: data.imageUrl,
+      caption: data.caption,
+      takenAt: data.takenAt,
+    });
+    const row = await this.repo.save(entity);
+    return this.toPhoto(row);
+  }
+
+  async deleteByObservationId(observationId: string): Promise<void> {
+    await this.repo.delete({ observationId });
+  }
+
+  private toPhoto(row: PhotoEntity): Photo {
+    return {
+      id: row.id,
+      observationId: row.observationId,
+      imageUrl: row.imageUrl,
+      caption: row.caption,
+      takenAt: row.takenAt,
+    };
+  }
+}

--- a/backend/src/spot-reports/dto/create-spot-report.dto.ts
+++ b/backend/src/spot-reports/dto/create-spot-report.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsString, Max, MaxLength, Min } from 'class-validator';
+
+export class CreateSpotReportDto {
+  @ApiProperty({ description: '명소 제보 설명', maxLength: 500 })
+  @IsString()
+  @MaxLength(500)
+  message: string;
+
+  @ApiProperty({ minimum: -90, maximum: 90 })
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat: number;
+
+  @ApiProperty({ minimum: -180, maximum: 180 })
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lng: number;
+}

--- a/backend/src/spot-reports/spot-report.entity.ts
+++ b/backend/src/spot-reports/spot-report.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import type { WeatherSnapshot } from '../common/interfaces/weather-snapshot';
+
+@Entity('spot_reports')
+export class SpotReportEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'user_id', type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'double precision' })
+  latitude: number;
+
+  @Column({ type: 'double precision' })
+  longitude: number;
+
+  @Column({ type: 'text' })
+  message: string;
+
+  @Column({ name: 'star_index_val', type: 'smallint' })
+  starIndexVal: number;
+
+  @Column({ name: 'weather_snapshot', type: 'jsonb' })
+  weatherSnapshot: WeatherSnapshot;
+
+  @CreateDateColumn({ name: 'created_at', type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/backend/src/spot-reports/spot-reports.controller.ts
+++ b/backend/src/spot-reports/spot-reports.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import type { JwtValidatedUser } from '../auth/strategies/jwt.strategy';
+import { CreateSpotReportDto } from './dto/create-spot-report.dto';
+import { SpotReportsService } from './spot-reports.service';
+
+@ApiTags('spot-reports')
+@Controller('spot-reports')
+export class SpotReportsController {
+  constructor(private readonly spotReportsService: SpotReportsService) {}
+
+  @Throttle({ default: { ttl: 60000, limit: 5 } })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @Post()
+  @ApiOperation({ summary: '명소 제보 — GPS + Star-Index 스냅샷 저장' })
+  create(
+    @CurrentUser() user: JwtValidatedUser,
+    @Body() dto: CreateSpotReportDto,
+  ) {
+    return this.spotReportsService.create(user.userId, dto);
+  }
+}

--- a/backend/src/spot-reports/spot-reports.module.ts
+++ b/backend/src/spot-reports/spot-reports.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from '../auth/auth.module';
+import { StarIndexModule } from '../star-index/star-index.module';
+import { SpotReportEntity } from './spot-report.entity';
+import { SpotReportsController } from './spot-reports.controller';
+import { SpotReportsService } from './spot-reports.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([SpotReportEntity]),
+    AuthModule,
+    StarIndexModule,
+  ],
+  controllers: [SpotReportsController],
+  providers: [SpotReportsService],
+  exports: [SpotReportsService],
+})
+export class SpotReportsModule {}

--- a/backend/src/spot-reports/spot-reports.service.ts
+++ b/backend/src/spot-reports/spot-reports.service.ts
@@ -1,0 +1,119 @@
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { StarIndexService } from '../star-index/star-index.service';
+import type { CreateSpotReportDto } from './dto/create-spot-report.dto';
+import { SpotReportEntity } from './spot-report.entity';
+
+@Injectable()
+export class SpotReportsService {
+  private readonly logger = new Logger(SpotReportsService.name);
+
+  constructor(
+    @InjectRepository(SpotReportEntity)
+    private readonly repo: Repository<SpotReportEntity>,
+    private readonly starIndex: StarIndexService,
+  ) {}
+
+  async create(userId: string, dto: CreateSpotReportDto) {
+    const message = dto.message.trim();
+    if (!message) {
+      throw new BadRequestException('명소 설명을 입력해 주세요.');
+    }
+
+    let starResult;
+    try {
+      starResult = await this.starIndex.calculateForLatLngFromCache(
+        dto.lat,
+        dto.lng,
+      );
+    } catch (e) {
+      if (e instanceof ServiceUnavailableException) {
+        throw e;
+      }
+      throw new ServiceUnavailableException(
+        '현재 위치의 Star-Index를 계산하지 못했습니다.',
+      );
+    }
+
+    const row = this.repo.create({
+      userId,
+      latitude: dto.lat,
+      longitude: dto.lng,
+      message,
+      starIndexVal: starResult.score,
+      weatherSnapshot: starResult.weatherSnapshot,
+    });
+    const saved = await this.repo.save(row);
+    this.logger.log(`명소 제보 — id=${saved.id}, user=${userId}`);
+
+    return {
+      id: saved.id,
+      starIndexVal: saved.starIndexVal,
+      latitude: saved.latitude,
+      longitude: saved.longitude,
+      createdAt: saved.createdAt.toISOString(),
+    };
+  }
+
+  async listForAdmin() {
+    const rows = await this.repo
+      .createQueryBuilder('r')
+      .innerJoin('users', 'u', 'u.id = r.user_id')
+      .select([
+        'r.id AS id',
+        'r.user_id AS "userId"',
+        'r.latitude AS latitude',
+        'r.longitude AS longitude',
+        'r.message AS message',
+        'r.star_index_val AS "starIndexVal"',
+        'r.weather_snapshot AS "weatherSnapshot"',
+        'r.created_at AS "createdAt"',
+        'u.email AS "userEmail"',
+        'u.nickname AS "userNickname"',
+      ])
+      .orderBy('r.created_at', 'DESC')
+      .getRawMany<{
+        id: string;
+        userId: string;
+        latitude: number;
+        longitude: number;
+        message: string;
+        starIndexVal: number;
+        weatherSnapshot: SpotReportEntity['weatherSnapshot'];
+        createdAt: Date;
+        userEmail: string;
+        userNickname: string | null;
+      }>();
+
+    return rows.map((row) => ({
+      id: row.id,
+      userId: row.userId,
+      latitude: row.latitude,
+      longitude: row.longitude,
+      message: row.message,
+      starIndexVal: row.starIndexVal,
+      weatherSnapshot: row.weatherSnapshot,
+      createdAt: row.createdAt.toISOString(),
+      user: {
+        email: row.userEmail,
+        nickname: row.userNickname,
+      },
+    }));
+  }
+
+  async delete(id: string): Promise<{ message: string }> {
+    const result = await this.repo.delete({ id });
+    if (!result.affected) {
+      throw new NotFoundException('제보를 찾을 수 없습니다.');
+    }
+    this.logger.log(`명소 제보 삭제 — id=${id}`);
+    return { message: '삭제했습니다.' };
+  }
+}

--- a/backend/src/storage/supabase-storage.service.ts
+++ b/backend/src/storage/supabase-storage.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 const AVATAR_BUCKET = 'avatars';
+const DIARY_PHOTOS_BUCKET = 'diary-photos';
 /** 업로드 시 사용하는 확장자와 동일 (jpeg → jpg) */
 const AVATAR_OBJECT_PATHS = ['jpg', 'png', 'webp'] as const;
 
@@ -36,6 +37,61 @@ export class SupabaseStorageService {
     if (mime === 'image/png') return 'png';
     if (mime === 'image/webp') return 'webp';
     return 'jpg';
+  }
+
+  /** 일기 사진 — observation별 고유 경로 */
+  private diaryPhotoPath(
+    userId: string,
+    observationId: string,
+    photoId: string,
+    ext: string,
+  ): string {
+    return `${userId}/${observationId}/${photoId}.${ext}`;
+  }
+
+  async uploadDiaryPhoto(
+    userId: string,
+    observationId: string,
+    photoId: string,
+    buffer: Buffer,
+    mimeType: string,
+  ): Promise<string> {
+    const client = this.requireClient();
+    const ext = this.extensionFromMime(mimeType);
+    const path = this.diaryPhotoPath(userId, observationId, photoId, ext);
+
+    const { error } = await client.storage
+      .from(DIARY_PHOTOS_BUCKET)
+      .upload(path, buffer, {
+        contentType: mimeType,
+        upsert: false,
+      });
+    if (error) {
+      this.logger.error(`일기 사진 업로드 실패: ${error.message}`);
+      throw new ServiceUnavailableException('일기 사진 업로드에 실패했습니다.');
+    }
+
+    const { data } = client.storage.from(DIARY_PHOTOS_BUCKET).getPublicUrl(path);
+    return data.publicUrl;
+  }
+
+  async removeDiaryPhotos(userId: string, observationId: string): Promise<void> {
+    if (!this.client) return;
+    const client = this.requireClient();
+    const prefix = `${userId}/${observationId}`;
+    const { data, error: listError } = await client.storage
+      .from(DIARY_PHOTOS_BUCKET)
+      .list(prefix);
+    if (listError) {
+      this.logger.warn(`일기 사진 목록 조회 경고: ${listError.message}`);
+      return;
+    }
+    if (!data?.length) return;
+    const paths = data.map((f) => `${prefix}/${f.name}`);
+    const { error } = await client.storage.from(DIARY_PHOTOS_BUCKET).remove(paths);
+    if (error) {
+      this.logger.warn(`일기 사진 삭제 경고: ${error.message}`);
+    }
   }
 
   private objectPath(userId: string, ext: string): string {

--- a/frontend/components/records/DiaryDetailModal.tsx
+++ b/frontend/components/records/DiaryDetailModal.tsx
@@ -1,0 +1,512 @@
+/**
+ * 일기 상세 모달 — 전체 내용 · 사진 · 삭제 · 불일치 제보
+ */
+
+import Feather from '@expo/vector-icons/Feather';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Image,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+import {
+  ApiRequestError,
+  deleteObservation,
+  fetchObservationReportStatus,
+  SessionExpiredError,
+  submitObservationMismatchReport,
+  type ObservationRowDto,
+} from '../../lib/api-client';
+import {
+  detectObservationMismatch,
+  mismatchHint,
+  mismatchTypeLabel,
+  type ObservationMismatchType,
+} from '../../lib/observation-mismatch';
+import { getStarIndexScoreDisplay } from '../../lib/star-index-display';
+import { spacing } from '../../themes/design-tokens';
+import { useTheme } from '../../themes/ThemeContext';
+import { Button } from '../ui';
+
+const RESULT_META: Record<
+  ObservationRowDto['result'],
+  { label: string; icon: React.ComponentProps<typeof Feather>['name'] }
+> = {
+  success: { label: '성공', icon: 'check-circle' },
+  partial: { label: '부분 성공', icon: 'minus-circle' },
+  fail: { label: '실패', icon: 'x-circle' },
+};
+
+function formatDateTimeKst(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleString('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function ResultStatCard({ result }: { result: ObservationRowDto['result'] }) {
+  const { theme } = useTheme();
+  const meta = RESULT_META[result];
+  const accent =
+    result === 'success'
+      ? theme.primaryGlow
+      : result === 'partial'
+        ? theme.secondary
+        : theme.destructive;
+
+  return (
+    <View style={styles.statCard}>
+      <View style={styles.statLabelRow}>
+        <Feather name={meta.icon} size={13} color={accent} />
+        <Text style={[styles.statCaption, { color: theme.mutedForeground }]}>관측 결과</Text>
+      </View>
+      <Text style={[styles.statValue, { color: accent }]}>{meta.label}</Text>
+    </View>
+  );
+}
+
+function StarIndexStatCard({ value }: { value: number }) {
+  const { theme } = useTheme();
+  const si = getStarIndexScoreDisplay(value);
+  const accent = si.measurable ? theme.primaryGlow : theme.destructive;
+
+  return (
+    <View style={styles.statCard}>
+      <View style={styles.statLabelRow}>
+        <Feather name="star" size={13} color={accent} />
+        <Text style={[styles.statCaption, { color: theme.mutedForeground }]}>Star-Index</Text>
+      </View>
+      <Text style={[styles.statValue, { color: accent }]}>{si.label}</Text>
+      {si.measurable ? (
+        <View style={[styles.gaugeTrack, { backgroundColor: 'rgba(255,255,255,0.08)' }]}>
+          <View
+            style={[
+              styles.gaugeFill,
+              { width: `${si.gaugePercent}%`, backgroundColor: accent },
+            ]}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function MismatchReportSection({
+  observationId,
+  mismatchType,
+  onSessionInvalidated,
+}: {
+  observationId: string;
+  mismatchType: ObservationMismatchType;
+  onSessionInvalidated: () => Promise<void>;
+}) {
+  const { theme } = useTheme();
+  const [reportBusy, setReportBusy] = useState(false);
+  const [reportSubmitted, setReportSubmitted] = useState(false);
+  const [reportError, setReportError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const status = await fetchObservationReportStatus(observationId);
+        if (!cancelled && status.submitted) {
+          setReportSubmitted(true);
+        }
+      } catch {
+        /* 제보 상태 조회 실패 시 제보 버튼만 표시 */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [observationId]);
+
+  const submitReport = useCallback(async () => {
+    setReportBusy(true);
+    setReportError(null);
+    try {
+      await submitObservationMismatchReport({
+        observationId,
+        mismatchType,
+      });
+      setReportSubmitted(true);
+    } catch (e) {
+      if (e instanceof SessionExpiredError) {
+        await onSessionInvalidated();
+        return;
+      }
+      if (e instanceof ApiRequestError && e.status === 409) {
+        setReportSubmitted(true);
+        return;
+      }
+      setReportError(
+        e instanceof ApiRequestError ? e.message : '제보에 실패했습니다.',
+      );
+    } finally {
+      setReportBusy(false);
+    }
+  }, [mismatchType, observationId, onSessionInvalidated]);
+
+  return (
+    <View style={[styles.reportBox, { borderColor: theme.cardBorder }]}>
+      <View style={styles.reportHeader}>
+        <Feather name="alert-circle" size={14} color={theme.secondary} />
+        <Text style={[styles.reportTag, { color: theme.secondary }]}>
+          {mismatchTypeLabel(mismatchType)}
+        </Text>
+      </View>
+      <Text style={[styles.reportHint, { color: theme.mutedForeground }]}>
+        {mismatchHint(mismatchType)}
+      </Text>
+      {reportSubmitted ? (
+        <Text style={[styles.reportDone, { color: theme.primaryGlow }]}>
+          제보가 접수되었습니다. 검토 후 반영하겠습니다.
+        </Text>
+      ) : (
+        <View style={{ marginTop: spacing.sm }}>
+          <Button
+            label="불일치 제보하기"
+            variant="outline"
+            size="sm"
+            loading={reportBusy}
+            disabled={reportBusy}
+            onPress={() => void submitReport()}
+          />
+        </View>
+      )}
+      {reportError ? (
+        <Text style={[styles.err, { color: theme.destructive }]}>{reportError}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+function DiaryPhotoGallery({
+  photos,
+}: {
+  photos: ObservationRowDto['photos'];
+}) {
+  const { theme } = useTheme();
+  const { width: screenWidth } = useWindowDimensions();
+  const photoWidth = Math.min(200, screenWidth - spacing.lg * 2 - spacing.sm);
+
+  if (photos.length === 0) return null;
+
+  return (
+    <View style={styles.photoSection}>
+      <FlatList
+        data={photos}
+        horizontal
+        keyExtractor={(item) => item.id}
+        showsHorizontalScrollIndicator={false}
+        nestedScrollEnabled
+        directionalLockEnabled
+        decelerationRate="fast"
+        snapToInterval={photoWidth + spacing.sm}
+        snapToAlignment="start"
+        disableIntervalMomentum
+        style={styles.photoList}
+        contentContainerStyle={styles.photoRow}
+        ItemSeparatorComponent={() => <View style={{ width: spacing.sm }} />}
+        renderItem={({ item }) => (
+          <Image
+            source={{ uri: item.imageUrl }}
+            style={[
+              styles.photo,
+              {
+                width: photoWidth,
+                borderColor: theme.cardBorder,
+              },
+            ]}
+            resizeMode="cover"
+          />
+        )}
+      />
+      {photos.length > 1 ? (
+        <Text style={[styles.photoSwipeHint, { color: theme.mutedForeground }]}>
+          ← 좌우로 밀어 {photos.length}장 보기
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+interface DiaryDetailModalProps {
+  visible: boolean;
+  row: ObservationRowDto | null;
+  onClose: () => void;
+  onDeleted: () => void;
+  onSessionInvalidated: () => Promise<void>;
+}
+
+export function DiaryDetailModal({
+  visible,
+  row,
+  onClose,
+  onDeleted,
+  onSessionInvalidated,
+}: DiaryDetailModalProps) {
+  const { theme } = useTheme();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const confirmDelete = useCallback(() => {
+    if (!row) return;
+    Alert.alert('일기 삭제', '이 일기를 삭제할까요? 되돌릴 수 없습니다.', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '삭제',
+        style: 'destructive',
+        onPress: () => {
+          void (async () => {
+            setBusy(true);
+            setError(null);
+            try {
+              await deleteObservation(row.id);
+              onDeleted();
+              onClose();
+            } catch (e) {
+              if (e instanceof SessionExpiredError) {
+                await onSessionInvalidated();
+                return;
+              }
+              setError(
+                e instanceof ApiRequestError ? e.message : '삭제에 실패했습니다.',
+              );
+            } finally {
+              setBusy(false);
+            }
+          })();
+        },
+      },
+    ]);
+  }, [onClose, onDeleted, onSessionInvalidated, row]);
+
+  if (!row) return null;
+
+  const mismatchType = detectObservationMismatch(row.starIndexVal, row.result);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.backdrop}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} accessibilityLabel="닫기" />
+        <View style={[styles.sheet, { backgroundColor: theme.deepNavy, borderColor: theme.border }]}>
+          <View style={[styles.handle, { backgroundColor: theme.border }]} />
+
+          <View style={styles.header}>
+            <Pressable onPress={onClose} hitSlop={12} accessibilityLabel="닫기">
+              <Feather name="x" size={22} color={theme.mutedForeground} />
+            </Pressable>
+            <Text style={[styles.headerTitle, { color: theme.foreground }]} numberOfLines={1}>
+              {row.title?.trim() || '일기'}
+            </Text>
+            <View style={{ width: 22 }} />
+          </View>
+
+          <ScrollView
+            style={[styles.scroll, { backgroundColor: theme.deepNavy }]}
+            contentContainerStyle={styles.scrollInner}
+            showsVerticalScrollIndicator={false}
+            nestedScrollEnabled
+            directionalLockEnabled
+            keyboardShouldPersistTaps="handled"
+          >
+            <Text style={[styles.date, { color: theme.mutedForeground }]}>
+              {formatDateTimeKst(row.observedAt)}
+            </Text>
+
+            <View style={styles.statsRow}>
+              <ResultStatCard result={row.result} />
+              <StarIndexStatCard value={row.starIndexVal} />
+            </View>
+
+            {mismatchType ? (
+              <MismatchReportSection
+                observationId={row.id}
+                mismatchType={mismatchType}
+                onSessionInvalidated={onSessionInvalidated}
+              />
+            ) : null}
+
+            {row.photos.length > 0 ? <DiaryPhotoGallery photos={row.photos} /> : null}
+
+            <Text style={[styles.content, { color: theme.foreground }]}>
+              {(row.content ?? '').trim() || '내용 없음'}
+            </Text>
+
+            {error ? (
+              <Text style={[styles.err, { color: theme.destructive }]}>{error}</Text>
+            ) : null}
+
+            {busy ? (
+              <ActivityIndicator color={theme.primaryGlow} style={{ marginVertical: 8 }} />
+            ) : null}
+          </ScrollView>
+
+          <View style={styles.footer}>
+            <Button
+              label="삭제"
+              variant="destructive"
+              fullWidth
+              disabled={busy}
+              onPress={confirmDelete}
+            />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.72)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    maxHeight: '94%',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    paddingBottom: spacing.xl,
+    zIndex: 1,
+    overflow: 'hidden',
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 16,
+    fontWeight: '700',
+    marginHorizontal: spacing.sm,
+  },
+  scroll: { maxHeight: 520 },
+  scrollInner: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+    gap: spacing.md,
+  },
+  date: { fontSize: 12, lineHeight: 18 },
+  statsRow: {
+    flexDirection: 'row',
+    gap: spacing.lg,
+  },
+  statCard: {
+    flex: 1,
+    gap: 4,
+    paddingVertical: 2,
+  },
+  statLabelRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+  },
+  statCaption: {
+    fontSize: 11,
+    fontWeight: '500',
+    letterSpacing: 0.2,
+  },
+  statValue: {
+    fontSize: 20,
+    fontWeight: '700',
+    letterSpacing: -0.3,
+    fontVariant: ['tabular-nums'],
+  },
+  gaugeTrack: {
+    height: 3,
+    borderRadius: 2,
+    overflow: 'hidden',
+    marginTop: 4,
+  },
+  gaugeFill: {
+    height: '100%',
+    borderRadius: 2,
+  },
+  reportBox: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    paddingVertical: spacing.sm,
+    gap: 6,
+  },
+  reportHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  reportTag: {
+    fontSize: 11,
+    fontWeight: '600',
+    letterSpacing: 0.15,
+  },
+  reportHint: {
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  reportDone: {
+    fontSize: 12,
+    lineHeight: 18,
+    marginTop: 2,
+  },
+  photoSection: {
+    marginHorizontal: -spacing.lg,
+  },
+  photoList: {
+    height: 140,
+  },
+  photoRow: {
+    paddingHorizontal: spacing.lg,
+    paddingRight: spacing.lg + spacing.sm,
+  },
+  photo: {
+    height: 140,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  photoSwipeHint: {
+    fontSize: 11,
+    textAlign: 'center',
+    marginTop: 6,
+    paddingHorizontal: spacing.lg,
+  },
+  content: {
+    fontSize: 15,
+    lineHeight: 24,
+  },
+  err: { fontSize: 12 },
+  footer: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+  },
+});

--- a/frontend/components/records/DiaryEntryCard.tsx
+++ b/frontend/components/records/DiaryEntryCard.tsx
@@ -1,0 +1,156 @@
+/**
+ * 일기 목록 카드 — 펼쳐보기 탭
+ */
+
+import Feather from '@expo/vector-icons/Feather';
+import React from 'react';
+import { Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { ObservationRowDto } from '../../lib/api-client';
+import { getStarIndexScoreDisplay } from '../../lib/star-index-display';
+import { spacing } from '../../themes/design-tokens';
+import { useTheme } from '../../themes/ThemeContext';
+import { GlassCard } from '../ui/GlassCard';
+
+const RESULT_META: Record<
+  ObservationRowDto['result'],
+  { label: string; icon: React.ComponentProps<typeof Feather>['name']; colorKey: 'primaryGlow' | 'secondary' | 'destructive' }
+> = {
+  success: { label: '성공', icon: 'check-circle', colorKey: 'primaryGlow' },
+  partial: { label: '부분', icon: 'minus-circle', colorKey: 'secondary' },
+  fail: { label: '실패', icon: 'x-circle', colorKey: 'destructive' },
+};
+
+function formatDateKst(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'short',
+  }).format(d);
+}
+
+function previewText(content: string | null | undefined, max = 80): string {
+  const t = (content ?? '').trim();
+  if (!t) return '내용 없음';
+  return t.length > max ? `${t.slice(0, max)}…` : t;
+}
+
+export interface DiaryEntryCardProps {
+  row: ObservationRowDto;
+  onPress: () => void;
+}
+
+export function DiaryEntryCard({ row, onPress }: DiaryEntryCardProps) {
+  const { theme } = useTheme();
+  const meta = RESULT_META[row.result];
+  const accent = theme[meta.colorKey];
+  const si = getStarIndexScoreDisplay(row.starIndexVal);
+  const cover = row.photos[0]?.imageUrl;
+
+  return (
+    <Pressable onPress={onPress} style={({ pressed }) => [{ opacity: pressed ? 0.92 : 1 }]}>
+      <GlassCard padding={0} style={styles.card} glow>
+        {cover ? (
+          <Image source={{ uri: cover }} style={styles.cover} resizeMode="cover" />
+        ) : (
+          <View style={[styles.coverPlaceholder, { backgroundColor: theme.inputBackground }]}>
+            <Feather name="moon" size={28} color={theme.mutedForeground} />
+          </View>
+        )}
+
+        <View style={styles.body}>
+          <View style={styles.topRow}>
+            <Text style={[styles.date, { color: theme.mutedForeground }]}>
+              {formatDateKst(row.observedAt)}
+            </Text>
+            <View style={[styles.badge, { borderColor: accent, backgroundColor: theme.primaryGlowMuted }]}>
+              <Feather name={meta.icon} size={11} color={accent} />
+              <Text style={[styles.badgeText, { color: accent }]}>{meta.label}</Text>
+            </View>
+          </View>
+
+          <Text style={[styles.title, { color: theme.foreground }]} numberOfLines={1}>
+            {row.title?.trim() || '제목 없음'}
+          </Text>
+
+          <Text style={[styles.preview, { color: theme.mutedForeground }]} numberOfLines={2}>
+            {previewText(row.content)}
+          </Text>
+
+          <View style={styles.footer}>
+            <View style={styles.footerLeft}>
+              <Feather name="star" size={12} color={theme.primaryGlow} />
+              <Text style={[styles.si, { color: si.measurable ? theme.primaryGlow : theme.destructive }]}>
+                {si.label}
+              </Text>
+            </View>
+            {row.photos.length > 0 ? (
+              <View style={styles.footerLeft}>
+                <Feather name="camera" size={12} color={theme.mutedForeground} />
+                <Text style={[styles.photoCount, { color: theme.mutedForeground }]}>
+                  {row.photos.length}장
+                </Text>
+              </View>
+            ) : null}
+          </View>
+        </View>
+      </GlassCard>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: spacing.md,
+    overflow: 'hidden',
+  },
+  cover: {
+    width: '100%',
+    height: 140,
+  },
+  coverPlaceholder: {
+    width: '100%',
+    height: 100,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  body: {
+    padding: spacing.md,
+    gap: 6,
+  },
+  topRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  date: { fontSize: 11, flex: 1 },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  badgeText: { fontSize: 10, fontWeight: '600' },
+  title: { fontSize: 17, fontWeight: '700', letterSpacing: -0.2 },
+  preview: { fontSize: 13, lineHeight: 19 },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    marginTop: 4,
+  },
+  footerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  si: { fontSize: 12, fontWeight: '600' },
+  photoCount: { fontSize: 12 },
+});

--- a/frontend/components/records/DiaryPhotoPicker.tsx
+++ b/frontend/components/records/DiaryPhotoPicker.tsx
@@ -1,0 +1,151 @@
+/**
+ * 일기 사진 첨부 — 마이페이지 ImagePicker 패턴 재사용, 다중 선택
+ */
+
+import Feather from '@expo/vector-icons/Feather';
+import * as ImagePicker from 'expo-image-picker';
+import React, { useCallback } from 'react';
+import {
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { spacing } from '../../themes/design-tokens';
+import { useTheme } from '../../themes/ThemeContext';
+
+export interface LocalDiaryPhoto {
+  uri: string;
+  mimeType: string;
+}
+
+interface DiaryPhotoPickerProps {
+  photos: LocalDiaryPhoto[];
+  onChange: (photos: LocalDiaryPhoto[]) => void;
+  disabled?: boolean;
+  error?: string | null;
+}
+
+export function DiaryPhotoPicker({
+  photos,
+  onChange,
+  disabled = false,
+  error = null,
+}: DiaryPhotoPickerProps) {
+  const { theme } = useTheme();
+
+  const pickPhotos = useCallback(async () => {
+    if (disabled) return;
+    const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!perm.granted) return;
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsMultipleSelection: true,
+      quality: 0.85,
+      selectionLimit: 10,
+    });
+    if (result.canceled || !result.assets.length) return;
+
+    const next = result.assets.map((asset) => ({
+      uri: asset.uri,
+      mimeType: asset.mimeType ?? 'image/jpeg',
+    }));
+    onChange([...photos, ...next].slice(0, 10));
+  }, [disabled, onChange, photos]);
+
+  const removeAt = useCallback(
+    (index: number) => {
+      onChange(photos.filter((_, i) => i !== index));
+    },
+    [onChange, photos],
+  );
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={[styles.label, { color: theme.foreground }]}>사진 첨부</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.row}
+      >
+        <Pressable
+          onPress={() => void pickPhotos()}
+          disabled={disabled || photos.length >= 10}
+          style={({ pressed }) => [
+            styles.addBtn,
+            {
+              borderColor: theme.cardBorder,
+              backgroundColor: theme.inputBackground,
+              opacity: disabled || photos.length >= 10 ? 0.45 : pressed ? 0.85 : 1,
+            },
+          ]}
+          accessibilityLabel="사진 추가"
+        >
+          <Feather name="plus" size={22} color={theme.primaryGlow} />
+        </Pressable>
+
+        {photos.map((photo, index) => (
+          <View key={`${photo.uri}-${index}`} style={styles.thumbWrap}>
+            <Image source={{ uri: photo.uri }} style={styles.thumb} />
+            <Pressable
+              onPress={() => removeAt(index)}
+              disabled={disabled}
+              style={[styles.removeBtn, { backgroundColor: 'rgba(0,0,0,0.65)' }]}
+              accessibilityLabel="사진 제거"
+            >
+              <Feather name="x" size={12} color="#fff" />
+            </Pressable>
+          </View>
+        ))}
+      </ScrollView>
+      <Text style={[styles.hint, { color: theme.mutedForeground }]}>
+        최대 10장 · {photos.length}장 선택됨
+      </Text>
+      {error ? (
+        <Text style={[styles.error, { color: theme.destructive }]}>{error}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const THUMB = 72;
+
+const styles = StyleSheet.create({
+  wrap: { gap: spacing.sm },
+  label: { fontSize: 13, fontWeight: '500' },
+  row: { flexDirection: 'row', alignItems: 'center', gap: spacing.sm, paddingVertical: 2 },
+  addBtn: {
+    width: THUMB,
+    height: THUMB,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  thumbWrap: {
+    width: THUMB,
+    height: THUMB,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  thumb: {
+    width: THUMB,
+    height: THUMB,
+  },
+  removeBtn: {
+    position: 'absolute',
+    top: 4,
+    right: 4,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  hint: { fontSize: 11 },
+  error: { fontSize: 12 },
+});

--- a/frontend/components/records/DiarySegmentTabs.tsx
+++ b/frontend/components/records/DiarySegmentTabs.tsx
@@ -15,9 +15,9 @@ interface DiarySegmentTabsProps {
 }
 
 const SECTIONS: { key: DiarySectionKey; label: string; accessibilityLabel: string }[] = [
-  { key: 'write', label: 'DIARY 작성', accessibilityLabel: 'DIARY 작성' },
-  { key: 'browse', label: '펼쳐보기', accessibilityLabel: 'DIARY 펼쳐보기' },
-  { key: 'register-spot', label: '명소 등록', accessibilityLabel: '명소 등록하기' },
+  { key: 'write', label: '일기 작성', accessibilityLabel: '일기 작성' },
+  { key: 'browse', label: '펼쳐보기', accessibilityLabel: '일기 펼쳐보기' },
+  { key: 'register-spot', label: '명소 제보', accessibilityLabel: '명소 제보하기' },
 ];
 
 export function DiarySegmentTabs({ active, onChange }: DiarySegmentTabsProps) {

--- a/frontend/components/records/DiaryWriteModal.tsx
+++ b/frontend/components/records/DiaryWriteModal.tsx
@@ -1,0 +1,240 @@
+/**
+ * 일기 작성 모달 — 제목 · 사진 · 본문 · 저장
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { spacing } from '../../themes/design-tokens';
+import { useTheme } from '../../themes/ThemeContext';
+import { Button, Input } from '../ui';
+import {
+  ApiRequestError,
+  createObservation,
+  SessionExpiredError,
+  uploadObservationPhoto,
+} from '../../lib/api-client';
+import type { StarIndexResponseDto } from '../../lib/types/api';
+import { DiaryPhotoPicker, type LocalDiaryPhoto } from './DiaryPhotoPicker';
+import type { ObservationResult } from './ObservationResultPicker';
+
+interface DiaryWriteModalProps {
+  visible: boolean;
+  result: ObservationResult;
+  starIndexData: StarIndexResponseDto;
+  spotId?: string;
+  onClose: () => void;
+  onSaved: () => void;
+  onSessionInvalidated: () => Promise<void>;
+}
+
+export function DiaryWriteModal({
+  visible,
+  result,
+  starIndexData,
+  spotId,
+  onClose,
+  onSaved,
+  onSessionInvalidated,
+}: DiaryWriteModalProps) {
+  const { theme } = useTheme();
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [photos, setPhotos] = useState<LocalDiaryPhoto[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!visible) return;
+    setTitle('');
+    setContent('');
+    setPhotos([]);
+    setError(null);
+  }, [visible]);
+
+  const save = useCallback(async () => {
+    const trimmedTitle = title.trim();
+    const trimmedContent = content.trim();
+    if (!trimmedTitle) {
+      setError('제목을 입력해 주세요.');
+      return;
+    }
+    if (!trimmedContent) {
+      setError('내용을 입력해 주세요.');
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      const created = await createObservation({
+        spotId,
+        starIndexVal: starIndexData.score,
+        weatherSnapshot: starIndexData.weatherSnapshot as unknown as Record<string, unknown>,
+        result,
+        title: trimmedTitle,
+        content: trimmedContent,
+      });
+
+      for (const photo of photos) {
+        await uploadObservationPhoto(created.id, photo.uri, photo.mimeType);
+      }
+
+      onSaved();
+      onClose();
+    } catch (e) {
+      if (e instanceof SessionExpiredError) {
+        await onSessionInvalidated();
+        return;
+      }
+      setError(
+        e instanceof ApiRequestError ? e.message : '일기 저장에 실패했습니다.',
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    content,
+    onClose,
+    onSaved,
+    onSessionInvalidated,
+    photos,
+    result,
+    spotId,
+    starIndexData,
+    title,
+  ]);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={styles.backdrop}>
+          <Pressable style={StyleSheet.absoluteFill} onPress={onClose} accessibilityLabel="닫기" />
+          <View
+            style={[styles.sheet, { backgroundColor: theme.deepNavy, borderColor: theme.border }]}
+          >
+            <View style={[styles.handle, { backgroundColor: theme.border }]} />
+            <Text style={[styles.title, { color: theme.foreground }]}>오늘의 일기</Text>
+
+            <ScrollView
+              style={[styles.scroll, { backgroundColor: theme.deepNavy }]}
+              contentContainerStyle={styles.scrollInner}
+              keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator={false}
+            >
+              <Input
+                label="제목"
+                value={title}
+                onChangeText={setTitle}
+                placeholder="오늘 밤하늘은 어땠나요?"
+                maxLength={120}
+              />
+
+              <DiaryPhotoPicker photos={photos} onChange={setPhotos} disabled={busy} />
+
+              <View style={styles.contentWrap}>
+                <Text style={[styles.contentLabel, { color: theme.foreground }]}>내용</Text>
+                <TextInput
+                  value={content}
+                  onChangeText={setContent}
+                  placeholder="별 관측 이야기를 자유롭게 적어 보세요"
+                  placeholderTextColor={theme.mutedForeground}
+                  multiline
+                  textAlignVertical="top"
+                  maxLength={5000}
+                  style={[
+                    styles.contentInput,
+                    {
+                      color: theme.foreground,
+                      backgroundColor: theme.inputBackground,
+                      borderColor: theme.cardBorder,
+                    },
+                  ]}
+                />
+              </View>
+
+              {error ? (
+                <Text style={[styles.err, { color: theme.destructive }]}>{error}</Text>
+              ) : null}
+
+              {busy ? (
+                <ActivityIndicator color={theme.primaryGlow} style={{ marginVertical: 8 }} />
+              ) : null}
+            </ScrollView>
+
+            <View style={styles.btnRow}>
+              <View style={{ flex: 1 }}>
+                <Button label="취소" variant="outline" fullWidth disabled={busy} onPress={onClose} />
+              </View>
+              <View style={{ flex: 1 }}>
+                <Button
+                  label="저장"
+                  fullWidth
+                  loading={busy}
+                  disabled={busy}
+                  onPress={() => void save()}
+                />
+              </View>
+            </View>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.72)',
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    maxHeight: '92%',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    borderWidth: 1,
+    borderBottomWidth: 0,
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.xl,
+    paddingTop: spacing.sm,
+    overflow: 'hidden',
+    zIndex: 1,
+  },
+  handle: {
+    alignSelf: 'center',
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    marginBottom: spacing.md,
+  },
+  title: { fontSize: 18, fontWeight: '700', marginBottom: spacing.md },
+  scroll: { maxHeight: 420 },
+  scrollInner: { gap: spacing.md, paddingBottom: spacing.sm },
+  contentWrap: { gap: spacing.sm },
+  contentLabel: { fontSize: 13, fontWeight: '500' },
+  contentInput: {
+    minHeight: 140,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  err: { fontSize: 12 },
+  btnRow: { flexDirection: 'row', gap: 10, marginTop: spacing.md },
+});

--- a/frontend/components/records/ObservationResultPicker.tsx
+++ b/frontend/components/records/ObservationResultPicker.tsx
@@ -1,0 +1,166 @@
+/**
+ * 관측 결과 선택 — 성공 / 부분 / 실패 (보더리스 탭 스타일)
+ */
+
+import Feather from '@expo/vector-icons/Feather';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { spacing } from '../../themes/design-tokens';
+import type { ThemeTokens } from '../../themes/themes';
+import { useTheme } from '../../themes/ThemeContext';
+
+export type ObservationResult = 'success' | 'partial' | 'fail';
+
+const OPTIONS: {
+  key: ObservationResult;
+  label: string;
+  icon: React.ComponentProps<typeof Feather>['name'];
+}[] = [
+  { key: 'success', label: '성공', icon: 'check' },
+  { key: 'partial', label: '부분', icon: 'minus' },
+  { key: 'fail', label: '실패', icon: 'x' },
+];
+
+function accentFor(key: ObservationResult, theme: ThemeTokens): string {
+  if (key === 'success') return theme.primaryGlow;
+  if (key === 'partial') return theme.secondary;
+  return theme.destructive;
+}
+
+interface ObservationResultPickerProps {
+  value: ObservationResult;
+  onChange: (value: ObservationResult) => void;
+}
+
+export function ObservationResultPicker({ value, onChange }: ObservationResultPickerProps) {
+  const { theme } = useTheme();
+  const activeIndex = OPTIONS.findIndex((o) => o.key === value);
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={[styles.caption, { color: theme.mutedForeground }]}>오늘 관측은 어땠나요?</Text>
+
+      <View style={styles.row}>
+        {OPTIONS.map((opt) => {
+          const active = value === opt.key;
+          const accent = accentFor(opt.key, theme);
+
+          return (
+            <Pressable
+              key={opt.key}
+              onPress={() => onChange(opt.key)}
+              style={({ pressed }) => [
+                styles.option,
+                { opacity: pressed ? 0.82 : 1 },
+              ]}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: active }}
+            >
+              <View style={styles.iconStack}>
+                {active ? (
+                  <View
+                    style={[
+                      styles.iconHalo,
+                      {
+                        backgroundColor:
+                          opt.key === 'success'
+                            ? theme.primaryGlowMuted
+                            : opt.key === 'partial'
+                              ? 'rgba(93, 173, 235, 0.14)'
+                              : 'rgba(239, 68, 68, 0.12)',
+                        shadowColor: accent,
+                      },
+                    ]}
+                  />
+                ) : null}
+                <Feather
+                  name={opt.icon}
+                  size={active ? 20 : 18}
+                  color={active ? accent : theme.mutedForeground}
+                />
+              </View>
+              <Text
+                style={[
+                  styles.label,
+                  {
+                    color: active ? accent : theme.mutedForeground,
+                    fontWeight: active ? '600' : '500',
+                  },
+                ]}
+              >
+                {opt.label}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <View style={[styles.track, { backgroundColor: theme.borderSubtle }]}>
+        <View
+          style={[
+            styles.thumb,
+            {
+              width: `${100 / OPTIONS.length}%`,
+              left: `${(100 / OPTIONS.length) * activeIndex}%`,
+              backgroundColor: accentFor(value, theme),
+              shadowColor: accentFor(value, theme),
+            },
+          ]}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    gap: spacing.sm,
+  },
+  caption: {
+    fontSize: 12,
+    letterSpacing: 0.1,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+  },
+  option: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 6,
+  },
+  iconStack: {
+    width: 44,
+    height: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  iconHalo: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 22,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.45,
+    shadowRadius: 10,
+    elevation: 2,
+  },
+  label: {
+    fontSize: 13,
+    letterSpacing: 0.15,
+  },
+  track: {
+    height: 2,
+    borderRadius: 1,
+    overflow: 'hidden',
+    marginTop: 2,
+  },
+  thumb: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    borderRadius: 1,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.55,
+    shadowRadius: 6,
+  },
+});

--- a/frontend/components/records/RecordsTabScreen.tsx
+++ b/frontend/components/records/RecordsTabScreen.tsx
@@ -11,14 +11,14 @@ import {
 import { screenHeaderText, screenSubheaderText, spacing } from '../../themes/design-tokens';
 import { useTheme } from '../../themes/ThemeContext';
 import { Button, Card } from '../ui';
-import { spotNameWithoutRegionPrefix, spotRegionSubtitle } from '../../lib/spot-display-name';
-import { fetchSpotsAll } from '../../lib/spots-api';
-import type { SpotDto } from '../../lib/types/api';
 import { DiarySegmentTabs, type DiarySectionKey } from './DiarySegmentTabs';
-import { ObservationLogCard } from './ObservationLogCard';
+import { DiaryDetailModal } from './DiaryDetailModal';
+import { DiaryEntryCard } from './DiaryEntryCard';
+import { DiaryWriteModal } from './DiaryWriteModal';
+import { SpotReportSection } from './SpotReportSection';
+import { ObservationResultPicker, type ObservationResult } from './ObservationResultPicker';
 import {
   ApiRequestError,
-  createObservation,
   fetchMyObservations,
   fetchStarIndex,
   fetchStarIndexAtLocation,
@@ -55,7 +55,6 @@ export function RecordsTabScreen({
   const [list, setList] = useState<ObservationRowDto[]>([]);
   const [listLoading, setListLoading] = useState(true);
   const [listErr, setListErr] = useState<string | null>(null);
-  const [spotById, setSpotById] = useState<Map<string, SpotDto>>(() => new Map());
 
   const [siData, setSiData] = useState<StarIndexResponseDto | null>(null);
   const [siLoading, setSiLoading] = useState(false);
@@ -65,16 +64,16 @@ export function RecordsTabScreen({
   /** true면 저장 시 spotId 없이 좌표 스냅샷만 (잘못된 명소 연결 방지) */
   const [siFromGps, setSiFromGps] = useState(false);
 
-  const [result, setResult] = useState<'success' | 'partial' | 'fail'>('success');
-  const [saveBusy, setSaveBusy] = useState(false);
-  const [saveMsg, setSaveMsg] = useState<string | null>(null);
+  const [result, setResult] = useState<ObservationResult>('success');
+  const [writeModalOpen, setWriteModalOpen] = useState(false);
+  const [detailRow, setDetailRow] = useState<ObservationRowDto | null>(null);
 
   const loadList = useCallback(async () => {
     setListLoading(true);
     setListErr(null);
     try {
       const rows = await fetchMyObservations();
-      setList(rows);
+      setList(rows.map((row) => ({ ...row, photos: row.photos ?? [] })));
     } catch (e) {
       if (e instanceof SessionExpiredError) {
         await onSessionInvalidated();
@@ -201,77 +200,20 @@ export function RecordsTabScreen({
   }, [loadList]);
 
   useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const spots = await fetchSpotsAll();
-        if (cancelled) return;
-        setSpotById(new Map(spots.map((s) => [s.id, s])));
-      } catch {
-        /* 명소 이름 없이 카드만 표시 */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const resolveLogCardLabels = useCallback(
-    (row: ObservationRowDto): { title: string; regionSubtitle?: string } => {
-      if (row.spotId) {
-        const spot = spotById.get(row.spotId);
-        if (spot) {
-          return {
-            title: spotNameWithoutRegionPrefix(spot.name),
-            regionSubtitle: spotRegionSubtitle(spot.name) || undefined,
-          };
-        }
-        return { title: `관측지 …${row.spotId.slice(-6)}` };
-      }
-      return { title: 'GPS 관측' };
-    },
-    [spotById],
-  );
-
-  useEffect(() => {
     void loadSi();
   }, [loadSi]);
 
-  const onSave = async () => {
-    if (!siData) return;
-    setSaveBusy(true);
-    setSaveMsg(null);
-    try {
-      const spotForRow = siFromGps
-        ? undefined
-        : siData.spotId && siData.spotId.length > 0
-          ? siData.spotId
-          : activeSpotId ?? undefined;
-      await createObservation({
-        spotId: spotForRow,
-        starIndexVal: siData.score,
-        weatherSnapshot: siData.weatherSnapshot as unknown as Record<
-          string,
-          unknown
-        >,
-        result,
-      });
-      setSaveMsg('저장했습니다.');
-      await loadList();
-    } catch (e) {
-      if (e instanceof SessionExpiredError) {
-        await onSessionInvalidated();
-        return;
-      }
-      if (e instanceof ApiRequestError) {
-        setSaveMsg(e.message);
-      } else {
-        setSaveMsg('저장에 실패했습니다.');
-      }
-    } finally {
-      setSaveBusy(false);
-    }
-  };
+  const resolveSpotIdForSave = useCallback((): string | undefined => {
+    if (!siData) return undefined;
+    if (siFromGps) return undefined;
+    if (siData.spotId && siData.spotId.length > 0) return siData.spotId;
+    return activeSpotId ?? undefined;
+  }, [activeSpotId, siData, siFromGps]);
+
+  const onDiarySaved = useCallback(async () => {
+    await loadList();
+    setDiarySection('browse');
+  }, [loadList]);
 
   const hasObserverGps =
     observerLat != null &&
@@ -283,171 +225,167 @@ export function RecordsTabScreen({
     Platform.OS !== 'web' || hasObserverGps || Boolean(activeSpotId);
 
   return (
-    <ScrollView
-      style={styles.scroll}
-      contentContainerStyle={styles.inner}
-      showsVerticalScrollIndicator={false}
-    >
-      <Text style={[styles.title, screenHeaderText(theme.foreground)]}>관측 기록</Text>
-      <Text style={[styles.sub, screenSubheaderText(theme.mutedForeground)]}>
-        별자리 촬영 히스토리 · Star-Index 스냅샷으로 저장합니다.
-      </Text>
+    <>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.inner}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={[styles.title, screenHeaderText(theme.foreground)]}>관측 일기</Text>
+        <Text style={[styles.sub, screenSubheaderText(theme.mutedForeground)]}>
+          오늘의 밤하늘을 기록하고, Star-Index와 함께 남겨 보세요.
+        </Text>
 
-      <DiarySegmentTabs active={diarySection} onChange={setDiarySection} />
+        <DiarySegmentTabs active={diarySection} onChange={setDiarySection} />
 
-      {diarySection === 'write' ? (
-        <>
-          {!canLoadStarIndex ? (
-            <Card title="위치·명소 필요" description="위치 권한을 허용하거나 지도에서 명소를 고르세요">
-              <Text style={{ color: theme.mutedForeground, fontSize: 13 }}>
-                GPS가 켜지면 현재 위치 격자로 Star-Index를 불러옵니다. 없으면 EXPO_PUBLIC_DEFAULT_SPOT_ID
-                또는 지도 마커로 명소를 정할 수 있어요.
-              </Text>
-            </Card>
-          ) : (
-            <Card
-              title="현재 Star-Index"
-              description={
-                siPlaceLabel
-                  ? `${siPlaceLabel} 기준`
-                  : siData?.name ?? 'GPS·격자 기준으로 불러옵니다'
-              }
-            >
-              {siLoading ? (
-                <ActivityIndicator color={theme.primaryGlow} />
-              ) : siErr ? (
-                <Text style={{ color: theme.destructive }}>{siErr}</Text>
-              ) : siData ? (
-                <View>
-                  {(() => {
-                    const si = getStarIndexScoreDisplay(siData.score);
-                    return (
+        {diarySection === 'write' ? (
+          <>
+            {!canLoadStarIndex ? (
+              <Card title="위치·명소 필요" description="위치 권한을 허용하거나 지도에서 명소를 고르세요">
+                <Text style={{ color: theme.mutedForeground, fontSize: 13 }}>
+                  GPS가 켜지면 현재 위치 격자로 Star-Index를 불러옵니다. 없으면 EXPO_PUBLIC_DEFAULT_SPOT_ID
+                  또는 지도 마커로 명소를 정할 수 있어요.
+                </Text>
+              </Card>
+            ) : (
+              <Card
+                title="현재 Star-Index"
+                description={
+                  siPlaceLabel
+                    ? `${siPlaceLabel} 기준`
+                    : siData?.name ?? 'GPS·격자 기준으로 불러옵니다'
+                }
+              >
+                {siLoading ? (
+                  <ActivityIndicator color={theme.primaryGlow} />
+                ) : siErr ? (
+                  <Text style={{ color: theme.destructive }}>{siErr}</Text>
+                ) : siData ? (
+                  <View>
+                    {(() => {
+                      const si = getStarIndexScoreDisplay(siData.score);
+                      return (
+                        <Text
+                          style={{
+                            color: si.measurable ? theme.primaryGlow : theme.destructive,
+                            fontSize: si.measurable ? 28 : 20,
+                            fontWeight: '300',
+                          }}
+                        >
+                          {si.label}
+                        </Text>
+                      );
+                    })()}
+                    <Text style={{ color: theme.mutedForeground, fontSize: 12, marginTop: 6 }}>
+                      {(siPlaceLabel ?? siData.name) +
+                        ` · 구름 ${siData.weatherSnapshot.cloud_score}`}
+                    </Text>
+                    {siData.isStale ? (
                       <Text
                         style={{
-                          color: si.measurable ? theme.primaryGlow : theme.destructive,
-                          fontSize: si.measurable ? 28 : 20,
-                          fontWeight: '300',
+                          color: theme.primaryGlow,
+                          fontSize: 11,
+                          marginTop: 8,
+                          lineHeight: 16,
                         }}
                       >
-                        {si.label}
+                        {formatStarIndexStaleHint(siData.cachedAt)}
                       </Text>
-                    );
-                  })()}
-                  <Text style={{ color: theme.mutedForeground, fontSize: 12, marginTop: 6 }}>
-                    {(siPlaceLabel ?? siData.name) +
-                      ` · 구름 ${siData.weatherSnapshot.cloud_score}`}
-                  </Text>
-                  {siData.isStale ? (
-                    <Text
-                      style={{
-                        color: theme.primaryGlow,
-                        fontSize: 11,
-                        marginTop: 8,
-                        lineHeight: 16,
-                      }}
-                    >
-                      {formatStarIndexStaleHint(siData.cachedAt)}
-                    </Text>
-                  ) : null}
+                    ) : null}
+                  </View>
+                ) : null}
+                <View style={{ marginTop: 8 }}>
+                  <Button
+                    label="다시 불러오기"
+                    variant="outline"
+                    size="sm"
+                    onPress={() => void loadSi()}
+                    disabled={siLoading}
+                  />
                 </View>
-              ) : null}
-              <View style={{ marginTop: 8 }}>
+              </Card>
+            )}
+
+            <Card
+              title="일기 작성"
+              description={
+                siData?.isStale
+                  ? '참고 점수·스냅샷과 함께 일기를 남깁니다'
+                  : '오늘의 관측 결과를 선택하고 일기를 작성하세요'
+              }
+            >
+              <ObservationResultPicker value={result} onChange={setResult} />
+              <View style={{ marginTop: spacing.md }}>
                 <Button
-                  label="다시 불러오기"
-                  variant="outline"
-                  size="sm"
-                  onPress={() => void loadSi()}
-                  disabled={siLoading}
+                  label="오늘의 일기 쓰기"
+                  fullWidth
+                  disabled={!siData}
+                  onPress={() => setWriteModalOpen(true)}
                 />
               </View>
             </Card>
-          )}
+          </>
+        ) : null}
 
-          <Card
-            title="새 기록"
-            description={
-              siData?.isStale
-                ? '참고 점수·스냅샷으로 저장 (실시간 기상 캐시 없음)'
-                : '결과 선택 후 저장'
-            }
-          >
-            <View style={styles.row}>
-              {(
-                [
-                  ['success', '성공'],
-                  ['partial', '부분'],
-                  ['fail', '실패'],
-                ] as const
-              ).map(([key, label]) => (
-                <Button
-                  key={key}
-                  label={label}
-                  variant={result === key ? 'primary' : 'outline'}
-                  size="sm"
-                  onPress={() => setResult(key)}
-                />
-              ))}
-            </View>
-            <View style={{ marginTop: 12 }}>
-              <Button
-                label="이 스냅샷으로 저장"
-                fullWidth
-                loading={saveBusy}
-                disabled={!siData || saveBusy}
-                onPress={() => void onSave()}
-              />
-            </View>
-            {saveMsg ? (
-              <Text style={{ color: theme.mutedForeground, marginTop: 8, fontSize: 12 }}>
-                {saveMsg}
+        {diarySection === 'register-spot' ? (
+          <SpotReportSection
+            observerLat={observerLat}
+            observerLng={observerLng}
+            useDeviceLocation={useDeviceLocation}
+            onSessionInvalidated={onSessionInvalidated}
+          />
+        ) : null}
+
+        {diarySection === 'browse' ? (
+          <Card title="내 일기" description={listLoading ? '불러오는 중…' : `${list.length}건`}>
+            {listLoading ? (
+              <ActivityIndicator color={theme.primaryGlow} />
+            ) : listErr ? (
+              <Text style={{ color: theme.destructive }}>{listErr}</Text>
+            ) : list.length === 0 ? (
+              <Text style={{ color: theme.mutedForeground, fontSize: 13 }}>
+                아직 작성한 일기가 없습니다. DIARY 작성에서 첫 일기를 남겨 보세요.
               </Text>
-            ) : null}
-          </Card>
-        </>
-      ) : null}
-
-      {diarySection === 'register-spot' ? (
-        <Card
-          title="명소가 목록에 없나요?"
-          description="추후 GPS 또는 지역 선택으로 새 명소를 제안·등록할 수 있게 준비 중입니다."
-        >
-          <Text style={{ color: theme.mutedForeground, fontSize: 13, lineHeight: 19 }}>
-            DB에 없는 관측지도 커뮤니티와 함께 채워 나갈 예정이에요.
-          </Text>
-        </Card>
-      ) : null}
-
-      {diarySection === 'browse' ? (
-        <Card title="내 기록" description={listLoading ? '불러오는 중…' : `${list.length}건`}>
-          {listLoading ? (
-            <ActivityIndicator color={theme.primaryGlow} />
-          ) : listErr ? (
-            <Text style={{ color: theme.destructive }}>{listErr}</Text>
-          ) : list.length === 0 ? (
-            <Text style={{ color: theme.mutedForeground, fontSize: 13 }}>기록이 없습니다.</Text>
-          ) : (
-            <View style={styles.logList}>
-              {list.map((row) => {
-                const labels = resolveLogCardLabels(row);
-                return (
-                  <ObservationLogCard
+            ) : (
+              <View style={styles.logList}>
+                {list.map((row) => (
+                  <DiaryEntryCard
                     key={row.id}
                     row={row}
-                    title={labels.title}
-                    regionSubtitle={labels.regionSubtitle}
+                    onPress={() => setDetailRow(row)}
                   />
-                );
-              })}
-            </View>
-          )}
-          {!listLoading ? (
-            <View style={{ marginTop: 8 }}>
-              <Button label="목록 새로고침" variant="ghost" size="sm" onPress={() => void loadList()} />
-            </View>
-          ) : null}
-        </Card>
+                ))}
+              </View>
+            )}
+            {!listLoading ? (
+              <View style={{ marginTop: 8 }}>
+                <Button label="목록 새로고침" variant="ghost" size="sm" onPress={() => void loadList()} />
+              </View>
+            ) : null}
+          </Card>
+        ) : null}
+      </ScrollView>
+
+      {siData ? (
+        <DiaryWriteModal
+          visible={writeModalOpen}
+          result={result}
+          starIndexData={siData}
+          spotId={resolveSpotIdForSave()}
+          onClose={() => setWriteModalOpen(false)}
+          onSaved={() => void onDiarySaved()}
+          onSessionInvalidated={onSessionInvalidated}
+        />
       ) : null}
-    </ScrollView>
+
+      <DiaryDetailModal
+        visible={detailRow != null}
+        row={detailRow}
+        onClose={() => setDetailRow(null)}
+        onDeleted={() => void loadList()}
+        onSessionInvalidated={onSessionInvalidated}
+      />
+    </>
   );
 }
 
@@ -456,7 +394,6 @@ const styles = StyleSheet.create({
   inner: { padding: spacing.lg, paddingBottom: 32 },
   title: { marginBottom: 4 },
   sub: { marginBottom: spacing.lg },
-  row: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
   logList: {
     marginTop: spacing.xs,
   },

--- a/frontend/components/records/SpotReportSection.tsx
+++ b/frontend/components/records/SpotReportSection.tsx
@@ -1,0 +1,177 @@
+/**
+ * 명소 제보 — GPS + 텍스트를 관리자에게 전송
+ */
+
+import * as Location from 'expo-location';
+import React, { useCallback, useState } from 'react';
+import {
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import {
+  ApiRequestError,
+  SessionExpiredError,
+  submitSpotReport,
+} from '../../lib/api-client';
+import { spacing } from '../../themes/design-tokens';
+import { useTheme } from '../../themes/ThemeContext';
+import { Button, Card } from '../ui';
+
+interface SpotReportSectionProps {
+  observerLat?: number | null;
+  observerLng?: number | null;
+  useDeviceLocation?: boolean;
+  onSessionInvalidated: () => Promise<void>;
+}
+
+async function resolveGps(
+  observerLat: number | null | undefined,
+  observerLng: number | null | undefined,
+  useDeviceLocation: boolean,
+): Promise<{ lat: number; lng: number } | null> {
+  if (useDeviceLocation && Platform.OS !== 'web') {
+    try {
+      const perm = await Location.getForegroundPermissionsAsync();
+      if (perm.status === Location.PermissionStatus.GRANTED) {
+        const pos = await Location.getCurrentPositionAsync({
+          accuracy: Location.Accuracy.Balanced,
+        });
+        return { lat: pos.coords.latitude, lng: pos.coords.longitude };
+      }
+    } catch {
+      /* 폴백 */
+    }
+  }
+
+  if (
+    observerLat != null &&
+    observerLng != null &&
+    Number.isFinite(observerLat) &&
+    Number.isFinite(observerLng)
+  ) {
+    return { lat: observerLat, lng: observerLng };
+  }
+
+  return null;
+}
+
+export function SpotReportSection({
+  observerLat = null,
+  observerLng = null,
+  useDeviceLocation = true,
+  onSessionInvalidated,
+}: SpotReportSectionProps) {
+  const { theme } = useTheme();
+  const [message, setMessage] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const submit = useCallback(async () => {
+    const trimmed = message.trim();
+    if (!trimmed) {
+      setError('명소 설명을 입력해 주세요.');
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+
+    try {
+      const coords = await resolveGps(observerLat, observerLng, useDeviceLocation);
+      if (!coords) {
+        setError('위치 권한을 허용하거나 GPS를 켜 주세요.');
+        return;
+      }
+
+      await submitSpotReport({
+        message: trimmed,
+        lat: coords.lat,
+        lng: coords.lng,
+      });
+
+      setMessage('');
+      setSuccess('제보를 보냈습니다.');
+    } catch (e) {
+      if (e instanceof SessionExpiredError) {
+        await onSessionInvalidated();
+        return;
+      }
+      setError(
+        e instanceof ApiRequestError ? e.message : '명소 제보에 실패했습니다.',
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [message, observerLat, observerLng, onSessionInvalidated, useDeviceLocation]);
+
+  return (
+    <Card
+      title="명소 제보"
+      description="목록에 없는 관측지를 알려 주세요. 현재 GPS와 Star-Index가 함께 전달됩니다."
+    >
+      <View style={styles.field}>
+        <Text style={[styles.label, { color: theme.foreground }]}>명소 설명</Text>
+        <TextInput
+          value={message}
+          onChangeText={(text) => {
+            setMessage(text);
+            setError(null);
+            setSuccess(null);
+          }}
+          placeholder="예: 주차 가능한 언덕, 동쪽 하늘이 잘 보여요"
+          placeholderTextColor={theme.mutedForeground}
+          multiline
+          textAlignVertical="top"
+          maxLength={500}
+          editable={!busy}
+          style={[
+            styles.input,
+            {
+              color: theme.foreground,
+              backgroundColor: theme.inputBackground,
+              borderColor: theme.cardBorder,
+            },
+          ]}
+        />
+        <Text style={[styles.hint, { color: theme.mutedForeground }]}>
+          {message.length}/500
+        </Text>
+      </View>
+
+      {error ? (
+        <Text style={[styles.feedback, { color: theme.destructive }]}>{error}</Text>
+      ) : null}
+      {success && !busy ? (
+        <Text style={[styles.feedback, { color: theme.primaryGlow }]}>{success}</Text>
+      ) : null}
+
+      <Button
+        label="명소 제보 보내기"
+        fullWidth
+        loading={busy}
+        disabled={busy}
+        onPress={() => void submit()}
+      />
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  field: { gap: spacing.sm, marginBottom: spacing.md },
+  label: { fontSize: 13, fontWeight: '500' },
+  input: {
+    minHeight: 120,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  hint: { fontSize: 11, textAlign: 'right' },
+  feedback: { fontSize: 12, lineHeight: 18, marginBottom: spacing.sm },
+});

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -733,6 +733,11 @@ export function submitStarIndexCorrection(
   );
 }
 
+export interface ObservationPhotoDto {
+  id: string;
+  imageUrl: string;
+}
+
 export interface ObservationRowDto {
   id: string;
   userId: string;
@@ -740,7 +745,10 @@ export interface ObservationRowDto {
   starIndexVal: number;
   weatherSnapshot: StarIndexResponseDto['weatherSnapshot'];
   result: 'success' | 'partial' | 'fail';
+  title: string | null;
+  content: string | null;
   observedAt: string;
+  photos: ObservationPhotoDto[];
 }
 
 export function fetchMyObservations(): Promise<ObservationRowDto[]> {
@@ -752,10 +760,108 @@ export interface CreateObservationPayload {
   starIndexVal: number;
   weatherSnapshot: Record<string, unknown>;
   result: 'success' | 'partial' | 'fail';
+  title?: string;
+  content?: string;
 }
 
 export function createObservation(
   payload: CreateObservationPayload,
 ): Promise<ObservationRowDto> {
   return authorizedPostJson<ObservationRowDto>('/observations', payload);
+}
+
+export async function uploadObservationPhoto(
+  observationId: string,
+  localUri: string,
+  mimeType: string,
+): Promise<ObservationRowDto> {
+  const { accessToken, refreshToken } = await loadTokens();
+  if (!accessToken || !refreshToken) {
+    throw new SessionExpiredError();
+  }
+
+  const ext =
+    mimeType === 'image/png' ? 'png' : mimeType === 'image/webp' ? 'webp' : 'jpg';
+  const form = new FormData();
+  form.append('file', {
+    uri: localUri,
+    name: `diary.${ext}`,
+    type: mimeType,
+  } as unknown as Blob);
+
+  const path = `/observations/${observationId}/photos`;
+  const doFetch = (token: string) =>
+    fetch(`${getApiBaseUrl()}${path}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: form,
+    });
+
+  let res = await doFetch(accessToken);
+  if (res.status === 401) {
+    try {
+      const next = await requestAccessRefresh(refreshToken);
+      await setAccessToken(next);
+      res = await doFetch(next);
+    } catch {
+      await clearSession();
+      throw new SessionExpiredError();
+    }
+  }
+
+  const body = await parseJsonSafe(res);
+  if (!res.ok) {
+    throw new ApiRequestError(
+      messageFromErrorBody(body, '일기 사진 업로드에 실패했습니다.'),
+      res.status,
+      body,
+    );
+  }
+  return body as ObservationRowDto;
+}
+
+export function deleteObservation(id: string): Promise<{ message: string }> {
+  return authorizedDeleteJson<{ message: string }>(`/observations/${id}`);
+}
+
+export type ObservationMismatchType =
+  | 'unmeasurable_but_success'
+  | 'high_score_but_fail';
+
+export interface ObservationReportStatusDto {
+  submitted: boolean;
+  status?: 'pending' | 'reviewed';
+  createdAt?: string;
+}
+
+export function fetchObservationReportStatus(
+  observationId: string,
+): Promise<ObservationReportStatusDto> {
+  return authorizedGetJson<ObservationReportStatusDto>(
+    `/observation-reports/status/${observationId}`,
+  );
+}
+
+export interface SubmitObservationReportPayload {
+  observationId: string;
+  mismatchType: ObservationMismatchType;
+  message?: string;
+}
+
+export function submitObservationMismatchReport(
+  payload: SubmitObservationReportPayload,
+): Promise<{ id: string; status: string; createdAt: string }> {
+  return authorizedPostJson('/observation-reports', payload);
+}
+
+export interface SubmitSpotReportPayload {
+  message: string;
+  lat: number;
+  lng: number;
+}
+
+export function submitSpotReport(
+  payload: SubmitSpotReportPayload,
+): Promise<{ id: string; starIndexVal: number; latitude: number; longitude: number; createdAt: string }> {
+  return authorizedPostJson('/spot-reports', payload);
 }

--- a/frontend/lib/observation-mismatch.ts
+++ b/frontend/lib/observation-mismatch.ts
@@ -1,0 +1,43 @@
+import { getStarIndexScoreDisplay } from './star-index-display';
+
+/** Star-Index 50 미만이면 UI상 측정불가 */
+export const STAR_INDEX_MEASURABLE_MIN = 50;
+
+/** “점수가 높음” 판정 기준 */
+export const STAR_INDEX_HIGH_SCORE_THRESHOLD = 70;
+
+export type ObservationMismatchType =
+  | 'unmeasurable_but_success'
+  | 'high_score_but_fail';
+
+export function detectObservationMismatch(
+  starIndexVal: number,
+  result: 'success' | 'partial' | 'fail',
+): ObservationMismatchType | null {
+  const si = getStarIndexScoreDisplay(starIndexVal);
+  if (!si.measurable && result === 'success') {
+    return 'unmeasurable_but_success';
+  }
+  if (
+    si.measurable &&
+    starIndexVal >= STAR_INDEX_HIGH_SCORE_THRESHOLD &&
+    result === 'fail'
+  ) {
+    return 'high_score_but_fail';
+  }
+  return null;
+}
+
+export function mismatchHint(type: ObservationMismatchType): string {
+  if (type === 'unmeasurable_but_success') {
+    return 'Star-Index는 측정불가인데 관측 결과가 성공으로 기록되어 있습니다. 실제 관측과 점수가 다르다면 제보해 주세요.';
+  }
+  return 'Star-Index 점수는 높은 편인데 관측 결과가 실패로 기록되어 있습니다. 실제 관측과 점수가 다르다면 제보해 주세요.';
+}
+
+export function mismatchTypeLabel(type: ObservationMismatchType): string {
+  if (type === 'unmeasurable_but_success') {
+    return '측정불가 · 관측 성공';
+  }
+  return '높은 점수 · 관측 실패';
+}


### PR DESCRIPTION
## 🔎 What
### Frontend — DIARY 일기
- 하단 탭 **관측 기록 → 관측 일기** 톤 정리, 세그먼트 **일기 작성 | 펼쳐보기 | 명소 제보** (`DiarySegmentTabs`)
- **일기 작성**: `ObservationResultPicker` (보더리스 탭 + 하단 인디케이터), 「오늘의 일기 쓰기」 → `DiaryWriteModal` (제목·다중 사진·본문·저장)
- **펼쳐보기**: `DiaryEntryCard` 카드 목록 → `DiaryDetailModal` 상세 (관측 결과·Star-Index·사진·삭제)
- 일기 상세/작성 모달: `theme.deepNavy` 불투명 시트, 바깥 터치 닫기, 사진 `FlatList` 가로 스크롤 (3장+ 제스처 충돌 수정)
- 불일치 시 제보 UI: 측정불가+성공 / 고점수+실패 → 「불일치 제보하기」
### Frontend — 명소 제보
- `SpotReportSection`: 명소 설명 입력 + 「명소 제보 보내기」 (GPS + 서버 Star-Index 스냅샷)
- 로딩은 버튼 스피너만, 성공 문구 **「제보를 보냈습니다.」**
### Backend — Observations / Photos
- Migration `1751000000000`: observations `title`, `content`
- `POST /observations`, `POST /observations/:id/photos`, `DELETE /observations/:id`
- 목록 응답에 `photos[]` 포함, Supabase `diary-photos` 버킷 업로드
### Backend — 불일치 제보
- Migration `1751100000000`: `observation_mismatch_reports`
- `POST /observation-reports`, `GET /observation-reports/status/:observationId`
- Admin: `GET/PATCH /admin/observation-reports`, `admin/observation-reports.html`
- `ADMIN_EMAILS` 화이트리스트 + `AdminGuard`
### Backend — 명소 제보
- Migration `1751200000000`: `spot_reports` (GPS, message, star_index_val, weather_snapshot)
- `POST /spot-reports` (제보 시 `calculateForLatLngFromCache`로 Star-Index 계산)
- Admin: `GET/DELETE /admin/spot-reports`, `admin/spot-reports.html` (삭제만, 점수 50 미만 → 측정불가 표기)

🔗 Issue
closes: #91 

✅ 체크리스트
- [x] 브랜치 base가 적절한가요? (develop)
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?

## Test plan
- [x] `npm run migration:run` (1751000000000, 1751100000000, 1751200000000)
- [x] Supabase `diary-photos` public 버킷 생성
- [x] `backend/.env`에 `ADMIN_EMAILS` 설정 후 백엔드 재시작
- [x] DIARY **일기 작성**: 결과 선택 → 오늘의 일기 쓰기 → 제목·사진·본문 저장 → 펼쳐보기 카드 노출
- [x] 일기 상세: 뒤 화면 비침 없음, 사진 4장+ 좌우 스크롤, 삭제 동작
- [x] 불일치 조건 일기에서 제보 → `admin/observation-reports.html` 목록 확인
- [x] **명소 제보**: GPS 허용 → 텍스트 입력 → 제보 → `admin/spot-reports.html` (점수·GPS·지도 링크·삭제)
