### PR TITLE
fix(upload): iPhone HEIC/HEIF 사진 JPEG 변환 후 업로드

### DIFF
--- a/frontend/components/profile/ProfileEditModal.tsx
+++ b/frontend/components/profile/ProfileEditModal.tsx
@@ -17,6 +17,10 @@ import {
   uploadMyAvatar,
 } from '../../lib/api-client';
 import type { UserProfileDto } from '../../lib/types/api';
+import {
+  prepareImageForUpload,
+  UPLOAD_IMAGE_FORMAT_ERROR,
+} from '../../lib/prepare-upload-image';
 import { Button, Input } from '../ui';
 import { ProfileAvatar } from './ProfileAvatar';
 import { ProfileImageCropModal, type PickedImage } from './ProfileImageCropModal';
@@ -94,11 +98,20 @@ export function ProfileEditModal({
     if (result.canceled || !result.assets[0]) return;
 
     const asset = result.assets[0];
-    setCropTarget({
-      uri: asset.uri,
-      width: asset.width,
-      height: asset.height,
-    });
+    try {
+      const prepared = await prepareImageForUpload(
+        asset.uri,
+        asset.mimeType,
+        asset.fileName ?? null,
+      );
+      setCropTarget({
+        uri: prepared.uri,
+        width: asset.width,
+        height: asset.height,
+      });
+    } catch {
+      setError(UPLOAD_IMAGE_FORMAT_ERROR);
+    }
   }, []);
 
   const uploadCropped = useCallback(async (uri: string) => {

--- a/frontend/components/records/DiaryPhotoPicker.tsx
+++ b/frontend/components/records/DiaryPhotoPicker.tsx
@@ -4,7 +4,7 @@
 
 import Feather from '@expo/vector-icons/Feather';
 import * as ImagePicker from 'expo-image-picker';
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   Image,
   ScrollView,
@@ -14,6 +14,10 @@ import {
 } from 'react-native';
 import { spacing } from '../../themes/design-tokens';
 import { useTheme } from '../../themes/ThemeContext';
+import {
+  prepareImageForUpload,
+  UPLOAD_IMAGE_FORMAT_ERROR,
+} from '../../lib/prepare-upload-image';
 import { AppPressable } from '../ui/AppPressable';
 
 export interface LocalDiaryPhoto {
@@ -35,9 +39,11 @@ export function DiaryPhotoPicker({
   error = null,
 }: DiaryPhotoPickerProps) {
   const { theme } = useTheme();
+  const [pickError, setPickError] = useState<string | null>(null);
 
   const pickPhotos = useCallback(async () => {
     if (disabled) return;
+    setPickError(null);
     const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!perm.granted) return;
 
@@ -49,10 +55,26 @@ export function DiaryPhotoPicker({
     });
     if (result.canceled || !result.assets.length) return;
 
-    const next = result.assets.map((asset) => ({
-      uri: asset.uri,
-      mimeType: asset.mimeType ?? 'image/jpeg',
-    }));
+    const next: LocalDiaryPhoto[] = [];
+    let failed = 0;
+    for (const asset of result.assets) {
+      try {
+        const prepared = await prepareImageForUpload(
+          asset.uri,
+          asset.mimeType,
+          asset.fileName ?? null,
+        );
+        next.push(prepared);
+      } catch {
+        failed += 1;
+      }
+    }
+
+    if (failed > 0) {
+      setPickError(UPLOAD_IMAGE_FORMAT_ERROR);
+    }
+    if (next.length === 0) return;
+
     onChange([...photos, ...next].slice(0, 10));
   }, [disabled, onChange, photos]);
 
@@ -104,8 +126,10 @@ export function DiaryPhotoPicker({
       <Text style={[styles.hint, { color: theme.mutedForeground }]}>
         최대 10장 · {photos.length}장 선택됨
       </Text>
-      {error ? (
-        <Text style={[styles.error, { color: theme.destructive }]}>{error}</Text>
+      {pickError || error ? (
+        <Text style={[styles.error, { color: theme.destructive }]}>
+          {pickError ?? error}
+        </Text>
       ) : null}
     </View>
   );

--- a/frontend/lib/api/observations-api.ts
+++ b/frontend/lib/api/observations-api.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '../config';
+import { prepareImageForUpload, UPLOAD_IMAGE_FORMAT_ERROR } from '../prepare-upload-image';
 import {
   clearSession,
   loadTokens,
@@ -65,13 +66,24 @@ export async function uploadObservationPhoto(
     throw new SessionExpiredError();
   }
 
+  let prepared;
+  try {
+    prepared = await prepareImageForUpload(localUri, mimeType);
+  } catch {
+    throw new ApiRequestError(UPLOAD_IMAGE_FORMAT_ERROR, 400, null);
+  }
+
   const ext =
-    mimeType === 'image/png' ? 'png' : mimeType === 'image/webp' ? 'webp' : 'jpg';
+    prepared.mimeType === 'image/png'
+      ? 'png'
+      : prepared.mimeType === 'image/webp'
+        ? 'webp'
+        : 'jpg';
   const form = new FormData();
   form.append('file', {
-    uri: localUri,
+    uri: prepared.uri,
     name: `diary.${ext}`,
-    type: mimeType,
+    type: prepared.mimeType,
   } as unknown as Blob);
 
   const path = `/observations/${observationId}/photos`;

--- a/frontend/lib/api/users.ts
+++ b/frontend/lib/api/users.ts
@@ -1,4 +1,5 @@
 import { getApiBaseUrl } from '../config';
+import { prepareImageForUpload, UPLOAD_IMAGE_FORMAT_ERROR } from '../prepare-upload-image';
 import {
   clearSession,
   clearUserScopedStorage,
@@ -36,13 +37,24 @@ export async function uploadMyAvatar(
     throw new SessionExpiredError();
   }
 
+  let prepared;
+  try {
+    prepared = await prepareImageForUpload(localUri, mimeType);
+  } catch {
+    throw new ApiRequestError(UPLOAD_IMAGE_FORMAT_ERROR, 400, null);
+  }
+
   const ext =
-    mimeType === 'image/png' ? 'png' : mimeType === 'image/webp' ? 'webp' : 'jpg';
+    prepared.mimeType === 'image/png'
+      ? 'png'
+      : prepared.mimeType === 'image/webp'
+        ? 'webp'
+        : 'jpg';
   const form = new FormData();
   form.append('file', {
-    uri: localUri,
+    uri: prepared.uri,
     name: `avatar.${ext}`,
-    type: mimeType,
+    type: prepared.mimeType,
   } as unknown as Blob);
 
   const doFetch = (token: string) =>

--- a/frontend/lib/prepare-upload-image.ts
+++ b/frontend/lib/prepare-upload-image.ts
@@ -1,0 +1,96 @@
+import { ImageManipulator, SaveFormat } from 'expo-image-manipulator';
+
+const HEIC_MIMES = new Set([
+  'image/heic',
+  'image/heif',
+  'image/heic-sequence',
+  'image/heif-sequence',
+]);
+
+const ALLOWED_UPLOAD_MIMES = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+]);
+
+const HEIC_EXT = /\.(heic|heif)$/i;
+
+export const UPLOAD_IMAGE_FORMAT_ERROR =
+  '이 사진 형식은 업로드에 실패했습니다. 다른 사진을 선택하거나 다시 시도해주세요.';
+
+export interface PreparedUploadImage {
+  uri: string;
+  mimeType: string;
+}
+
+function normalizeMimeType(mimeType?: string | null): string {
+  const mime = (mimeType ?? '').toLowerCase();
+  if (mime === 'image/png') return 'image/png';
+  if (mime === 'image/webp') return 'image/webp';
+  return 'image/jpeg';
+}
+
+function looksLikeHeic(
+  mimeType?: string | null,
+  uri?: string,
+  fileName?: string | null,
+): boolean {
+  const mime = (mimeType ?? '').toLowerCase();
+  if (HEIC_MIMES.has(mime) || mime.includes('heic') || mime.includes('heif')) {
+    return true;
+  }
+  const path = (uri ?? '').split('?')[0];
+  if (HEIC_EXT.test(path)) return true;
+  if (fileName && HEIC_EXT.test(fileName)) return true;
+  return false;
+}
+
+/** 서버 허용 형식이 아니거나 HEIC/HEIF면 JPEG 변환 */
+export function needsUploadImageConversion(
+  mimeType?: string | null,
+  uri?: string,
+  fileName?: string | null,
+): boolean {
+  if (looksLikeHeic(mimeType, uri, fileName)) return true;
+  const mime = (mimeType ?? '').toLowerCase();
+  if (!mime) return true;
+  return !ALLOWED_UPLOAD_MIMES.has(mime);
+}
+
+/**
+ * 업로드 전 이미지 정규화.
+ * HEIC/HEIF·미지원 MIME은 JPEG로 변환하고, PNG/WebP·JPEG는 그대로 둔다.
+ */
+export async function prepareImageForUpload(
+  uri: string,
+  mimeType?: string | null,
+  fileName?: string | null,
+): Promise<PreparedUploadImage> {
+  if (!uri?.trim()) {
+    throw new Error('IMAGE_CONVERT_FAILED');
+  }
+
+  if (!needsUploadImageConversion(mimeType, uri, fileName)) {
+    return {
+      uri,
+      mimeType: normalizeMimeType(mimeType),
+    };
+  }
+
+  const context = ImageManipulator.manipulate(uri);
+  const rendered = await context.renderAsync();
+  const saved = await rendered.saveAsync({
+    compress: 0.85,
+    format: SaveFormat.JPEG,
+  });
+
+  if (!saved.uri) {
+    throw new Error('IMAGE_CONVERT_FAILED');
+  }
+
+  return {
+    uri: saved.uri,
+    mimeType: 'image/jpeg',
+  };
+}


### PR DESCRIPTION
﻿## What

iPhone HEIC/HEIF 사진이 서버 MIME 검증에 걸려 일기·프로필 업로드가 실패하던 문제를 수정했습니다.

### 처리 방식
- HEIC/HEIF를 expo-image-manipulator로 JPEG 변환 후 업로드
- uploadObservationPhoto, uploadMyAvatar에서 항상 prepareImageForUpload 경유
- MIME/확장자/fileName 기준 변환 대상 판별 강화

### 수정 파일
- frontend/lib/prepare-upload-image.ts (신규)
- frontend/lib/api/observations-api.ts
- frontend/lib/api/users.ts
- frontend/components/records/DiaryPhotoPicker.tsx
- frontend/components/profile/ProfileEditModal.tsx

### 변경 전후
- 전: HEIC 그대로 전송 → 서버에서 JPEG, PNG, WebP만 허용 오류
- 후: JPEG 변환 후 image/jpeg로 업로드

### 서버 재시작
- 불필요 (백엔드 변경 없음). Expo 리로드 필요 (npx expo start --clear)

## Issue

closes: #(이슈 번호 기입)

## 체크리스트

- [x] 브랜치 base: develop
- [ ] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?

## 검증 방법

1. cd frontend && npm run typecheck
2. fix/heif-image-upload 브랜치에서 Expo 리로드
3. iPhone HEIC 일기 업로드 성공
4. JPG/PNG 회귀 테스트
