### PR TITLE
feat: 가상 밤하늘 뷰어(SVG·GL) 시점·비주얼 개선 

### DIFF
--- a/frontend/components/sky/SkyGlCanvas.tsx
+++ b/frontend/components/sky/SkyGlCanvas.tsx
@@ -8,7 +8,14 @@ import type {
   SkyViewStarDto,
 } from '../../lib/api-client';
 import { createSkyGlTextures, deleteSkyGlTextures } from './gl-textures';
-import { azAltToNorm, magToRadius, planetDiskRadius, rotateSkyNorm } from './sky-projection';
+import {
+  dirFromAzAlt,
+  GL_FOV_V_DEG,
+  magToRadius,
+  planetDiskRadius,
+  projectPerspectiveClip,
+  type ViewBasis,
+} from './sky-projection';
 
 type Rgb = [number, number, number];
 
@@ -57,21 +64,6 @@ function createProgram(gl: WebGLRenderingContext, vs: string, fs: string): WebGL
   return p;
 }
 
-/** 스타렐리움식 천장 좌표(nx,ny) → clip (-1..1), sky-projection·SVG와 동일 */
-function normToClip(
-  nx: number,
-  ny: number,
-  w: number,
-  h: number,
-): { x: number; y: number } {
-  const scale = Math.min(w, h) / 100;
-  const ox = (w - 100 * scale) / 2;
-  const oy = (h - 100 * scale) / 2;
-  const px = ox + nx * scale;
-  const py = oy + ny * scale;
-  return { x: (px / w) * 2 - 1, y: 1 - (py / h) * 2 };
-}
-
 /** 시각등급 → 밝기·살짝 푸른 백색 */
 function starRgbFromMag(mag: number): Rgb {
   const m = Math.max(-2, Math.min(7, mag));
@@ -92,46 +84,38 @@ void main() {
 }
 `;
 
-/** 역회전 + 프로시저럴 텍스처 샘플(은하·지평선 림) */
+/** 원근 카메라: 화면 픽셀 → 시선 광선(직선 투영) → 고도별 대기색·은하·지평선 */
 const FS_SKY_DOME = `
 precision mediump float;
 varying vec2 v_ndc;
-uniform vec2 u_resolution;
-uniform float u_ox;
-uniform float u_oy;
-uniform float u_scale;
-uniform float u_skyRotDeg;
+uniform vec3 u_fwd;
+uniform vec3 u_right;
+uniform vec3 u_up;
+uniform vec3 u_sunDir;
+uniform float u_sunAlt;
+uniform float u_tanHalfFov;
+uniform float u_aspect;
 uniform sampler2D u_milky;
 uniform sampler2D u_horizonRim;
 
-const vec2 ZEN = vec2(50.0, 50.0);
-
 void main() {
-  float px = (v_ndc.x * 0.5 + 0.5) * u_resolution.x;
-  float py = (v_ndc.y * 0.5 + 0.5) * u_resolution.y;
-  float nx = (px - u_ox) / u_scale;
-  float ny = (py - u_oy) / u_scale;
-  vec2 p = vec2(nx, ny) - ZEN;
-  float rad = radians(u_skyRotDeg);
-  float c = cos(rad);
-  float s = sin(rad);
-  vec2 sky = vec2(p.x * c + p.y * s, -p.x * s + p.y * c) + ZEN;
-  float r = distance(sky, ZEN);
+  // 풀스크린 NDC(-1..1) → 원근 광선. 화면을 사각형으로 가득 채움(둥근 테두리 없음)
+  vec3 dir = normalize(
+    u_fwd
+    + v_ndc.x * u_tanHalfFov * u_aspect * u_right
+    + v_ndc.y * u_tanHalfFov * u_up
+  );
+  float altDeg = degrees(asin(clamp(dir.z, -1.0, 1.0)));
 
-  if (r > 49.2) {
-    gl_FragColor = vec4(0.015, 0.018, 0.022, 1.0);
-    return;
-  }
-
-  if (r > 46.15) {
-    float t = clamp((r - 46.15) / 3.2, 0.0, 1.0);
+  // 지평선 아래 = 땅
+  if (altDeg < 0.0) {
+    float t = clamp(-altDeg / 12.0, 0.0, 1.0);
     vec3 treetop = vec3(0.03, 0.06, 0.025);
     vec3 ground = vec3(0.012, 0.014, 0.018);
-    gl_FragColor = vec4(mix(treetop, ground, smoothstep(0.2, 1.0, t)), 1.0);
+    gl_FragColor = vec4(mix(treetop, ground, t), 1.0);
     return;
   }
 
-  float altDeg = 90.0 - clamp(r / 46.0, 0.0, 1.0) * 90.0;
   float tZen = clamp(altDeg / 90.0, 0.0, 1.0);
 
   vec3 deep = vec3(0.018, 0.02, 0.045);
@@ -144,12 +128,19 @@ void main() {
   float midMix = smoothstep(0.16, 0.48, tZen) * (1.0 - smoothstep(0.58, 0.92, tZen));
   skyCol = mix(skyCol, mid, midMix * 0.5);
   skyCol = mix(skyCol, twi, smoothstep(0.08, 0.35, 1.0 - tZen));
-  float low = smoothstep(22.0, 0.0, altDeg);
-  skyCol = mix(skyCol, horizWarm, low * 0.55);
-  float rim = smoothstep(12.0, 0.0, altDeg);
-  skyCol += horizGlow * rim * 0.22;
 
-  float az = atan(sky.x - ZEN.x, -(sky.y - ZEN.y));
+  // 황혼 세기: 태양이 지평선 부근일 때 최대, 깊은 밤(-18°↓)/낮(+12°↑)이면 0
+  float tw = smoothstep(-18.0, -3.0, u_sunAlt) * (1.0 - smoothstep(4.0, 14.0, u_sunAlt));
+  // 태양 방향 정렬: 해가 진 방위 쪽에 노을을 집중, 나머지 지평선엔 옅게만
+  float aim = max(0.0, dot(dir, normalize(u_sunDir)));
+  float glowAim = 0.10 + 0.90 * pow(aim, 2.5);
+
+  float low = smoothstep(22.0, 0.0, altDeg);
+  skyCol = mix(skyCol, horizWarm, low * 0.55 * tw * glowAim);
+  float rim = smoothstep(12.0, 0.0, altDeg);
+  skyCol += horizGlow * rim * 0.30 * tw * glowAim;
+
+  float az = atan(dir.x, dir.y);
   float azn = az * 0.15915494309189535;
   float altn = clamp(altDeg / 90.0, 0.0, 1.0);
   vec2 muv = vec2(fract(azn), 1.0 - altn * 0.94 + 0.03);
@@ -162,7 +153,7 @@ void main() {
 
   vec4 rimTex = texture2D(u_horizonRim, vec2(0.5, 1.0 - altn));
   float rimMask = smoothstep(20.0, 0.0, altDeg);
-  skyCol += rimTex.rgb * rimTex.a * rimMask * 0.42;
+  skyCol += rimTex.rgb * rimTex.a * rimMask * 0.42 * tw * glowAim;
 
   gl_FragColor = vec4(clamp(skyCol, 0.0, 1.0), 1.0);
 }
@@ -212,10 +203,8 @@ void main() {
 `;
 
 export interface SkyGlCanvasProps {
-  /** 나침반·기기 정렬(°) — 셰이더 배경·은하 밴드만 */
-  skyRotationDeg: number;
-  /** 손가락 패닝 등 천체만 추가 회전(°). 배경은 돌지 않음 */
-  celestialPanDeg?: number;
+  /** 1인칭 자유 시점 카메라 기저(orthonormal) */
+  viewBasis: ViewBasis;
   data: SkyViewResponseDto;
   lineSegments: ConstellationLineSegmentDto[];
   starsByHip: Map<number, SkyViewStarDto>;
@@ -223,6 +212,8 @@ export interface SkyGlCanvasProps {
   lineColorHex: string;
   bodyPlanetHex: string;
   bodyMoonHex: string;
+  /** 태양 지평좌표(방위·고도) — 황혼/노을 방향성 연출용. null이면 깊은 밤 처리 */
+  sunAltAz?: { azDeg: number; altDeg: number } | null;
   squareSize?: number;
   layoutWidth?: number;
   layoutHeight?: number;
@@ -233,8 +224,7 @@ export interface SkyGlCanvasProps {
  * 스타렐리움에 가까운 야간 천구: 대기 셰이더 + 은하수 밴드 + 지평선/땅 + 소프트 별 스프라이트.
  */
 export function SkyGlCanvas({
-  skyRotationDeg,
-  celestialPanDeg = 0,
+  viewBasis,
   data,
   lineSegments,
   starsByHip,
@@ -242,6 +232,7 @@ export function SkyGlCanvas({
   lineColorHex,
   bodyPlanetHex,
   bodyMoonHex,
+  sunAltAz,
   squareSize,
   layoutWidth,
   layoutHeight,
@@ -249,9 +240,12 @@ export function SkyGlCanvas({
 }: SkyGlCanvasProps) {
   const [gl, setGl] = useState<ExpoWebGLRenderingContext | null>(null);
   const [glErr, setGlErr] = useState<string | null>(null);
+  const sunAltDeg = sunAltAz?.altDeg ?? -90;
+  const sunDir: Rgb = sunAltAz
+    ? (dirFromAzAlt(sunAltAz.azDeg, sunAltAz.altDeg) as Rgb)
+    : [0, 0, -1];
   const propsRef = useRef({
-    skyRotationDeg,
-    celestialPanDeg,
+    viewBasis,
     data,
     lineSegments,
     starsByHip,
@@ -259,11 +253,12 @@ export function SkyGlCanvas({
     lineRgb: hexToRgb01(lineColorHex),
     planetRgb: hexToRgb01(bodyPlanetHex),
     moonRgb: hexToRgb01(bodyMoonHex),
+    sunDir,
+    sunAltDeg,
   });
 
   propsRef.current = {
-    skyRotationDeg,
-    celestialPanDeg,
+    viewBasis,
     data,
     lineSegments,
     starsByHip,
@@ -271,6 +266,8 @@ export function SkyGlCanvas({
     lineRgb: hexToRgb01(lineColorHex),
     planetRgb: hexToRgb01(bodyPlanetHex),
     moonRgb: hexToRgb01(bodyMoonHex),
+    sunDir,
+    sunAltDeg,
   };
 
   const onContextCreate = useCallback((g: ExpoWebGLRenderingContext) => {
@@ -300,11 +297,13 @@ export function SkyGlCanvas({
     }
 
     const skyPosLoc = glCtx.getAttribLocation(skyProg, 'a_pos');
-    const uRes = glCtx.getUniformLocation(skyProg, 'u_resolution');
-    const uOx = glCtx.getUniformLocation(skyProg, 'u_ox');
-    const uOy = glCtx.getUniformLocation(skyProg, 'u_oy');
-    const uSc = glCtx.getUniformLocation(skyProg, 'u_scale');
-    const uRot = glCtx.getUniformLocation(skyProg, 'u_skyRotDeg');
+    const uFwd = glCtx.getUniformLocation(skyProg, 'u_fwd');
+    const uRight = glCtx.getUniformLocation(skyProg, 'u_right');
+    const uUp = glCtx.getUniformLocation(skyProg, 'u_up');
+    const uSunDir = glCtx.getUniformLocation(skyProg, 'u_sunDir');
+    const uSunAlt = glCtx.getUniformLocation(skyProg, 'u_sunAlt');
+    const uTanHalfFov = glCtx.getUniformLocation(skyProg, 'u_tanHalfFov');
+    const uAspect = glCtx.getUniformLocation(skyProg, 'u_aspect');
     const uMilky = glCtx.getUniformLocation(skyProg, 'u_milky');
     const uHorizonRim = glCtx.getUniformLocation(skyProg, 'u_horizonRim');
 
@@ -355,17 +354,18 @@ export function SkyGlCanvas({
       glCtx.viewport(0, 0, w, h);
       glCtx.disable(glCtx.BLEND);
 
-      const scale = Math.min(w, h) / 100;
-      const ox = (w - 100 * scale) / 2;
-      const oy = (h - 100 * scale) / 2;
+      const aspect = h > 0 ? w / h : 1;
+      const tanHalfFov = Math.tan((GL_FOV_V_DEG * Math.PI) / 360);
 
+      const basis = p.viewBasis;
       glCtx.useProgram(skyProg);
-      glCtx.uniform2f(uRes, w, h);
-      glCtx.uniform1f(uOx, ox);
-      glCtx.uniform1f(uOy, oy);
-      glCtx.uniform1f(uSc, scale);
-      glCtx.uniform1f(uRot, p.skyRotationDeg);
-      const celestialRot = p.skyRotationDeg + p.celestialPanDeg;
+      glCtx.uniform3f(uFwd, basis.fwd[0], basis.fwd[1], basis.fwd[2]);
+      glCtx.uniform3f(uRight, basis.right[0], basis.right[1], basis.right[2]);
+      glCtx.uniform3f(uUp, basis.up[0], basis.up[1], basis.up[2]);
+      glCtx.uniform3f(uSunDir, p.sunDir[0], p.sunDir[1], p.sunDir[2]);
+      glCtx.uniform1f(uSunAlt, p.sunAltDeg);
+      glCtx.uniform1f(uTanHalfFov, tanHalfFov);
+      glCtx.uniform1f(uAspect, aspect);
       glCtx.activeTexture(glCtx.TEXTURE0);
       glCtx.bindTexture(glCtx.TEXTURE_2D, textures.milky);
       glCtx.uniform1i(uMilky, 0);
@@ -388,20 +388,17 @@ export function SkyGlCanvas({
         const a = p.starsByHip.get(seg.fromHip);
         const b = p.starsByHip.get(seg.toHip);
         if (!a?.visible || !b?.visible) continue;
-        const na = azAltToNorm(a.azDeg, a.altDeg);
-        const nb = azAltToNorm(b.azDeg, b.altDeg);
-        const pa = rotateSkyNorm(na.nx, na.ny, celestialRot);
-        const pb = rotateSkyNorm(nb.nx, nb.ny, celestialRot);
-        const ca = normToClip(pa.nx, pa.ny, w, h);
-        const cb = normToClip(pb.nx, pb.ny, w, h);
+        const pa = projectPerspectiveClip(a.azDeg, a.altDeg, basis, tanHalfFov, aspect);
+        const pb = projectPerspectiveClip(b.azDeg, b.altDeg, basis, tanHalfFov, aspect);
+        if (!pa.visible || !pb.visible) continue;
         const o = li * 10;
-        lineInterleaved[o] = ca.x;
-        lineInterleaved[o + 1] = ca.y;
+        lineInterleaved[o] = pa.cx;
+        lineInterleaved[o + 1] = pa.cy;
         lineInterleaved[o + 2] = lineRgbLine[0];
         lineInterleaved[o + 3] = lineRgbLine[1];
         lineInterleaved[o + 4] = lineRgbLine[2];
-        lineInterleaved[o + 5] = cb.x;
-        lineInterleaved[o + 6] = cb.y;
+        lineInterleaved[o + 5] = pb.cx;
+        lineInterleaved[o + 6] = pb.cy;
         lineInterleaved[o + 7] = lineRgbLine[0];
         lineInterleaved[o + 8] = lineRgbLine[1];
         lineInterleaved[o + 9] = lineRgbLine[2];
@@ -428,11 +425,10 @@ export function SkyGlCanvas({
       }
 
       let pi = 0;
-      const pushPoint = (nx: number, ny: number, rgb: Rgb, sizePx: number) => {
-        const { x, y } = normToClip(nx, ny, w, h);
+      const pushPoint = (cx: number, cy: number, rgb: Rgb, sizePx: number) => {
         const o = pi * 6;
-        pointInterleaved[o] = x;
-        pointInterleaved[o + 1] = y;
+        pointInterleaved[o] = cx;
+        pointInterleaved[o + 1] = cy;
         pointInterleaved[o + 2] = rgb[0];
         pointInterleaved[o + 3] = rgb[1];
         pointInterleaved[o + 4] = rgb[2];
@@ -441,22 +437,41 @@ export function SkyGlCanvas({
       };
 
       const minDim = Math.min(w, h);
+      const tSec = Date.now() / 1000;
+      let starIdx = 0;
       for (const s of p.data.stars) {
+        starIdx += 1;
         if (!s.visible) continue;
-        const { nx, ny } = azAltToNorm(s.azDeg, s.altDeg);
-        const r = rotateSkyNorm(nx, ny, celestialRot);
+        const r = projectPerspectiveClip(s.azDeg, s.altDeg, basis, tanHalfFov, aspect);
+        if (!r.visible) continue;
         const rgb = starRgbFromMag(s.mag);
         const pr = magToRadius(s.mag) * (minDim / 100) * 2.85;
         const sz = Math.max(2.2, Math.min(18, pr));
-        pushPoint(r.nx, r.ny, rgb, sz);
-        if (pi >= maxPoints - 4) break;
+        // 대기 산란에 의한 반짝임(scintillation): 별마다 위상이 달라 0.6~1.0로 깜빡
+        const twk =
+          0.8 +
+          0.2 *
+            Math.sin(tSec * 2.4 + starIdx * 1.7) *
+            Math.cos(tSec * 1.6 + starIdx * 0.9);
+        const tRgb: Rgb = [rgb[0] * twk, rgb[1] * twk, rgb[2] * twk];
+        // 블룸/할레이션: 밝은 별 아래에 크고 옅은 헤일로를 가산 합성
+        if (s.mag < 1.7) {
+          pushPoint(
+            r.cx,
+            r.cy,
+            [tRgb[0] * 0.42, tRgb[1] * 0.42, tRgb[2] * 0.46],
+            Math.min(34, sz * 2.6),
+          );
+        }
+        pushPoint(r.cx, r.cy, tRgb, sz * (0.94 + 0.06 * twk));
+        if (pi >= maxPoints - 6) break;
       }
 
       for (const b of p.data.bodies ?? []) {
         if (!(b as SkyViewBodyDto).visible) continue;
         const body = b as SkyViewBodyDto;
-        const { nx, ny } = azAltToNorm(body.azDeg, body.altDeg);
-        const r = rotateSkyNorm(nx, ny, celestialRot);
+        const r = projectPerspectiveClip(body.azDeg, body.altDeg, basis, tanHalfFov, aspect);
+        if (!r.visible) continue;
         const rgb: Rgb =
           body.id === 'moon'
             ? (p.moonRgb as Rgb)
@@ -467,8 +482,16 @@ export function SkyGlCanvas({
           body.id === 'moon'
             ? Math.max(16, minDim * 0.045)
             : Math.max(10, planetDiskRadius(body.magnitude) * (minDim / 100) * 2.8);
-        pushPoint(r.nx, r.ny, rgb, Math.min(36, sz));
-        if (pi >= maxPoints - 1) break;
+        const disk = Math.min(36, sz);
+        // 행성·달의 부드러운 광채(블룸)
+        pushPoint(
+          r.cx,
+          r.cy,
+          [rgb[0] * 0.34, rgb[1] * 0.34, rgb[2] * 0.36],
+          Math.min(64, disk * 2.4),
+        );
+        pushPoint(r.cx, r.cy, rgb, disk);
+        if (pi >= maxPoints - 2) break;
       }
 
       if (pi > 0) {

--- a/frontend/components/sky/SkyTabScreen.tsx
+++ b/frontend/components/sky/SkyTabScreen.tsx
@@ -1,7 +1,7 @@
 import * as Location from 'expo-location';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as ScreenOrientation from 'expo-screen-orientation';
-import { Accelerometer, Gyroscope } from 'expo-sensors';
+import { Gyroscope } from 'expo-sensors';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -20,7 +20,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Svg, {
   Circle,
   Defs,
-  Ellipse,
   G,
   Line,
   LinearGradient,
@@ -55,10 +54,12 @@ import { getConstellationLore } from './constellation-lore';
 import { SkyGlCanvas } from './SkyGlCanvas';
 import { sunAltAzDeg } from '../../lib/sun-position';
 import {
-  azAltToNorm,
+  computeViewBasis,
+  GL_TAN_HALF_FOV,
   magToRadius,
   normToLayoutSlice,
-  rotateSkyNorm,
+  projectPerspectiveClip,
+  projectToView,
 } from './sky-projection';
 import { skyBackdropFromSunAlt } from './sky-appearance';
 import { namedStarLabelKo } from './named-star-labels';
@@ -368,27 +369,386 @@ function formatKstHm(isoUtc: string): string {
   }
 }
 
-/** 스타렐리움식 지평선 위 나무·언덕 실루엣(회전 천구 위에 덮어 별이 지평선 아래 가려짐) */
-const STELLARIUM_HILL_BASE =
-  'M0,100 L0,93 Q12,90 28,91 Q42,88 50,90 Q62,87 78,90 Q90,88 100,91 L100,100 Z';
-const STELLARIUM_TREE_LINE =
-  'M0,100 L0,91 L4,92 L7,87 L11,89 L14,84 L18,86 L22,81 L27,84 L31,79 L36,82 L42,76 L48,80 L55,73 L62,78 L68,74 L75,77 L82,71 L90,75 L96,70 L100,73 L100,100 Z';
-const STELLARIUM_BOKEH = [
-  { cx: 78, cy: 94.5, r: 1.15, o: 0.45 },
-  { cx: 86, cy: 93.2, r: 0.85, o: 0.38 },
-  { cx: 72, cy: 95.8, r: 0.7, o: 0.32 },
-  { cx: 91, cy: 95.5, r: 1.6, o: 0.18 },
-  { cx: 83, cy: 96.8, r: 0.9, o: 0.28 },
-] as const;
-
 const SKY_RENDER_STORAGE_KEY = 'starChaser:skyRenderMode';
 const SKY_CONTROLS_EXPANDED_KEY = 'starChaser:skyControlsExpanded';
 
 const HEADING_LOWPASS = 0.88;
 /** 자이로 보조 시 나침반에 가끔 붙는 가중(드리프트 억제) */
 const COMPASS_BLEND_MOTION = 0.07;
-/** 가속도계 롤 → 천구 회전에 더하는 비율(세로 기기 기준 실험값) */
-const TILT_GAIN = 0.09;
+
+/** 1인칭 자유 시점 카메라 — 드래그 감도(°/px)와 시선 고도 범위 */
+const VIEW_YAW_GAIN = 0.2;
+const VIEW_PITCH_GAIN = 0.2;
+/** 시선 고도: 지평선(0°, 정면)부터 천정(90°, 수직으로 올려다봄)까지만 */
+const VIEW_ALT_MIN = 0;
+const VIEW_ALT_MAX = 90;
+/** 처음 시선: 남쪽 지평선을 정면으로(서서 앞을 보는 느낌) */
+const VIEW_DEFAULT_YAW = 180;
+const VIEW_DEFAULT_PITCH = 0;
+
+function clampNum(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+function normYaw(deg: number): number {
+  let d = deg % 360;
+  if (d < 0) d += 360;
+  return d;
+}
+
+/** 한 타일 폭(viewBox 단위). 360°↔2타일이라 좌우로 끝없이 돌려도 이음새가 없음 */
+const CAMP_TILE = 90;
+/** 지평선 화면 높이: 정면(0°)에서 하단에 낮게, 올려다볼수록 아래로 내려가 사라짐 */
+const CAMP_HORIZON_BASE = 82;
+const CAMP_HORIZON_SLOPE = 0.5;
+
+type CampColors = {
+  pine: string;
+  trunk: string;
+  tent: string;
+  accent: string;
+};
+
+/** 16진수 색을 f배 어둡게(0~1) — 같은 색 계열로 지붕/도어 음영을 만든다 */
+function darkenHex(hex: string, f: number): string {
+  const n = parseInt(hex.replace('#', ''), 16);
+  const cl = (v: number) => Math.max(0, Math.min(255, Math.round(v)));
+  const r = cl(((n >> 16) & 255) * f);
+  const g = cl(((n >> 8) & 255) * f);
+  const b = cl((n & 255) * f);
+  const h2 = (x: number) => x.toString(16).padStart(2, '0');
+  return `#${h2(r)}${h2(g)}${h2(b)}`;
+}
+
+/**
+ * 디테일 있는 글램핑 텐트(단색). round=true면 둥근 벨 텐트, false면 박공형 캐빈 텐트.
+ * 본체는 한 가지 색, 지붕·도어는 그 색의 음영으로만 표현(한 텐트=한 색).
+ * 굴뚝·당김줄·도어 분할선·입구 빛으로 디테일을 더한다. lightOpacity로 입구 빛만 점등.
+ */
+function GlampTent({
+  cx,
+  foot,
+  hw,
+  h,
+  body,
+  round,
+  lightOpacity,
+}: {
+  cx: number;
+  foot: number;
+  hw: number;
+  h: number;
+  body: string;
+  round: boolean;
+  lightOpacity: number;
+}) {
+  const wallTop = foot - h * 0.42;
+  const peak = foot - h;
+  const shoulder = foot - h * 0.8;
+  const roofShade = darkenHex(body, 0.82);
+  const seam = darkenHex(body, 0.7);
+  const doorShade = darkenHex(body, 0.52);
+  const doorSplit = darkenHex(body, 0.38);
+  const dw = hw * 0.32;
+  const doorTop = foot - h * 0.5;
+  const f = (n: number) => n.toFixed(1);
+
+  const bodyPath = round
+    ? `M ${f(cx - hw)} ${f(foot)} L ${f(cx - hw)} ${f(wallTop)} Q ${f(cx - hw)} ${f(peak)} ${f(cx)} ${f(peak)} Q ${f(cx + hw)} ${f(peak)} ${f(cx + hw)} ${f(wallTop)} L ${f(cx + hw)} ${f(foot)} Z`
+    : `M ${f(cx - hw)} ${f(foot)} L ${f(cx - hw)} ${f(wallTop)} L ${f(cx - hw * 0.5)} ${f(shoulder)} L ${f(cx)} ${f(peak)} L ${f(cx + hw * 0.5)} ${f(shoulder)} L ${f(cx + hw)} ${f(wallTop)} L ${f(cx + hw)} ${f(foot)} Z`;
+  const roofPath = round
+    ? `M ${f(cx - hw)} ${f(wallTop)} Q ${f(cx - hw)} ${f(peak)} ${f(cx)} ${f(peak)} Q ${f(cx + hw)} ${f(peak)} ${f(cx + hw)} ${f(wallTop)} Z`
+    : `M ${f(cx - hw)} ${f(wallTop)} L ${f(cx - hw * 0.5)} ${f(shoulder)} L ${f(cx)} ${f(peak)} L ${f(cx + hw * 0.5)} ${f(shoulder)} L ${f(cx + hw)} ${f(wallTop)} Z`;
+  const doorPath = `M ${f(cx - dw)} ${f(foot)} L ${f(cx - dw)} ${f(doorTop + 1.6)} Q ${f(cx)} ${f(doorTop)} ${f(cx + dw)} ${f(doorTop + 1.6)} L ${f(cx + dw)} ${f(foot)} Z`;
+  const glowPath = `M ${f(cx - dw * 0.66)} ${f(foot)} L ${f(cx - dw * 0.66)} ${f(doorTop + 2.4)} Q ${f(cx)} ${f(doorTop + 1.2)} ${f(cx + dw * 0.66)} ${f(doorTop + 2.4)} L ${f(cx + dw * 0.66)} ${f(foot)} Z`;
+
+  return (
+    <>
+      {/* 당김줄(가이라인) */}
+      <Path
+        d={`M ${f(cx - hw)} ${f(wallTop + 1)} L ${f(cx - hw - 3.5)} ${f(foot)}`}
+        stroke={roofShade}
+        strokeWidth={0.3}
+        opacity={0.5}
+      />
+      <Path
+        d={`M ${f(cx + hw)} ${f(wallTop + 1)} L ${f(cx + hw + 3.5)} ${f(foot)}`}
+        stroke={roofShade}
+        strokeWidth={0.3}
+        opacity={0.5}
+      />
+      {/* 본체 */}
+      <Path d={bodyPath} fill={body} />
+      {/* 지붕 음영(두 톤) */}
+      <Path d={roofPath} fill={roofShade} />
+      {/* 벽 이음선 */}
+      <Path d={`M ${f(cx - hw * 0.5)} ${f(wallTop)} L ${f(cx - hw * 0.5)} ${f(foot)}`} stroke={seam} strokeWidth={0.25} opacity={0.6} />
+      <Path d={`M ${f(cx + hw * 0.5)} ${f(wallTop)} L ${f(cx + hw * 0.5)} ${f(foot)}`} stroke={seam} strokeWidth={0.25} opacity={0.6} />
+      {/* 도어 */}
+      <Path d={doorPath} fill={doorShade} />
+      <Path d={`M ${f(cx)} ${f(foot)} L ${f(cx)} ${f(doorTop + 0.8)}`} stroke={doorSplit} strokeWidth={0.3} />
+      {/* 입구에서 새어 나오는 빛 */}
+      <Path d={glowPath} fill="url(#tentGlow)" opacity={lightOpacity} />
+    </>
+  );
+}
+
+/**
+ * 돔 텐트(첨부 일러스트 참조) — 넓고 둥근 돔 본체(살짝 뾰족한 꼭대기), 옆면 패널 솔기,
+ * 가운데 큰 아치형 입구(밝은 테두리 + 어두운 내부 + 밤엔 안쪽 빛), 바닥 고정 스테이크.
+ * 단색 본체에 같은 색의 명암으로만 디테일을 준다.
+ */
+function DomeTent({
+  cx,
+  foot,
+  hw,
+  h,
+  body,
+  lightOpacity,
+}: {
+  cx: number;
+  foot: number;
+  hw: number;
+  h: number;
+  body: string;
+  lightOpacity: number;
+}) {
+  const peak = foot - h;
+  const seam = darkenHex(body, 0.78);
+  const frameLight = darkenHex(body, 1.16);
+  const interior = darkenHex(body, 0.24);
+  const baseLine = darkenHex(body, 0.55);
+  const stake = darkenHex(body, 0.45);
+  const f = (n: number) => n.toFixed(1);
+  // 아치(문/내부) path: 수직 옆선 + 둥근 윗부분, 바닥 평평
+  const arch = (acx: number, aw: number, ayTop: number, ayBot: number) => {
+    const sh = ayTop + aw * 0.8;
+    return `M ${f(acx - aw)} ${f(ayBot)} L ${f(acx - aw)} ${f(sh)} Q ${f(acx - aw)} ${f(ayTop)} ${f(acx)} ${f(ayTop)} Q ${f(acx + aw)} ${f(ayTop)} ${f(acx + aw)} ${f(sh)} L ${f(acx + aw)} ${f(ayBot)} Z`;
+  };
+  const frameW = hw * 0.58;
+  const frameTop = foot - h * 0.84;
+  const intW = frameW - 1;
+  const intTop = frameTop + 1.3;
+  return (
+    <>
+      {/* 넓고 둥근 돔 본체 — 어깨가 둥글고 위가 부드럽게 둥근 반타원형 외곽선 */}
+      <Path
+        d={`M ${f(cx - hw)} ${f(foot)} C ${f(cx - hw)} ${f(foot - h * 0.9)} ${f(cx - hw * 0.52)} ${f(peak)} ${f(cx)} ${f(peak)} C ${f(cx + hw * 0.52)} ${f(peak)} ${f(cx + hw)} ${f(foot - h * 0.9)} ${f(cx + hw)} ${f(foot)} Z`}
+        fill={body}
+      />
+      {/* 윗부분 크라운 패널 솔기 */}
+      <Path
+        d={`M ${f(cx - hw * 0.55)} ${f(foot - h * 0.74)} Q ${f(cx)} ${f(foot - h * 1.0)} ${f(cx + hw * 0.55)} ${f(foot - h * 0.74)}`}
+        stroke={seam}
+        strokeWidth={0.35}
+        fill="none"
+        opacity={0.55}
+      />
+      {/* 가운데 패널을 감싸는 좌·우 솔기(꼭대기 → 바닥) */}
+      <Path
+        d={`M ${f(cx)} ${f(peak + 0.5)} Q ${f(cx - hw * 0.5)} ${f(foot - h * 0.45)} ${f(cx - hw * 0.62)} ${f(foot)}`}
+        stroke={seam}
+        strokeWidth={0.35}
+        fill="none"
+        opacity={0.55}
+      />
+      <Path
+        d={`M ${f(cx)} ${f(peak + 0.5)} Q ${f(cx + hw * 0.5)} ${f(foot - h * 0.45)} ${f(cx + hw * 0.62)} ${f(foot)}`}
+        stroke={seam}
+        strokeWidth={0.35}
+        fill="none"
+        opacity={0.55}
+      />
+      {/* 바닥 그림자선 */}
+      <Path d={`M ${f(cx - hw)} ${f(foot)} L ${f(cx + hw)} ${f(foot)}`} stroke={baseLine} strokeWidth={0.4} opacity={0.6} />
+      {/* 입구: 밝은 테두리 → 어두운 내부 → (밤) 안쪽 빛 */}
+      <Path d={arch(cx, frameW, frameTop, foot)} fill={frameLight} />
+      <Path d={arch(cx, intW, intTop, foot)} fill={interior} />
+      <Path d={arch(cx, intW, intTop, foot)} fill="url(#tentGlow)" opacity={lightOpacity} />
+      {/* 바닥 고정 스테이크(좌·우) */}
+      <Path d={`M ${f(cx - hw)} ${f(foot)} L ${f(cx - hw - 2.4)} ${f(foot + 1.4)}`} stroke={stake} strokeWidth={0.45} />
+      <Path d={`M ${f(cx - hw - 3)} ${f(foot + 1.4)} L ${f(cx - hw - 1.8)} ${f(foot + 1.4)}`} stroke={stake} strokeWidth={0.45} />
+      <Path d={`M ${f(cx + hw)} ${f(foot)} L ${f(cx + hw + 2.4)} ${f(foot + 1.4)}`} stroke={stake} strokeWidth={0.45} />
+      <Path d={`M ${f(cx + hw + 3)} ${f(foot + 1.4)} L ${f(cx + hw + 1.8)} ${f(foot + 1.4)}`} stroke={stake} strokeWidth={0.45} />
+    </>
+  );
+}
+
+/**
+ * 침엽수(전나무) 잎 실루엣 path — tiers 단의 가지가 바깥 끝으로 살짝 처지는(droop) 모양.
+ * 아래로 갈수록 넓어지고, 단끼리 겹쳐 자연스러운 전나무 윤곽을 만든다(3단/5단 등).
+ */
+function pinePath(cx: number, footY: number, h: number, w: number, tiers: number): string {
+  const trunkH = h * 0.12;
+  const top = footY - h;
+  const foliageBot = footY - trunkH * 0.3;
+  const foliageH = foliageBot - top;
+  const step = foliageH / tiers;
+  const F = (n: number) => n.toFixed(1);
+  let d = '';
+  for (let i = 0; i < tiers; i += 1) {
+    const apexY = top + i * step;
+    const baseY = apexY + step * 1.95;
+    const hw = (w / 2) * (0.34 + 0.66 * ((i + 1) / tiers));
+    const droop = hw * 0.42; // 바깥 가지 끝이 가운데보다 아래로 처짐
+    d += `M ${F(cx)} ${F(apexY)} L ${F(cx - hw)} ${F(baseY)} Q ${F(cx)} ${F(baseY - droop)} ${F(cx + hw)} ${F(baseY)} Z `;
+  }
+  return d;
+}
+
+/** 침엽수 한 그루: 갈색 줄기 + 다층 처진 잎(tiers로 3단/5단 등 다양하게) */
+function PineTree({
+  cx,
+  footY,
+  h,
+  w,
+  colors,
+  tiers = 4,
+  opacity = 1,
+}: {
+  cx: number;
+  footY: number;
+  h: number;
+  w: number;
+  colors: CampColors;
+  tiers?: number;
+  opacity?: number;
+}) {
+  const trunkH = h * 0.12;
+  const trunkW = Math.max(0.8, w * 0.12);
+  return (
+    <G opacity={opacity}>
+      <Rect x={cx - trunkW / 2} y={footY - trunkH} width={trunkW} height={trunkH + 0.4} fill={colors.trunk} />
+      <Path d={pinePath(cx, footY, h, w, tiers)} fill={colors.pine} />
+    </G>
+  );
+}
+
+/**
+ * 활엽수(첨부 이미지 참조) — 가는 줄기 위로 키가 크고 꽉 찬 타원형(달걀형) 수관.
+ * 수관은 여러 작은 덩이를 위→아래로 쌓아 가운데가 가장 넓은 자연스러운 윤곽을 만든다.
+ */
+function BroadleafTree({
+  cx,
+  footY,
+  h,
+  colors,
+}: {
+  cx: number;
+  footY: number;
+  h: number;
+  colors: CampColors;
+}) {
+  const trunkH = h * 0.26;
+  const crownTop = footY - h;
+  const crownH = h * 0.82;
+  const rMax = h * 0.24;
+  const F = (n: number) => n.toFixed(1);
+  // [세로위치(0=꼭대기,1=아래), 가로offset(rMax비율), 반지름(rMax비율)]
+  const blobs: Array<[number, number, number]> = [
+    [0.05, 0, 0.45],
+    [0.18, -0.55, 0.5],
+    [0.18, 0.55, 0.52],
+    [0.3, 0.05, 0.72],
+    [0.4, -0.8, 0.55],
+    [0.42, 0.85, 0.56],
+    [0.52, -0.36, 0.78],
+    [0.54, 0.46, 0.76],
+    [0.68, -0.74, 0.6],
+    [0.7, 0.78, 0.62],
+    [0.72, 0.05, 0.74],
+    [0.86, -0.4, 0.56],
+    [0.88, 0.44, 0.56],
+  ];
+  return (
+    <>
+      {/* 가는 줄기(살짝 테이퍼) + 낮은 가지 */}
+      <Path
+        d={`M ${F(cx - 1.2)} ${F(footY)} L ${F(cx - 0.5)} ${F(footY - trunkH)} L ${F(cx + 0.5)} ${F(footY - trunkH)} L ${F(cx + 1.2)} ${F(footY)} Z`}
+        fill={colors.trunk}
+      />
+      <Path d={`M ${F(cx)} ${F(footY - trunkH * 0.7)} L ${F(cx - 2.2)} ${F(footY - trunkH * 1.35)}`} stroke={colors.trunk} strokeWidth={0.6} />
+      <Path d={`M ${F(cx)} ${F(footY - trunkH * 0.8)} L ${F(cx + 2.4)} ${F(footY - trunkH * 1.45)}`} stroke={colors.trunk} strokeWidth={0.6} />
+      {/* 키 큰 타원형 수관 */}
+      {blobs.map((b, i) => (
+        <Circle
+          key={`leaf-${i}`}
+          cx={cx + b[1] * rMax}
+          cy={crownTop + b[0] * crownH}
+          r={b[2] * rMax}
+          fill={colors.pine}
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * 별 보러 온 캠핑 명소의 전경 한 타일. 평평한 땅 위에 나무들과 텐트가 서 있고 텐트·랜턴에서
+ * 빛이 새어 나온다(언덕은 없음 — 이미 언덕 위에 서 있다는 설정). x[0,CAMP_TILE] 로컬
+ * 좌표로 그려 가로로 이어붙이면(타일링) 시선 회전 시 매끄럽게 흐른다. 땅(바닥)은 따로 한
+ * 겹으로 그리므로 여기선 나무·텐트·불빛만 그린다.
+ *
+ * variant(0/1)로 서로 다른 캠프 두 종류(A형 텐트 / 돔형 텐트, 나무 배치도 다름)를 그린다.
+ * 한 바퀴(360°)에 정확히 캠프 2개가 있어, 인접한 두 캠프는 항상 다른 모습이다.
+ * colors는 시각(밤=검정 실루엣 → 낮=본연의 색)에 따라 바뀌고, lightOpacity로 조명
+ * (텐트 입구·랜턴·모닥불)을 낮엔 끄고 밤엔 켠다.
+ */
+function CampSceneTile({
+  y,
+  variant,
+  lightOpacity,
+  colors,
+}: {
+  y: number;
+  variant: number;
+  lightOpacity: number;
+  colors: CampColors;
+}) {
+  const foot = y + 0.5;
+  if (variant === 1) {
+    // 캠프 B — 주황 벨(돔) 텐트 + 왼쪽 활엽수·침엽수 무리, 오른쪽 큰 침엽수
+    return (
+      <>
+        <PineTree cx={28} footY={y - 1} h={9} w={6} colors={colors} tiers={3} opacity={0.62} />
+        <PineTree cx={62} footY={y - 1} h={10} w={6.5} colors={colors} tiers={4} opacity={0.62} />
+        {/* 텐트 주변 분위기 글로우 */}
+        <Circle cx={50} cy={y - 2} r={16} fill="url(#campGlow)" opacity={lightOpacity} />
+        {/* 왼쪽 나무들 */}
+        <BroadleafTree cx={12} footY={foot} h={19} colors={colors} />
+        <PineTree cx={22} footY={foot} h={17} w={9} colors={colors} tiers={5} />
+        <PineTree cx={31} footY={foot} h={12} w={7.5} colors={colors} tiers={3} />
+        {/* 주황 돔 텐트(단색) */}
+        <DomeTent cx={50} foot={foot} hw={9.1} h={10.4} body={colors.accent} lightOpacity={lightOpacity} />
+        {/* 오른쪽 큰 침엽수 무리 */}
+        <PineTree cx={72} footY={foot} h={22} w={11} colors={colors} tiers={5} />
+        <PineTree cx={82} footY={foot} h={14} w={7} colors={colors} tiers={3} />
+        {/* 랜턴 불씨 */}
+        <Circle cx={38} cy={y - 0.3} r={1.3} fill="#ffd9a0" opacity={0.95 * lightOpacity} />
+      </>
+    );
+  }
+  // 캠프 A — 베이지 캐빈(박공) 텐트 + 왼쪽 큰 침엽수·활엽수, 오른쪽 침엽수 무리
+  return (
+    <>
+      <PineTree cx={33} footY={y - 1} h={10} w={6.5} colors={colors} tiers={4} opacity={0.62} />
+      <PineTree cx={58} footY={y - 1} h={9} w={6} colors={colors} tiers={3} opacity={0.62} />
+      {/* 텐트 주변 분위기 글로우 */}
+      <Circle cx={44} cy={y - 2} r={15} fill="url(#campGlow)" opacity={lightOpacity} />
+      {/* 왼쪽 나무들 */}
+      <PineTree cx={10} footY={foot} h={21} w={11} colors={colors} tiers={5} />
+      <BroadleafTree cx={24} footY={foot} h={19} colors={colors} />
+      {/* 오른쪽 나무 무리 */}
+      <PineTree cx={66} footY={foot} h={16} w={8.5} colors={colors} tiers={3} />
+      <PineTree cx={73} footY={foot} h={22} w={11} colors={colors} tiers={5} />
+      <PineTree cx={85} footY={foot} h={13} w={7} colors={colors} tiers={3} />
+      {/* 베이지 캐빈 텐트(단색 + 음영 디테일) */}
+      <GlampTent cx={44} foot={foot} hw={9} h={15} body={colors.tent} round={false} lightOpacity={lightOpacity} />
+      {/* 모닥불 불씨 */}
+      <Circle cx={56} cy={y - 0.3} r={1.3} fill="#ffd9a0" opacity={0.95 * lightOpacity} />
+    </>
+  );
+}
 
 export function SkyTabScreen({
   observerLat,
@@ -422,12 +782,12 @@ export function SkyTabScreen({
   const [lineSegments, setLineSegments] = useState<ConstellationLineSegmentDto[]>([]);
   const [alignHeading, setAlignHeading] = useState(false);
   const [motionAssist, setMotionAssist] = useState(false);
-  const [tiltRollDeg, setTiltRollDeg] = useState(0);
   /**
-   * 손가락 가로 드래그로 “고개를 돌린 것처럼” 별·은하·별선만 방위 이동(°).
-   * 지평 실루엣·나침반 정렬(skyRotation)은 그대로 둠.
+   * 1인칭 시선 — 방위(좌우)·고도(상하). 수평선은 항상 수평(롤 없음)으로 유지.
+   * 가로 드래그=방위 회전(둘러보기), 세로 드래그=고도(0°지평선~90°천정).
    */
-  const [viewAzPanDeg, setViewAzPanDeg] = useState(0);
+  const [viewYawDeg, setViewYawDeg] = useState(VIEW_DEFAULT_YAW);
+  const [viewPitchDeg, setViewPitchDeg] = useState(VIEW_DEFAULT_PITCH);
   const [renderEngine, setRenderEngine] = useState<'svg' | 'gl'>('svg');
 
   useEffect(() => {
@@ -568,7 +928,8 @@ export function SkyTabScreen({
   }, [load]);
 
   useEffect(() => {
-    setViewAzPanDeg(0);
+    setViewYawDeg(VIEW_DEFAULT_YAW);
+    setViewPitchDeg(VIEW_DEFAULT_PITCH);
   }, [obsLat, obsLng]);
 
   useEffect(() => {
@@ -653,7 +1014,6 @@ export function SkyTabScreen({
     const wasMotion = prevMotionAssistRef.current;
     if (!motionAssist) {
       fusedHeadingRef.current = null;
-      setTiltRollDeg(0);
       if (wasMotion && headingDeg != null) {
         headingSmoothRef.current = headingDeg;
       }
@@ -726,18 +1086,6 @@ export function SkyTabScreen({
     return () => sub.remove();
   }, [alignHeading, motionAssist]);
 
-  useEffect(() => {
-    if (!alignHeading || !motionAssist || Platform.OS === 'web') {
-      return;
-    }
-    Accelerometer.setUpdateInterval(Platform.OS === 'android' ? 200 : 50);
-    const sub = Accelerometer.addListener((a) => {
-      const roll = (Math.atan2(a.x, a.y) * 180) / Math.PI;
-      setTiltRollDeg(roll);
-    });
-    return () => sub.remove();
-  }, [alignHeading, motionAssist]);
-
   const starsByHip = useMemo(() => {
     const m = new Map<number, SkyViewStarDto>();
     if (!data) return m;
@@ -745,38 +1093,81 @@ export function SkyTabScreen({
     return m;
   }, [data]);
 
-  /** 나침반 = 자북에서 기기 상단까지 시계방향° → 천구 도표는 반시계 보정. 자이로 보조 시 가속도 롤을 소량 가산 */
-  const skyRotation =
+  /** 시선 방위: 나침반(방위 맞춤) 켜지면 기기 방향, 아니면 드래그로 누적한 yaw */
+  const viewAz =
     alignHeading && Platform.OS !== 'web' && headingDeg != null
-      ? -headingDeg + (motionAssist ? tiltRollDeg * TILT_GAIN : 0)
-      : 0;
+      ? normYaw(headingDeg)
+      : viewYawDeg;
+  const viewAlt = viewPitchDeg;
 
-  const celestialRot = skyRotation + viewAzPanDeg;
+  /** 항상 수평인(롤 0) 시선 기저 — 모든 천체 투영에 사용 */
+  const viewBasis = useMemo(
+    () => computeViewBasis(viewAz, viewAlt),
+    [viewAz, viewAlt],
+  );
 
-  const skyPanLastX = useRef<number | null>(null);
+  const useGlView = renderEngine === 'gl' && Platform.OS !== 'web';
+
+  /**
+   * (az,alt) → 레이아웃 픽셀. RN 라벨/히트 오버레이가 실제 렌더와 같은 투영을 쓰도록
+   * GL이면 원근(perspective), SVG면 어안(azimuthal)으로 분기한다.
+   */
+  const projectOverlayPx = useCallback(
+    (azDeg: number, altDeg: number): { x: number; y: number } | null => {
+      if (skyVp.w <= 0 || skyVp.h <= 0) return null;
+      if (useGlView) {
+        const r = projectPerspectiveClip(
+          azDeg,
+          altDeg,
+          viewBasis,
+          GL_TAN_HALF_FOV,
+          skyVp.w / skyVp.h,
+        );
+        if (!r.visible) return null;
+        return {
+          x: ((r.cx + 1) / 2) * skyVp.w,
+          y: ((1 - r.cy) / 2) * skyVp.h,
+        };
+      }
+      const p = projectToView(azDeg, altDeg, viewBasis);
+      if (!p.visible) return null;
+      return normToLayoutSlice(p.nx, p.ny, skyVp.w, skyVp.h);
+    },
+    [useGlView, viewBasis, skyVp.w, skyVp.h],
+  );
+
+  const skyPanLast = useRef<{ x: number; y: number } | null>(null);
   const skyPanResponder = useMemo(
     () =>
       PanResponder.create({
         onStartShouldSetPanResponder: () => false,
         onMoveShouldSetPanResponder: (_, g) =>
-          data != null &&
-          Math.abs(g.dx) > 16 &&
-          Math.abs(g.dx) > Math.abs(g.dy) * 0.65,
+          data != null && (Math.abs(g.dx) > 8 || Math.abs(g.dy) > 8),
         onPanResponderGrant: (e) => {
-          skyPanLastX.current = e.nativeEvent.pageX;
+          skyPanLast.current = {
+            x: e.nativeEvent.pageX,
+            y: e.nativeEvent.pageY,
+          };
         },
         onPanResponderMove: (e) => {
-          if (skyPanLastX.current == null) return;
+          if (skyPanLast.current == null) return;
           const x = e.nativeEvent.pageX;
-          const dx = x - skyPanLastX.current;
-          skyPanLastX.current = x;
-          setViewAzPanDeg((deg) => deg + dx * 0.32);
+          const y = e.nativeEvent.pageY;
+          const dx = x - skyPanLast.current.x;
+          const dy = y - skyPanLast.current.y;
+          skyPanLast.current = { x, y };
+          // 가로: 손가락 방향으로 둘러보기(왼쪽으로 끌면 오른쪽 별이 왼쪽으로 이동)
+          setViewYawDeg((deg) => normYaw(deg - dx * VIEW_YAW_GAIN));
+          // 세로: 아래로 끌면 더 위를 올려다봄(고도↑). 0°(지평선)~90°(천정)로 제한
+          setViewPitchDeg((deg) =>
+            clampNum(deg + dy * VIEW_PITCH_GAIN, VIEW_ALT_MIN, VIEW_ALT_MAX),
+          );
         },
         onPanResponderRelease: () => {
-          skyPanLastX.current = null;
+          skyPanLast.current = null;
         },
         onPanResponderTerminate: () => {
-          skyPanLastX.current = null;
+          skyPanLast.current = null;
         },
       }),
     [data],
@@ -805,19 +1196,18 @@ export function SkyTabScreen({
       if (!s.visible) continue;
       const ko = namedStarLabelKo(s.hip);
       if (!ko) continue;
-      const base = azAltToNorm(s.azDeg, s.altDeg);
-      const { nx, ny } = rotateSkyNorm(base.nx, base.ny, celestialRot);
-      const { x, y } = normToLayoutSlice(nx, ny, skyVp.w, skyVp.h);
+      const px = projectOverlayPx(s.azDeg, s.altDeg);
+      if (!px) continue;
       anchors.push({
         id: String(s.hip),
-        anchorX: x,
-        anchorY: y + 7,
+        anchorX: px.x,
+        anchorY: px.y + 7,
         label: ko,
         mag: s.mag,
       });
     }
     return layoutNamedStarLabels(anchors);
-  }, [data, skyVp.w, skyVp.h, celestialRot]);
+  }, [data, skyVp.w, skyVp.h, projectOverlayPx]);
 
   /** 겹칠 때 어두운 별이 위 레이어를 받도록 시각등급 내림차순 */
   const starHitTargets = useMemo(() => {
@@ -826,18 +1216,50 @@ export function SkyTabScreen({
     const rows: Array<{ star: SkyViewStarDto; left: number; top: number }> = [];
     for (const s of data.stars) {
       if (!s.visible) continue;
-      const base = azAltToNorm(s.azDeg, s.altDeg);
-      const { nx, ny } = rotateSkyNorm(base.nx, base.ny, celestialRot);
-      const { x, y } = normToLayoutSlice(nx, ny, skyVp.w, skyVp.h);
-      rows.push({ star: s, left: x - half, top: y - half });
+      const px = projectOverlayPx(s.azDeg, s.altDeg);
+      if (!px) continue;
+      rows.push({ star: s, left: px.x - half, top: px.y - half });
     }
     rows.sort((a, b) => b.star.mag - a.star.mag);
     return rows;
-  }, [data, skyVp.w, skyVp.h, celestialRot]);
+  }, [data, skyVp.w, skyVp.h, projectOverlayPx]);
+
+  /**
+   * 지평선 전경(캠핑 명소): 평평한 땅 + 나무·텐트·불빛 실루엣. 시선 고도(viewAlt)에 따라
+   * 정면(0°)에선 하단 ~1/4를 차지하고, 위로 올려다볼수록 아래로 내려가며 옅어져 사라진다.
+   * 좌우로 돌리면 전경이 가로로 흐른다(시차). 땅은 평평하다 — 이미 언덕 위라는 설정.
+   */
+  const groundScene = useMemo(() => {
+    if (!data) return null;
+    // 위로 올려다볼수록 옅어짐: 정면 또렷 → 40°↑ 하늘만(지평선은 그 전에 화면 아래로)
+    const fade = clampNum((40 - viewAlt) / 22, 0, 1);
+    if (fade <= 0.02) return null;
+    const horizonY = CAMP_HORIZON_BASE + viewAlt * CAMP_HORIZON_SLOPE;
+    // 좌우로 돌면 전경도 흐른다(지평선 부근 별 이동량과 비슷). 0~CAMP_TILE 로 래핑
+    const offset = (viewAz * 0.5) % CAMP_TILE;
+    const scroll = -offset;
+    // 현재 스크롤된 타일 수(연속). 변종(텐트 디자인)을 이 index로 정해 북쪽을 넘어
+    // 한 바퀴 돌아도(360°=2타일) 같은 방향엔 늘 같은 캠프가 보이게 한다.
+    const worldTile = Math.floor((viewAz * 0.5) / CAMP_TILE);
+    return { fade, horizonY, scroll, worldTile };
+  }, [data, viewAlt, viewAz]);
+
+  const yawDelta = Math.abs(((viewYawDeg - VIEW_DEFAULT_YAW + 540) % 360) - 180);
+  const viewIsDefault =
+    yawDelta < 0.6 && Math.abs(viewPitchDeg - VIEW_DEFAULT_PITCH) < 0.6;
+  /** 시선이 천정(수직)에 도달 — UI로 알려줌 */
+  const atZenith = viewAlt >= 89.5;
+
+  /** 하늘 그라데이션의 지평선(따뜻한 색) 위치를 전경 지평선에 맞춤 — 시선 올리면 함께 내려감 */
+  const skyHorizonPct = clampNum(
+    CAMP_HORIZON_BASE + viewAlt * CAMP_HORIZON_SLOPE,
+    48,
+    100,
+  );
+  const skyMidPct = Math.min(46, skyHorizonPct * 0.58);
 
   const kstPrimary = formatKstFull(observeAtIso);
   const utcNote = formatUtcFootnote(observeAtIso);
-  const useGlView = renderEngine === 'gl' && Platform.OS !== 'web';
 
   const win = Dimensions.get('window');
   const stageW = skyStage.w > 0 ? skyStage.w : win.width;
@@ -878,7 +1300,8 @@ export function SkyTabScreen({
           gradientUnits="userSpaceOnUse"
         >
           <Stop offset="0%" stopColor={skyBackdrop.zenith} />
-          <Stop offset="46%" stopColor={skyBackdrop.mid} />
+          <Stop offset={`${skyMidPct.toFixed(1)}%`} stopColor={skyBackdrop.mid} />
+          <Stop offset={`${skyHorizonPct.toFixed(1)}%`} stopColor={skyBackdrop.horizon} />
           <Stop offset="100%" stopColor={skyBackdrop.horizon} />
         </LinearGradient>
         <RadialGradient
@@ -907,120 +1330,128 @@ export function SkyTabScreen({
           <Stop offset="52%" stopColor="#9098d0" stopOpacity="0.095" />
           <Stop offset="100%" stopColor="#5860a0" stopOpacity="0" />
         </LinearGradient>
-        <RadialGradient id="mwDustA" cx="32" cy="34" r="38" gradientUnits="userSpaceOnUse">
-          <Stop offset="0%" stopColor="#c8d0f8" stopOpacity="0.28" />
-          <Stop offset="45%" stopColor="#7080b0" stopOpacity="0.12" />
-          <Stop offset="100%" stopColor="#283050" stopOpacity="0" />
+        {/* 캠프 불빛이 번지는 따뜻한 광원 — 텐트 주변/랜턴 */}
+        <RadialGradient id="campGlow" cx="50%" cy="50%" rx="50%" ry="50%">
+          <Stop offset="0%" stopColor="#ffb061" stopOpacity="0.5" />
+          <Stop offset="55%" stopColor="#ff8a3d" stopOpacity="0.16" />
+          <Stop offset="100%" stopColor="#ff8a3d" stopOpacity="0" />
         </RadialGradient>
-        <RadialGradient id="mwDustB" cx="70" cy="46" r="32" gradientUnits="userSpaceOnUse">
-          <Stop offset="0%" stopColor="#a8b0e0" stopOpacity="0.26" />
-          <Stop offset="100%" stopColor="#202840" stopOpacity="0" />
+        {/* 텐트 입구에서 새어 나오는 빛 */}
+        <RadialGradient id="tentGlow" cx="50%" cy="100%" rx="75%" ry="100%">
+          <Stop offset="0%" stopColor="#ffe0a6" stopOpacity="0.95" />
+          <Stop offset="60%" stopColor="#ffac55" stopOpacity="0.5" />
+          <Stop offset="100%" stopColor="#ff8a3d" stopOpacity="0" />
         </RadialGradient>
       </Defs>
-      {/* 하늘 배경·은하 — 태양 고도(관측 시각·위치)에 따라 낮/황혼/밤 */}
-      <G transform={`rotate(${skyRotation}, 50, 50)`}>
-        <Rect x="0" y="0" width="100" height="100" fill="url(#dynSkyMain)" />
-        <Rect
-          x="0"
-          y="0"
-          width="100"
-          height="100"
-          fill="url(#zenithCool)"
-          opacity={skyBackdrop.zenithCoolOpacity}
-        />
-        <Rect
-          x="0"
-          y="0"
-          width="100"
-          height="100"
-          fill="url(#milkyWayBand)"
-          opacity={skyBackdrop.milkyOpacity}
-        />
-        <Ellipse
-          cx="34"
-          cy="36"
-          rx="27"
-          ry="11"
-          fill="url(#mwDustA)"
-          opacity={skyBackdrop.milkyOpacity * 0.45}
-        />
-        <Ellipse
-          cx="64"
-          cy="46"
-          rx="22"
-          ry="8"
-          fill="url(#mwDustB)"
-          opacity={skyBackdrop.milkyOpacity * 0.37}
-        />
-      </G>
-      {/* 별·태양·별선·행성 — 나침반 + 패닝 */}
-      <G transform={`rotate(${celestialRot}, 50, 50)`}>
-        {sunAltAzForSky ? (
-          <SunGlyph
-            nx={azAltToNorm(sunAltAzForSky.azDeg, sunAltAzForSky.altDeg).nx}
-            ny={azAltToNorm(sunAltAzForSky.azDeg, sunAltAzForSky.altDeg).ny}
-            altDeg={sunAltAzForSky.altDeg}
+      {/* 하늘 배경·은하 — 태양 고도(관측 시각·위치)에 따라 낮/황혼/밤. 시선 이동과 무관한 분위기 레이어 */}
+      <Rect x="0" y="0" width="100" height="100" fill="url(#dynSkyMain)" />
+      <Rect
+        x="0"
+        y="0"
+        width="100"
+        height="100"
+        fill="url(#zenithCool)"
+        opacity={skyBackdrop.zenithCoolOpacity}
+      />
+      <Rect
+        x="0"
+        y="0"
+        width="100"
+        height="100"
+        fill="url(#milkyWayBand)"
+        opacity={skyBackdrop.milkyOpacity}
+      />
+      {/* 별·태양·별선·행성 — 시선(viewAz/viewAlt) 기준 1인칭 투영 */}
+      {sunAltAzForSky
+        ? (() => {
+            const p = projectToView(
+              sunAltAzForSky.azDeg,
+              sunAltAzForSky.altDeg,
+              viewBasis,
+            );
+            if (!p.visible) return null;
+            return <SunGlyph nx={p.nx} ny={p.ny} altDeg={sunAltAzForSky.altDeg} />;
+          })()
+        : null}
+      {lineSegments.map((seg, i) => {
+        const a = starsByHip.get(seg.fromHip);
+        const b = starsByHip.get(seg.toHip);
+        if (!a?.visible || !b?.visible) return null;
+        const pa = projectToView(a.azDeg, a.altDeg, viewBasis);
+        const pb = projectToView(b.azDeg, b.altDeg, viewBasis);
+        if (!pa.visible || !pb.visible) return null;
+        return (
+          <Line
+            key={`${seg.fromHip}-${seg.toHip}-${i}`}
+            x1={pa.nx}
+            y1={pa.ny}
+            x2={pb.nx}
+            y2={pb.ny}
+            stroke="#c4b8e8"
+            strokeOpacity={skyBackdrop.lineOpacity}
+            strokeWidth={0.4}
           />
-        ) : null}
-        {lineSegments.map((seg, i) => {
-          const a = starsByHip.get(seg.fromHip);
-          const b = starsByHip.get(seg.toHip);
-          if (!a?.visible || !b?.visible) return null;
-          const pa = azAltToNorm(a.azDeg, a.altDeg);
-          const pb = azAltToNorm(b.azDeg, b.altDeg);
+        );
+      })}
+      {data.stars
+        .filter((s) => s.visible)
+        .map((s) => {
+          const p = projectToView(s.azDeg, s.altDeg, viewBasis);
+          if (!p.visible) return null;
           return (
-            <Line
-              key={`${seg.fromHip}-${seg.toHip}-${i}`}
-              x1={pa.nx}
-              y1={pa.ny}
-              x2={pb.nx}
-              y2={pb.ny}
-              stroke="#c4b8e8"
-              strokeOpacity={skyBackdrop.lineOpacity}
-              strokeWidth={0.4}
+            <CompactStarGlyph
+              key={s.hip}
+              nx={p.nx}
+              ny={p.ny}
+              mag={s.mag}
+              opacityScale={skyBackdrop.starOpacity}
             />
           );
         })}
-        {data.stars
-          .filter((s) => s.visible)
-          .map((s) => {
-            const { nx, ny } = azAltToNorm(s.azDeg, s.altDeg);
-            return (
-              <CompactStarGlyph
-                key={s.hip}
-                nx={nx}
-                ny={ny}
-                mag={s.mag}
-                opacityScale={skyBackdrop.starOpacity}
-              />
-            );
-          })}
-        {(data.bodies ?? [])
-          .filter((b: SkyViewBodyDto) => b.visible)
-          .map((b: SkyViewBodyDto) => {
-            const { nx, ny } = azAltToNorm(b.azDeg, b.altDeg);
-            return <CelestialBodyMarker key={b.id} nx={nx} ny={ny} body={b} />;
-          })}
-      </G>
-      <G transform={`rotate(${skyRotation}, 50, 50)`}>
-        <Path d={STELLARIUM_HILL_BASE} fill="#030308" opacity={skyBackdrop.hillOpacity} />
-        <Path d={STELLARIUM_TREE_LINE} fill="#020205" opacity={skyBackdrop.hillOpacity} />
-        {STELLARIUM_BOKEH.map((b, i) => (
-          <Circle
-            key={`bokeh-${i}`}
-            cx={b.cx}
-            cy={b.cy}
-            r={b.r}
-            fill="#ffe8c8"
-            opacity={b.o * skyBackdrop.hillOpacity}
+      {(data.bodies ?? [])
+        .filter((b: SkyViewBodyDto) => b.visible)
+        .map((b: SkyViewBodyDto) => {
+          const p = projectToView(b.azDeg, b.altDeg, viewBasis);
+          if (!p.visible) return null;
+          return <CelestialBodyMarker key={b.id} nx={p.nx} ny={p.ny} body={b} />;
+        })}
+      {/* 지평선 전경(캠핑 명소): 평평한 땅 한 겹 + 가로로 타일링되는 나무·텐트·불빛.
+          실루엣은 낮에도 선명하게(투명도는 시선 고도 페이드만), 불빛은 lightOpacity로 낮엔 꺼짐 */}
+      {groundScene ? (
+        <G opacity={groundScene.fade}>
+          <Rect
+            x={0}
+            y={groundScene.horizonY}
+            width={100}
+            height={150 - groundScene.horizonY}
+            fill={skyBackdrop.campGround}
           />
-        ))}
-      </G>
+          {[-1, 0, 1, 2].map((k) => (
+            <G
+              key={`camp-${k}`}
+              transform={`translate(${(groundScene.scroll + k * CAMP_TILE).toFixed(2)} 0)`}
+            >
+              <CampSceneTile
+                y={groundScene.horizonY}
+                variant={(((groundScene.worldTile + k) % 2) + 2) % 2}
+                lightOpacity={skyBackdrop.lightOpacity}
+                colors={{
+                  pine: skyBackdrop.campPine,
+                  trunk: skyBackdrop.campTrunk,
+                  tent: skyBackdrop.campTent,
+                  accent: skyBackdrop.campTentAccent,
+                }}
+              />
+            </G>
+          ))}
+        </G>
+      ) : null}
       {data.constellationLabels.map((lb, idx) => {
-        const base = azAltToNorm(lb.azDeg, lb.altDeg);
-        const { nx, ny } = rotateSkyNorm(base.nx, base.ny, celestialRot);
+        const p = projectToView(lb.azDeg, lb.altDeg, viewBasis);
+        if (!p.visible) return null;
+        const nx = p.nx;
         const label = CON_LABEL_KO[lb.con] ?? lb.con;
-        const ly = Math.max(5, ny - 4);
+        const ly = p.ny - 4;
         return (
           <SvgText
             key={`${lb.con}-${idx}`}
@@ -1056,10 +1487,9 @@ export function SkyTabScreen({
     data && skyVp.w > 0 && skyVp.h > 0 ? (
       <View style={StyleSheet.absoluteFill} pointerEvents="box-none" collapsable={false}>
         {data.constellationLabels.map((lb, idx) => {
-          const base = azAltToNorm(lb.azDeg, lb.altDeg);
-          const { nx, ny } = rotateSkyNorm(base.nx, base.ny, celestialRot);
-          const ly = Math.max(5, ny - 4);
-          const { x, y } = normToLayoutSlice(nx, ly, skyVp.w, skyVp.h);
+          const px = projectOverlayPx(lb.azDeg, lb.altDeg);
+          if (!px) return null;
+          const { x, y } = px;
           const labelKo = CON_LABEL_KO[lb.con] ?? lb.con;
           return (
             <Pressable
@@ -1270,13 +1700,16 @@ export function SkyTabScreen({
               ) : null}
               <View style={{ marginTop: 8 }}>
                 <Button
-                  label="시야 원위치 (좌우 패닝 초기화)"
+                  label="시야 원위치"
                   variant="outline"
                   size="sm"
-                  disabled={Math.abs(viewAzPanDeg) < 0.25}
-                  onPress={() => setViewAzPanDeg(0)}
+                  disabled={viewIsDefault}
+                  onPress={() => {
+                    setViewYawDeg(VIEW_DEFAULT_YAW);
+                    setViewPitchDeg(VIEW_DEFAULT_PITCH);
+                  }}
                 />
-                {Math.abs(viewAzPanDeg) >= 0.25 ? (
+                {!viewIsDefault ? (
                   <Text
                     style={{
                       color: theme.mutedForeground,
@@ -1285,7 +1718,8 @@ export function SkyTabScreen({
                       lineHeight: 13,
                     }}
                   >
-                    가로로 드래그해 천구만 돌려 본 상태입니다. 버튼으로 처음 각도로 돌아갑니다.
+                    화면을 드래그해 시선을 돌려 본 상태입니다(좌우=방위, 위아래=고도). 버튼으로 처음
+                    방향으로 돌아갑니다.
                   </Text>
                 ) : null}
               </View>
@@ -1462,8 +1896,7 @@ export function SkyTabScreen({
                   layoutWidth={skyVp.w}
                   layoutHeight={skyVp.h}
                   hideCaption
-                  skyRotationDeg={skyRotation}
-                  celestialPanDeg={viewAzPanDeg}
+                  viewBasis={viewBasis}
                   data={data}
                   lineSegments={lineSegments}
                   starsByHip={starsByHip}
@@ -1471,6 +1904,7 @@ export function SkyTabScreen({
                   lineColorHex="#c4b8e8"
                   bodyPlanetHex="#f4e6d8"
                   bodyMoonHex="#fff6dc"
+                  sunAltAz={sunAltAzForSky}
                 />
               ) : !useGlView ? (
                 <View style={{ flex: 1, position: 'relative' }}>{skySvg}</View>
@@ -1509,6 +1943,24 @@ export function SkyTabScreen({
                 </View>
               ) : null}
               {constellationHitOverlay}
+            </View>
+          ) : null}
+
+          {data && atZenith ? (
+            <View pointerEvents="none" style={styles.zenithBadgeWrap}>
+              <View
+                style={[
+                  styles.zenithBadge,
+                  { borderColor: theme.starGold, backgroundColor: 'rgba(6,8,18,0.66)' },
+                ]}
+              >
+                <Text style={[styles.zenithBadgeText, { color: theme.starGold }]}>
+                  천정 · 90°
+                </Text>
+                <Text style={[styles.zenithBadgeSub, { color: theme.mutedForeground }]}>
+                  머리 위를 보는 중
+                </Text>
+              </View>
             </View>
           ) : null}
 
@@ -1760,6 +2212,34 @@ const styles = StyleSheet.create({
     marginTop: 2,
     fontFamily: 'SpaceMono-Regular',
     opacity: 0.85,
+  },
+  zenithBadgeWrap: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 6,
+  },
+  zenithBadge: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 999,
+    borderWidth: StyleSheet.hairlineWidth * 2,
+    alignItems: 'center',
+  },
+  zenithBadgeText: {
+    fontSize: 12,
+    fontWeight: '700',
+    fontFamily: 'SpaceMono-Regular',
+    letterSpacing: 0.6,
+  },
+  zenithBadgeSub: {
+    fontSize: 9,
+    marginTop: 2,
+    letterSpacing: 0.3,
   },
   skyMetaFloat: {
     position: 'absolute',

--- a/frontend/components/sky/sky-appearance.ts
+++ b/frontend/components/sky/sky-appearance.ts
@@ -38,7 +38,12 @@ export function skyBackdropFromSunAlt(altDeg: number): {
   starOpacity: number;
   lineOpacity: number;
   labelOpacity: number;
-  hillOpacity: number;
+  lightOpacity: number;
+  campGround: string;
+  campPine: string;
+  campTrunk: string;
+  campTent: string;
+  campTentAccent: string;
 } {
   /** 0 = 한밤, 1 = 대낮에 가까움 */
   const dayFactor = clamp01((altDeg - (-10)) / (28 - (-10)));
@@ -74,7 +79,23 @@ export function skyBackdropFromSunAlt(altDeg: number): {
 
   const lineOpacity = Math.max(0.14, 0.28 * starOpacity);
   const labelOpacity = Math.max(0.38, 0.88 * starOpacity);
-  const hillOpacity = 0.55 + (1 - dayFactor) * 0.43;
+  /**
+   * 캠프 조명(텐트·랜턴·모닥불 불빛) 세기. 밤=1, 박명에 걸쳐 사그라들고 낮=0.
+   * 땅·나무·텐트 자체는 색만 바뀌고(아래) 불빛만 이 값으로 끈다.
+   */
+  const lightOpacity = clamp01(1 - dayFactor * 2);
+
+  /**
+   * 전경(땅·나무·텐트) 색: 한밤엔 검은 실루엣, 새벽(해 ~-6°)부터 점점 본연의 색으로,
+   * 해가 ~12° 뜨면 완전한 낮 색. 색만 변할 뿐 형태/선명도는 그대로.
+   */
+  const colorT = clamp01((altDeg + 6) / 18);
+  const campNight: [number, number, number] = [4, 5, 12];
+  const campGround = mixRgb(campNight, [74, 72, 54], colorT); // 흙·풀 섞인 자연색 땅
+  const campPine = mixRgb(campNight, [46, 84, 52], colorT); // 초록 침엽수
+  const campTrunk = mixRgb(campNight, [88, 60, 40], colorT); // 갈색 줄기
+  const campTent = mixRgb(campNight, [212, 184, 138], colorT); // 베이지 텐트
+  const campTentAccent = mixRgb(campNight, [226, 124, 54], colorT); // 주황 텐트
 
   return {
     zenith,
@@ -85,6 +106,11 @@ export function skyBackdropFromSunAlt(altDeg: number): {
     starOpacity,
     lineOpacity,
     labelOpacity,
-    hillOpacity,
+    lightOpacity,
+    campGround,
+    campPine,
+    campTrunk,
+    campTent,
+    campTentAccent,
   };
 }

--- a/frontend/components/sky/sky-projection.ts
+++ b/frontend/components/sky/sky-projection.ts
@@ -47,3 +47,103 @@ export function normToLayoutSlice(
   const oy = (layoutH - 100 * scale) / 2;
   return { x: ox + nx * scale, y: oy + ny * scale };
 }
+
+/* ────────────────────────────────────────────────────────────────────────
+ * 1인칭 카메라 투영 (천정 고정 회전 대신 "바라보는 방향" 기준 둘러보기)
+ *
+ * 화면 중앙 = 시선 방향(viewAz, viewAlt). 별까지의 천구각거리(ρ)와 화면상
+ * 방위(카메라 right/up 성분)로 방위등거리(azimuthal-equidistant) 투영한다.
+ * 천정을 정면(viewAlt=90)으로 두면 기존 천정중심 표시와 동일한 축척이 된다.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** 천정→지평선(90°)=46 units 라는 기존 축척 유지 */
+export const SKY_UNITS_PER_RAD = 46 / (Math.PI / 2);
+
+/** GL 몰입(원근) 뷰 수직 시야각(°). GL 캔버스와 라벨 오버레이가 공유한다. */
+export const GL_FOV_V_DEG = 105;
+export const GL_TAN_HALF_FOV = Math.tan((GL_FOV_V_DEG * Math.PI) / 360);
+
+export type Vec3 = [number, number, number];
+
+export type ViewBasis = {
+  fwd: Vec3;
+  right: Vec3;
+  up: Vec3;
+};
+
+/** 방위·고도 → 지평좌표 단위벡터 (x=동, y=북, z=상) */
+export function dirFromAzAlt(azDeg: number, altDeg: number): Vec3 {
+  const a = (azDeg * Math.PI) / 180;
+  const e = (altDeg * Math.PI) / 180;
+  const ce = Math.cos(e);
+  return [ce * Math.sin(a), ce * Math.cos(a), Math.sin(e)];
+}
+
+/**
+ * 1인칭 "제자리에서 몸 돌리고 고개 드는" 시점 기저.
+ *
+ * 카메라 right(화면 오른쪽) = 방위각+90°의 지평선 방향 → 항상 수평이고, 천정에서도
+ * 방위각에 의존한다. 그래서:
+ *  - 고도 0°(정면): right=수평, up=천정 → 좌우 회전은 순수 수평 패닝
+ *  - 고도 90°(천정): forward=천정 고정(화면 중심), 방위각이 바뀌면 right/up이 돌아
+ *    별이 화면 중심을 축으로 roll
+ *  - 중간 고도: 패닝과 roll이 고도에 비례해 자연스럽게 섞임
+ *
+ * 기존 cross(forward, 월드업) 방식은 천정에서 0벡터가 돼 방위각이 무시되던(회전 안 됨)
+ * 특이점이 있었는데, right를 방위각에서 직접 잡아 해소했다(고도<90°에선 결과 동일).
+ */
+export function computeViewBasis(viewAzDeg: number, viewAltDeg: number): ViewBasis {
+  const fwd = dirFromAzAlt(viewAzDeg, viewAltDeg);
+  const right = dirFromAzAlt(viewAzDeg + 90, 0);
+  // up = cross(right, fwd) (right·fwd=0 이라 이미 정규직교)
+  const up: Vec3 = [
+    right[1] * fwd[2] - right[2] * fwd[1],
+    right[2] * fwd[0] - right[0] * fwd[2],
+    right[0] * fwd[1] - right[1] * fwd[0],
+  ];
+  return { fwd, right, up };
+}
+
+/**
+ * 원근(perspective) 투영 — GL 몰입 뷰 전용. 클립좌표(-1..1)를 직접 반환한다.
+ * 어안(projectToView)과 달리 사람 눈/카메라처럼 직선 투영이라 화면을 사각형으로
+ * 가득 채우고 둥근 테두리가 생기지 않는다. tanHalfFov=tan(수직시야각/2), aspect=가로/세로.
+ */
+export function projectPerspectiveClip(
+  azDeg: number,
+  altDeg: number,
+  basis: ViewBasis,
+  tanHalfFov: number,
+  aspect: number,
+): { cx: number; cy: number; visible: boolean } {
+  const s = dirFromAzAlt(azDeg, altDeg);
+  const f = s[0] * basis.fwd[0] + s[1] * basis.fwd[1] + s[2] * basis.fwd[2];
+  if (f <= 0.05) return { cx: 0, cy: 0, visible: false };
+  const rc = s[0] * basis.right[0] + s[1] * basis.right[1] + s[2] * basis.right[2];
+  const uc = s[0] * basis.up[0] + s[1] * basis.up[1] + s[2] * basis.up[2];
+  const cx = rc / f / (tanHalfFov * aspect);
+  const cy = uc / f / tanHalfFov;
+  const visible = cx > -1.18 && cx < 1.18 && cy > -1.18 && cy < 1.18;
+  return { cx, cy, visible };
+}
+
+/** 별(az,alt)을 시선 기준 viewBox(0–100) 좌표로. visible=false면 시야 뒤/가장자리 */
+export function projectToView(
+  azDeg: number,
+  altDeg: number,
+  basis: ViewBasis,
+): { nx: number; ny: number; rho: number; visible: boolean } {
+  const s = dirFromAzAlt(azDeg, altDeg);
+  const fwd = s[0] * basis.fwd[0] + s[1] * basis.fwd[1] + s[2] * basis.fwd[2];
+  const rc = s[0] * basis.right[0] + s[1] * basis.right[1] + s[2] * basis.right[2];
+  const uc = s[0] * basis.up[0] + s[1] * basis.up[1] + s[2] * basis.up[2];
+  const rho = Math.acos(Math.max(-1, Math.min(1, fwd)));
+  const dl = Math.hypot(rc, uc) || 1e-6;
+  const radius = rho * SKY_UNITS_PER_RAD;
+  return {
+    nx: 50 + radius * (rc / dl),
+    ny: 50 - radius * (uc / dl),
+    rho,
+    visible: rho < (Math.PI * 110) / 180,
+  };
+}


### PR DESCRIPTION
## 🔎 What

- 1인칭 시점 카메라(좌우 회전/상하 고개, 0~90° 제한)로 재구성
- SVG: 언덕 제거 후 캠핑 씬(땅·나무·텐트·조명) + 낮밤 색/조명 전환, 땅 색 자연화
- GL 실사 비주얼: 별 반짝임(scintillation) + 밝은 별·행성 블룸(광채) + 황혼 시 해가 진 방위만 노을(사방 링 제거)
- GL 어안 → 원근 투영 전환(둥근 원 제거, 화면 꽉 채움) + 라벨 원근 정렬
- GL 시야각 105°로 확대
## 🔗 Issue 

- Closes: #96 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
