### PR TITLE
fix(diary): 일기 사진 썸네일 잘림 개선 및 상세 갤러리 확대 미리보기

### DIFF
--- a/frontend/components/records/DiaryDetailModal.tsx
+++ b/frontend/components/records/DiaryDetailModal.tsx
@@ -6,7 +6,6 @@ import Feather from '@expo/vector-icons/Feather';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
-  FlatList,
   Image,
   Modal,
   Pressable,
@@ -16,6 +15,7 @@ import {
   View,
   useWindowDimensions,
 } from 'react-native';
+import { DiaryImagePreviewModal } from './DiaryImagePreviewModal';
 import {
   ApiRequestError,
   deleteObservation,
@@ -208,8 +208,10 @@ function MismatchReportSection({
 
 function DiaryPhotoGallery({
   photos,
+  onPhotoPress,
 }: {
   photos: ObservationRowDto['photos'];
+  onPhotoPress: (index: number) => void;
 }) {
   const { theme } = useTheme();
   const { width: screenWidth } = useWindowDimensions();
@@ -219,39 +221,44 @@ function DiaryPhotoGallery({
 
   return (
     <View style={styles.photoSection}>
-      <FlatList
-        data={photos}
+      <ScrollView
         horizontal
-        keyExtractor={(item) => item.id}
-        showsHorizontalScrollIndicator={false}
         nestedScrollEnabled
-        directionalLockEnabled
+        showsHorizontalScrollIndicator={false}
         decelerationRate="fast"
         snapToInterval={photoWidth + spacing.sm}
         snapToAlignment="start"
         disableIntervalMomentum
         style={styles.photoList}
         contentContainerStyle={styles.photoRow}
-        ItemSeparatorComponent={() => <View style={{ width: spacing.sm }} />}
-        renderItem={({ item }) => (
-          <Image
-            source={{ uri: item.imageUrl }}
-            style={[
-              styles.photo,
-              {
-                width: photoWidth,
-                borderColor: theme.cardBorder,
-              },
-            ]}
-            resizeMode="cover"
-          />
-        )}
-      />
-      {photos.length > 1 ? (
-        <Text style={[styles.photoSwipeHint, { color: theme.mutedForeground }]}>
-          ← 좌우로 밀어 {photos.length}장 보기
-        </Text>
-      ) : null}
+        keyboardShouldPersistTaps="handled"
+      >
+        {photos.map((item, index) => (
+          <React.Fragment key={item.id}>
+            {index > 0 ? <View style={{ width: spacing.sm }} /> : null}
+            <Pressable
+              onPress={() => onPhotoPress(index)}
+              accessibilityRole="imagebutton"
+              accessibilityLabel={`일기 사진 ${index + 1}장 크게 보기`}
+              style={({ pressed }) => [
+                styles.photoFrame,
+                {
+                  width: photoWidth,
+                  borderColor: theme.cardBorder,
+                  backgroundColor: theme.inputBackground,
+                  opacity: pressed ? 0.88 : 1,
+                },
+              ]}
+            >
+              <Image
+                source={{ uri: item.imageUrl }}
+                style={styles.photoImage}
+                resizeMode="contain"
+              />
+            </Pressable>
+          </React.Fragment>
+        ))}
+      </ScrollView>
     </View>
   );
 }
@@ -275,11 +282,13 @@ export function DiaryDetailModal({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
 
   useEffect(() => {
     if (!visible) {
       setDeleteConfirmOpen(false);
       setError(null);
+      setPreviewIndex(null);
     }
   }, [visible]);
 
@@ -351,7 +360,12 @@ export function DiaryDetailModal({
               <StarIndexStatCard value={row.starIndexVal} />
             </View>
 
-            {row.photos.length > 0 ? <DiaryPhotoGallery photos={row.photos} /> : null}
+            {row.photos.length > 0 ? (
+              <DiaryPhotoGallery
+                photos={row.photos}
+                onPhotoPress={(index) => setPreviewIndex(index)}
+              />
+            ) : null}
 
             <Text style={[styles.content, { color: theme.foreground }]}>
               {(row.content ?? '').trim() || '내용 없음'}
@@ -438,6 +452,13 @@ export function DiaryDetailModal({
               </View>
             </View>
           ) : null}
+
+          <DiaryImagePreviewModal
+            visible={previewIndex != null}
+            photos={row.photos}
+            initialIndex={previewIndex ?? 0}
+            onClose={() => setPreviewIndex(null)}
+          />
         </View>
       </View>
     </Modal>
@@ -586,16 +607,17 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.lg,
     paddingRight: spacing.lg + spacing.sm,
   },
-  photo: {
+  photoFrame: {
     height: 140,
     borderRadius: 12,
     borderWidth: 1,
+    overflow: 'hidden',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
-  photoSwipeHint: {
-    fontSize: 11,
-    textAlign: 'center',
-    marginTop: 6,
-    paddingHorizontal: spacing.lg,
+  photoImage: {
+    width: '100%',
+    height: '100%',
   },
   content: {
     fontSize: 15,

--- a/frontend/components/records/DiaryEntryCard.tsx
+++ b/frontend/components/records/DiaryEntryCard.tsx
@@ -57,7 +57,9 @@ export function DiaryEntryCard({ row, onPress }: DiaryEntryCardProps) {
     <AppPressable onPress={onPress} style={({ pressed }) => [{ opacity: pressed ? 0.92 : 1 }]}>
       <GlassCard padding={0} style={styles.card} glow>
         {cover ? (
-          <Image source={{ uri: cover }} style={styles.cover} resizeMode="cover" />
+          <View style={[styles.coverFrame, { backgroundColor: theme.inputBackground }]}>
+            <Image source={{ uri: cover }} style={styles.cover} resizeMode="contain" />
+          </View>
         ) : (
           <View style={[styles.coverPlaceholder, { backgroundColor: theme.inputBackground }]}>
             <Feather name="moon" size={28} color={theme.mutedForeground} />
@@ -119,9 +121,15 @@ const styles = StyleSheet.create({
     marginBottom: spacing.md,
     overflow: 'hidden',
   },
-  cover: {
+  coverFrame: {
     width: '100%',
     height: 140,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cover: {
+    width: '100%',
+    height: '100%',
   },
   coverPlaceholder: {
     width: '100%',

--- a/frontend/components/records/DiaryImagePreviewModal.tsx
+++ b/frontend/components/records/DiaryImagePreviewModal.tsx
@@ -1,0 +1,163 @@
+/**
+ * 일기 사진 전체 화면 미리보기 — 좌우 스와이프 · 닫기
+ */
+
+import Feather from '@expo/vector-icons/Feather';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  FlatList,
+  Image,
+  Modal,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { spacing } from '../../themes/design-tokens';
+import { useTheme } from '../../themes/ThemeContext';
+
+export interface DiaryPreviewPhoto {
+  id: string;
+  imageUrl: string;
+}
+
+interface DiaryImagePreviewModalProps {
+  visible: boolean;
+  photos: DiaryPreviewPhoto[];
+  initialIndex?: number;
+  onClose: () => void;
+}
+
+export function DiaryImagePreviewModal({
+  visible,
+  photos,
+  initialIndex = 0,
+  onClose,
+}: DiaryImagePreviewModalProps) {
+  const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
+  const listRef = useRef<FlatList<DiaryPreviewPhoto>>(null);
+  const safeIndex = Math.min(Math.max(initialIndex, 0), Math.max(photos.length - 1, 0));
+  const [activeIndex, setActiveIndex] = useState(safeIndex);
+
+  useEffect(() => {
+    if (!visible) return;
+    setActiveIndex(safeIndex);
+    const timer = setTimeout(() => {
+      listRef.current?.scrollToIndex({ index: safeIndex, animated: false });
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [visible, safeIndex]);
+
+  const onScrollEnd = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const x = e.nativeEvent.contentOffset.x;
+      const next = Math.round(x / screenWidth);
+      if (next >= 0 && next < photos.length) {
+        setActiveIndex(next);
+      }
+    },
+    [photos.length, screenWidth],
+  );
+
+  if (photos.length === 0) return null;
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <View style={[styles.backdrop, { backgroundColor: theme.overlay }]}>
+        <View style={[styles.topBar, { paddingTop: Math.max(insets.top, spacing.sm) }]}>
+          <Pressable
+            onPress={onClose}
+            hitSlop={12}
+            style={({ pressed }) => [styles.closeBtn, pressed && { opacity: 0.75 }]}
+            accessibilityRole="button"
+            accessibilityLabel="닫기"
+          >
+            <Feather name="x" size={24} color={theme.foreground} />
+          </Pressable>
+          {photos.length > 1 ? (
+            <Text style={[styles.counter, { color: theme.mutedForeground }]}>
+              {activeIndex + 1} / {photos.length}
+            </Text>
+          ) : (
+            <View style={{ width: 24 }} />
+          )}
+        </View>
+
+        <FlatList
+          ref={listRef}
+          data={photos}
+          horizontal
+          pagingEnabled
+          scrollEnabled={photos.length > 1}
+          nestedScrollEnabled
+          showsHorizontalScrollIndicator={false}
+          keyExtractor={(item) => item.id}
+          style={styles.list}
+          initialScrollIndex={photos.length > 1 ? safeIndex : undefined}
+          getItemLayout={(_, index) => ({
+            length: screenWidth,
+            offset: screenWidth * index,
+            index,
+          })}
+          onMomentumScrollEnd={onScrollEnd}
+          onScrollToIndexFailed={() => {
+            /* 레이아웃 직후 재시도는 useEffect에서 처리 */
+          }}
+          renderItem={({ item }) => (
+            <View style={[styles.slide, { width: screenWidth, height: screenHeight * 0.72 }]}>
+              <Image
+                source={{ uri: item.imageUrl }}
+                style={styles.image}
+                resizeMode="contain"
+                accessibilityLabel="일기 사진 크게 보기"
+              />
+            </View>
+          )}
+        />
+
+        <View style={{ height: insets.bottom + spacing.md }} />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+  },
+  list: {
+    flex: 1,
+  },
+  topBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.sm,
+  },
+  closeBtn: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  counter: {
+    fontSize: 13,
+    fontWeight: '500',
+    fontVariant: ['tabular-nums'],
+  },
+  slide: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+});


### PR DESCRIPTION
## 🔎 What

다이어리(LOG) 탭에서 업로드된 사진이 카드·상세 갤러리에서 `cover` + 고정 높이로 과도하게 잘리던 문제를 수정했습니다. 사진 확대(전체 화면 미리보기)는 **일기 상세 갤러리에서만** 동작합니다.

### 이미지 스타일 변경
- **목록 카드** (`DiaryEntryCard`): `resizeMode=cover` → `contain`, `theme.inputBackground` 프레임(140px) — 탭 시 상세 모달만 열림(확대 없음)
- **상세 갤러리** (`DiaryDetailModal`): `contain` + 프레임 스타일, 가로 스크롤은 `ScrollView`로 교체(중첩 스크롤 안정화)

### 터치 확대 방식
- 신규 `DiaryImagePreviewModal` (React Native `Modal`)
- **일기 상세 갤러리** 사진 탭 시에만 전체 화면 표시
- 닫기: X 버튼, Android 뒤로가기
- 여러 장: 가로 페이징 스와이프 + 상단 `n / total` 카운터

### 변경 전후 체감
- **전:** 세로·가로 사진이 카드/갤러리에서 잘려 보이고, 크게 볼 방법이 없거나 제스처가 막힘
- **후:** 목록·갤러리 썸네일은 레이아웃을 유지하며 전체가 보이고, 상세에서 사진 탭 시 원본 비율로 확대 가능

### 후속 피드백 반영
- 안내 문구(`좌우로 밀어…`, `탭하면 크게…`) 제거
- 목록 카드 사진 탭 확대 제거 → 상세 갤러리 전용으로 정리
- 미리보기 Modal `Pressable` 래퍼 제거로 다중 사진 스와이프 수정

## 🔗 Issue

* closes: #(이슈 번호 기입)

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요? (`develop`)
* [ ] 제목이 이슈 제목과 동일한가요?
* [ ] 최소 1명의 리뷰를 받았나요?

## 검증 방법

1. `cd frontend && npm run typecheck`
2. Expo 앱 → LOG 탭 → **펼쳐보기**
3. 세로/가로/정사각형 사진이 있는 일기 확인
   - 목록 카드 썸네일이 과도하게 잘리지 않는지
   - 카드 탭 → 상세 모달 → 갤러리 좌우 스와이프
   - 갤러리 사진 탭 → 전체 화면 확대·다중 사진 스와이프
4. 목록 카드 사진만 탭해도 확대되지 않는지 확인
5. 미리보기 X/뒤로가기로 닫히는지 확인

## iOS / Android 테스트

| 항목 | iOS | Android |
|------|-----|---------|
| 카드 썸네일 contain | 실기기 확인 필요 | 실기기 확인 필요 |
| 상세 갤러리 가로 스와이프 | 실기기 확인 필요 | 실기기 확인 필요 |
| 상세 갤러리 탭 확대 | 실기기 확인 필요 | 실기기 확인 필요 |
| 다중 사진 확대 스와이프 | 실기기 확인 필요 | 실기기 확인 필요 |