### PR TITLE
fix(mypage): 회원 탈퇴 색상 통일 및 탈퇴 완료 피드백 개선

### DIFF
--- a/frontend/components/auth/auth-screen.tsx
+++ b/frontend/components/auth/auth-screen.tsx
@@ -68,12 +68,20 @@ function applyEmailFieldError(
 export function AuthScreen() {
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
-  const { login, register, justLoggedOut, clearJustLoggedOut } = useAuth();
+  const {
+    login,
+    register,
+    justLoggedOut,
+    clearJustLoggedOut,
+    justAccountDeleted,
+    clearJustAccountDeleted,
+  } = useAuth();
   const [mode, setMode] = useState<Mode>('login');
   const [formOpen, setFormOpen] = useState(false);
   const scrollRef = useRef<ScrollView>(null);
   const [kbHeight, setKbHeight] = useState(0);
   const [logoutSuccessOpen, setLogoutSuccessOpen] = useState(false);
+  const [accountDeletedSuccessOpen, setAccountDeletedSuccessOpen] = useState(false);
   const sheetY = useRef(new Animated.Value(SHEET_CLOSED_Y)).current;
   const welcomeOpacity = useRef(new Animated.Value(1)).current;
   const brandReveal = useRef(new Animated.Value(0)).current;
@@ -86,6 +94,12 @@ export function AuthScreen() {
     setLogoutSuccessOpen(true);
     clearJustLoggedOut();
   }, [justLoggedOut, clearJustLoggedOut]);
+
+  useEffect(() => {
+    if (!justAccountDeleted) return;
+    setAccountDeletedSuccessOpen(true);
+    clearJustAccountDeleted();
+  }, [justAccountDeleted, clearJustAccountDeleted]);
 
   useEffect(() => {
     const show = Keyboard.addListener(
@@ -822,6 +836,17 @@ export function AuthScreen() {
         autoDismissMs={2400}
         onPrimary={() => setLogoutSuccessOpen(false)}
         onRequestClose={() => setLogoutSuccessOpen(false)}
+      />
+
+      <AppAlertModal
+        visible={accountDeletedSuccessOpen}
+        tone="success"
+        title="회원 탈퇴가 완료되었습니다"
+        message="계정과 데이터가 삭제되었습니다. 이용해 주셔서 감사합니다."
+        primaryLabel="확인"
+        autoDismissMs={3200}
+        onPrimary={() => setAccountDeletedSuccessOpen(false)}
+        onRequestClose={() => setAccountDeletedSuccessOpen(false)}
       />
     </Screen>
   );

--- a/frontend/components/profile/ProfileDeleteAccountModal.tsx
+++ b/frontend/components/profile/ProfileDeleteAccountModal.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from 'react';
 import {
-  ActivityIndicator,
   Modal,
   Pressable,
   StyleSheet,
@@ -35,9 +34,10 @@ export function ProfileDeleteAccountModal({
   }, []);
 
   const handleClose = useCallback(() => {
+    if (busy) return;
     resetForm();
     onClose();
-  }, [onClose, resetForm]);
+  }, [busy, onClose, resetForm]);
 
   const handleDelete = useCallback(async () => {
     setFormError(null);
@@ -62,13 +62,18 @@ export function ProfileDeleteAccountModal({
   }, [onDeleted, password, resetForm]);
 
   return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={handleClose}>
-      <Pressable style={styles.backdrop} onPress={handleClose}>
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={busy ? undefined : handleClose}
+    >
+      <Pressable style={styles.backdrop} onPress={busy ? undefined : handleClose}>
         <Pressable
           style={[styles.sheet, { backgroundColor: theme.card, borderColor: theme.border }]}
           onPress={(e) => e.stopPropagation()}
         >
-          <Text style={[styles.title, { color: danger.title }]}>회원 탈퇴</Text>
+          <Text style={[styles.title, { color: danger.subtitle }]}>회원 탈퇴</Text>
           <Text style={[styles.warning, { color: danger.subtitle }]}>
             탈퇴하면 프로필·관측 기록·알림 설정 등 모든 데이터가 삭제되며 복구할 수 없습니다.
           </Text>
@@ -91,10 +96,6 @@ export function ProfileDeleteAccountModal({
             <Text style={[styles.err, { color: theme.destructive }]}>{formError}</Text>
           ) : null}
 
-          {busy ? (
-            <ActivityIndicator color={theme.starGold} style={{ marginVertical: 8 }} />
-          ) : null}
-
           <View style={styles.btnRow}>
             <View style={{ flex: 1 }}>
               <Button
@@ -110,6 +111,7 @@ export function ProfileDeleteAccountModal({
                 label="탈퇴하기"
                 variant="red"
                 fullWidth
+                loading={busy}
                 disabled={busy}
                 onPress={() => void handleDelete()}
               />

--- a/frontend/components/profile/ProfileTabScreen.tsx
+++ b/frontend/components/profile/ProfileTabScreen.tsx
@@ -76,7 +76,7 @@ export function ProfileTabScreen({
 }: ProfileTabScreenProps) {
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
-  const { applyProfile } = useAuth();
+  const { applyProfile, completeAccountDeletion } = useAuth();
   const [profile, setProfile] = useState<UserProfileDto | null>(null);
   const [profileLoading, setProfileLoading] = useState(true);
   const [profileError, setProfileError] = useState<string | null>(null);
@@ -511,6 +511,7 @@ export function ProfileTabScreen({
               subtitle="계정과 데이터가 삭제됩니다"
               chevron
               danger
+              dangerMuted
               isRedMode={isRedMode}
               onPress={() => setDeleteOpen(true)}
             />
@@ -616,7 +617,7 @@ export function ProfileTabScreen({
         onClose={() => setDeleteOpen(false)}
         onDeleted={() => {
           setDeleteOpen(false);
-          onLogout();
+          completeAccountDeletion();
         }}
       />
 
@@ -650,6 +651,7 @@ function SettingRow({
   chevron,
   trailingText,
   danger = false,
+  dangerMuted = false,
   isRedMode = false,
   onPress,
 }: {
@@ -664,10 +666,16 @@ function SettingRow({
   chevron?: boolean;
   trailingText?: string;
   danger?: boolean;
+  /** danger일 때 제목·아이콘을 subtitle 톤(연한 빨강)으로 맞춤 */
+  dangerMuted?: boolean;
   isRedMode?: boolean;
   onPress?: () => void;
 }) {
   const accent = danger ? dangerAccent(theme, isRedMode) : null;
+  const mutedDanger = danger && dangerMuted && accent;
+  const titleColor = mutedDanger ? accent.subtitle : (accent?.title ?? theme.foreground);
+  const iconColor = mutedDanger ? accent.subtitle : (accent?.icon ?? theme.primaryGlow);
+  const chevronColor = mutedDanger ? accent.subtitle : (accent?.icon ?? theme.mutedForeground);
   const inner = (
     <>
       <View
@@ -680,12 +688,12 @@ function SettingRow({
       >
         <ProfileSettingIcon
           name={icon}
-          color={accent?.icon ?? theme.primaryGlow}
+          color={iconColor}
           size={16}
         />
       </View>
       <View style={styles.rowText}>
-        <Text style={[styles.rowTitle, { color: accent?.title ?? theme.foreground }]}>
+        <Text style={[styles.rowTitle, { color: titleColor }]}>
           {title}
         </Text>
         {subtitle ? (
@@ -706,7 +714,7 @@ function SettingRow({
       ) : chevron ? (
         <ProfileSettingIcon
           name="chevron-right"
-          color={accent?.icon ?? theme.mutedForeground}
+          color={chevronColor}
           size={18}
         />
       ) : null}

--- a/frontend/contexts/auth-context.tsx
+++ b/frontend/contexts/auth-context.tsx
@@ -30,6 +30,11 @@ interface AuthContextValue {
   /** 로그아웃 직후 Auth 화면에서 완료 알림 */
   justLoggedOut: boolean;
   clearJustLoggedOut: () => void;
+  /** 회원 탈퇴 완료 직후 Auth 화면 안내 */
+  justAccountDeleted: boolean;
+  clearJustAccountDeleted: () => void;
+  /** 탈퇴 API 성공 후 세션은 이미 정리된 상태 — 화면 전환만 수행 */
+  completeAccountDeletion: () => void;
   /** refresh 실패 등 — 저장소 비우고 로그인 화면으로 */
   onSessionInvalidated: () => Promise<void>;
   /** 프로필 수정 후 context·AsyncStorage 동기화 */
@@ -63,6 +68,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [hasValidSession, setHasValidSession] = useState(false);
   const [user, setUser] = useState<StoredUser | null>(null);
   const [justLoggedOut, setJustLoggedOut] = useState(false);
+  const [justAccountDeleted, setJustAccountDeleted] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -122,11 +128,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await clearSession();
     setHasValidSession(false);
     setUser(null);
+    setJustAccountDeleted(false);
     setJustLoggedOut(true);
   }, []);
 
   const clearJustLoggedOut = useCallback(() => {
     setJustLoggedOut(false);
+  }, []);
+
+  const clearJustAccountDeleted = useCallback(() => {
+    setJustAccountDeleted(false);
+  }, []);
+
+  const completeAccountDeletion = useCallback(() => {
+    setHasValidSession(false);
+    setUser(null);
+    setJustLoggedOut(false);
+    setJustAccountDeleted(true);
   }, []);
 
   const onSessionInvalidated = useCallback(async () => {
@@ -151,6 +169,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       logout,
       justLoggedOut,
       clearJustLoggedOut,
+      justAccountDeleted,
+      clearJustAccountDeleted,
+      completeAccountDeletion,
       onSessionInvalidated,
       applyProfile,
     }),
@@ -163,6 +184,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       logout,
       justLoggedOut,
       clearJustLoggedOut,
+      justAccountDeleted,
+      clearJustAccountDeleted,
+      completeAccountDeletion,
       onSessionInvalidated,
       applyProfile,
     ],


### PR DESCRIPTION
## 🔎 What

- 마이페이지 회원 탈퇴 **제목·아이콘·chevron** 색상을 부제 `"계정과 데이터가 삭제됩니다"`와 동일한 muted danger(`dangerAccent.subtitle` / `dimRedFg`)로 통일
- 탈퇴 성공 시 로그아웃 메시지 대신 **회원 탈퇴 완료** 전용 안내 표시
- 비밀번호 확인 모달: 요청 중 로딩·중복 터치·백드롭 닫기 방지, 실패 시 에러 메시지 유지

## 색상 변경

| 요소 | Before | After |
|------|--------|-------|
| 제목·아이콘·chevron | `dangerAccent.title` / `icon` (강한 빨강) | `dangerAccent.subtitle` (`dimRedFg`) |
| 부제 | `dangerAccent.subtitle` | 동일 (변경 없음) |

## 탈퇴 API

- **연결됨** — `DELETE /users/me` (`deleteMyAccount`), mock 없음

## 성공 시 정리되는 상태

- `clearUserScopedStorage(userId)`
- `clearSession()`
- auth context: `hasValidSession=false`, `user=null`
- Auth 화면 이동 + "회원 탈퇴가 완료되었습니다" 모달

## Test plan

- [x] 회원 탈퇴 행 제목·아이콘·부제 색상 일치 확인
- [x] 탭 시 비밀번호 모달 바로 표시 (중간 확인 모달 없음)
- [x] 잘못된 비밀번호 → 에러 메시지


## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요? (`develop`)
* [ ] 제목이 이슈 제목과 동일한가요?
* [ ] 최소 1명의 리뷰를 받았나요?
