### PR TITLE
feat(map): MAP 탭 명소 검색 및 지도 이동

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -37,6 +37,7 @@ import {
 } from './components/map/KakaoMapWebView';
 import { MapClusterSpotsSheet } from './components/map/MapClusterSpotsSheet';
 import { MapFloatingControls } from './components/map/MapFloatingControls';
+import { MapSpotSearchOverlay } from './components/map/MapSpotSearchOverlay';
 import { MapSpotDetailModal } from './components/map/MapSpotDetailModal';
 import { ProfileTabScreen } from './components/profile/ProfileTabScreen';
 import { useDeviceLocationState } from './hooks/use-device-location';
@@ -52,6 +53,8 @@ import { getDefaultSpotId } from './lib/config';
 import * as Location from 'expo-location';
 import { starIndexCardErrorFromApi } from './lib/star-index-errors';
 import type { ClusterSpotRnDto } from './lib/types/map-spot';
+import { spotNameWithoutRegionPrefix } from './lib/spot-display-name';
+import type { SpotDto } from './lib/types/api';
 
 function AppContent() {
   const { theme, toggleRed, isRedMode } = useTheme();
@@ -102,6 +105,11 @@ function AppContent() {
   } | null>(null);
   /** MAP 탭 — NASA VIIRS 타일 오버레이 ON/OFF */
   const [mapViirsEnabled, setMapViirsEnabled] = useState(false);
+  const [mapSpotSearchOpen, setMapSpotSearchOpen] = useState(false);
+
+  useEffect(() => {
+    if (!mapExploring) setMapSpotSearchOpen(false);
+  }, [mapExploring]);
   const [mapClusterScoreRefreshToken, setMapClusterScoreRefreshToken] = useState(0);
 
   const defaultSpotId = getDefaultSpotId();
@@ -180,6 +188,15 @@ function AppContent() {
     }
     void requestLocationPermission();
   }, [deviceLat, deviceLng, requestLocationPermission]);
+
+  const onMapSearchPickSpot = useCallback((spot: SpotDto) => {
+    setMapSpotSearchOpen(false);
+    if (!Number.isFinite(spot.lat) || !Number.isFinite(spot.lng)) return;
+    const ref = mapWebViewRef.current;
+    if (!ref) return;
+    const label = spotNameWithoutRegionPrefix(spot.name) || spot.name;
+    ref.focusMap(spot.lat, spot.lng, 7, label, spot.id);
+  }, []);
 
   const {
     loading: mapSiLoading,
@@ -328,13 +345,24 @@ function AppContent() {
             />
 
             {mapExploring ? (
-              <MapFloatingControls
-                theme={theme}
-                viirsEnabled={mapViirsEnabled}
-                onToggleViirs={() => setMapViirsEnabled((v) => !v)}
-                onMyLocation={onMapMyLocation}
-                locationReady={deviceLat != null && deviceLng != null}
-              />
+              <>
+                <MapSpotSearchOverlay
+                  theme={theme}
+                  visible={mapSpotSearchOpen}
+                  onClose={() => setMapSpotSearchOpen(false)}
+                  onPickSpot={onMapSearchPickSpot}
+                  onSessionInvalidated={onSessionInvalidated}
+                />
+                <MapFloatingControls
+                  theme={theme}
+                  viirsEnabled={mapViirsEnabled}
+                  onToggleViirs={() => setMapViirsEnabled((v) => !v)}
+                  onMyLocation={onMapMyLocation}
+                  locationReady={deviceLat != null && deviceLng != null}
+                  searchOpen={mapSpotSearchOpen}
+                  onOpenSearch={() => setMapSpotSearchOpen((v) => !v)}
+                />
+              </>
             ) : null}
             </View>
           </Animated.View>

--- a/frontend/components/map/MapFloatingControls.tsx
+++ b/frontend/components/map/MapFloatingControls.tsx
@@ -16,7 +16,12 @@ interface MapFloatingControlsProps {
   onToggleViirs: () => void;
   onMyLocation: () => void;
   locationReady: boolean;
+  searchOpen?: boolean;
+  onOpenSearch: () => void;
 }
+
+const TOP_BTN = 44;
+const TOP_BTN_GAP = 8;
 
 export function MapFloatingControls({
   theme,
@@ -24,17 +29,40 @@ export function MapFloatingControls({
   onToggleViirs,
   onMyLocation,
   locationReady,
+  searchOpen = false,
+  onOpenSearch,
 }: MapFloatingControlsProps) {
   const insets = useSafeAreaInsets();
+  const top = Math.max(insets.top, 8) + spacing.sm;
 
   return (
-    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+    <View style={[StyleSheet.absoluteFill, styles.layer]} pointerEvents="box-none">
+      <Pressable
+        onPress={onOpenSearch}
+        style={({ pressed }) => [
+          styles.topBtn,
+          {
+            top,
+            right: spacing.lg + TOP_BTN + TOP_BTN_GAP,
+            backgroundColor: theme.deepNavy,
+            borderColor: searchOpen ? theme.primaryGlow : theme.cardBorder,
+            borderWidth: searchOpen ? 1.5 : 1,
+            opacity: pressed ? 0.88 : 1,
+          },
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel="명소 검색"
+      >
+        <Feather name="search" size={20} color={theme.primaryGlow} />
+      </Pressable>
+
       <Pressable
         onPress={onMyLocation}
         style={({ pressed }) => [
-          styles.locBtn,
+          styles.topBtn,
           {
-            top: Math.max(insets.top, 8) + spacing.sm,
+            top,
+            right: spacing.lg,
             backgroundColor: theme.deepNavy,
             borderColor: theme.cardBorder,
             opacity: pressed ? 0.88 : locationReady ? 1 : 0.75,
@@ -86,12 +114,14 @@ export function MapFloatingControls({
 }
 
 const styles = StyleSheet.create({
-  locBtn: {
+  layer: {
+    zIndex: 30,
+  },
+  topBtn: {
     position: 'absolute',
-    right: spacing.lg,
-    width: 44,
-    height: 44,
-    borderRadius: 22,
+    width: TOP_BTN,
+    height: TOP_BTN,
+    borderRadius: TOP_BTN / 2,
     borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'center',

--- a/frontend/components/map/MapSpotSearchOverlay.tsx
+++ b/frontend/components/map/MapSpotSearchOverlay.tsx
@@ -1,0 +1,321 @@
+/**
+ * MAP 탭 — 명소 검색 오버레이 (GET /spots/search)
+ */
+
+import Feather from '@expo/vector-icons/Feather';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { ApiRequestError, SessionExpiredError } from '../../lib/api-client';
+import { fetchSpotsSearch } from '../../lib/spots-api';
+import {
+  spotNameWithoutRegionPrefix,
+  spotRegionSubtitle,
+} from '../../lib/spot-display-name';
+import type { SpotDto } from '../../lib/types/api';
+import { glassCardStyle, spacing } from '../../themes/design-tokens';
+import type { ThemeTokens } from '../../themes/themes';
+import { AppAlertModal } from '../ui/AppAlertModal';
+
+const SEARCH_DEBOUNCE_MS = 320;
+const TOP_BUTTON_SIZE = 44;
+const TOP_BUTTON_GAP = 8;
+
+function hasValidCoords(spot: SpotDto): boolean {
+  return Number.isFinite(spot.lat) && Number.isFinite(spot.lng);
+}
+
+interface MapSpotSearchOverlayProps {
+  theme: ThemeTokens;
+  visible: boolean;
+  onClose: () => void;
+  onPickSpot: (spot: SpotDto) => void;
+  onSessionInvalidated: () => Promise<void>;
+}
+
+export function MapSpotSearchOverlay({
+  theme,
+  visible,
+  onClose,
+  onPickSpot,
+  onSessionInvalidated,
+}: MapSpotSearchOverlayProps) {
+  const insets = useSafeAreaInsets();
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SpotDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState(false);
+  const [noCoordsAlert, setNoCoordsAlert] = useState(false);
+  const searchSeq = useRef(0);
+  const inputRef = useRef<TextInput>(null);
+
+  const topOffset = Math.max(insets.top, 8) + spacing.sm;
+
+  useEffect(() => {
+    if (!visible) return;
+    setQuery('');
+    setResults([]);
+    setError(null);
+    setHasSearched(false);
+    const timer = setTimeout(() => inputRef.current?.focus(), 80);
+    return () => clearTimeout(timer);
+  }, [visible]);
+
+  useEffect(() => {
+    if (!visible) return;
+    const q = query.trim();
+    if (q.length < 1) {
+      setResults([]);
+      setLoading(false);
+      setHasSearched(false);
+      setError(null);
+      return;
+    }
+
+    const seq = ++searchSeq.current;
+    setLoading(true);
+    setError(null);
+
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          const rows = await fetchSpotsSearch(q, 50);
+          if (searchSeq.current !== seq) return;
+          setResults(rows);
+          setHasSearched(true);
+        } catch (e) {
+          if (searchSeq.current !== seq) return;
+          if (e instanceof SessionExpiredError) {
+            await onSessionInvalidated();
+            return;
+          }
+          setError(
+            e instanceof ApiRequestError ? e.message : '명소 검색에 실패했습니다.',
+          );
+          setResults([]);
+          setHasSearched(true);
+        } finally {
+          if (searchSeq.current === seq) setLoading(false);
+        }
+      })();
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [query, visible, onSessionInvalidated]);
+
+  if (!visible) return null;
+
+  const trimmed = query.trim();
+  const showEmpty =
+    trimmed.length >= 1 && hasSearched && !loading && results.length === 0 && !error;
+
+  const handlePick = (spot: SpotDto) => {
+    if (!hasValidCoords(spot)) {
+      setNoCoordsAlert(true);
+      return;
+    }
+    onPickSpot(spot);
+  };
+
+  return (
+    <>
+      <Pressable
+        style={styles.backdrop}
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel="검색 닫기"
+      />
+      <View style={[styles.wrap, { top: topOffset }]} pointerEvents="box-none">
+        <View
+          style={[
+            styles.panel,
+            glassCardStyle(theme),
+            { marginRight: spacing.lg + TOP_BUTTON_SIZE * 2 + TOP_BUTTON_GAP },
+          ]}
+        >
+          <View
+            style={[
+              styles.inputRow,
+              { backgroundColor: theme.inputBackground, borderColor: theme.cardBorder },
+            ]}
+          >
+            <Feather name="search" size={16} color={theme.mutedForeground} />
+            <TextInput
+              ref={inputRef}
+              value={query}
+              onChangeText={setQuery}
+              placeholder="명소·지역 검색 (예: 황매산, 제주)"
+              placeholderTextColor={theme.mutedForeground}
+              style={[styles.input, { color: theme.foreground }]}
+              returnKeyType="search"
+              autoCorrect={false}
+              autoCapitalize="none"
+            />
+            {query.length > 0 ? (
+              <Pressable
+                onPress={() => setQuery('')}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="검색어 지우기"
+              >
+                <Feather name="x-circle" size={16} color={theme.mutedForeground} />
+              </Pressable>
+            ) : null}
+          </View>
+
+          {error ? (
+            <Text style={[styles.hint, { color: theme.destructive }]}>{error}</Text>
+          ) : null}
+
+          {loading ? (
+            <View style={styles.loadingRow}>
+              <ActivityIndicator size="small" color={theme.primaryGlow} />
+              <Text style={[styles.hint, { color: theme.mutedForeground }]}>검색 중…</Text>
+            </View>
+          ) : null}
+
+          {showEmpty ? (
+            <Text style={[styles.empty, { color: theme.mutedForeground }]}>
+              검색 결과가 없습니다
+            </Text>
+          ) : null}
+
+          {results.length > 0 ? (
+            <FlatList
+              data={results}
+              keyExtractor={(item) => item.id}
+              keyboardShouldPersistTaps="handled"
+              style={styles.list}
+              showsVerticalScrollIndicator={false}
+              renderItem={({ item }) => {
+                const title = spotNameWithoutRegionPrefix(item.name) || item.name;
+                const region = spotRegionSubtitle(item.name);
+                const missingCoords = !hasValidCoords(item);
+                return (
+                  <Pressable
+                    onPress={() => handlePick(item)}
+                    style={({ pressed }) => [
+                      styles.resultRow,
+                      {
+                        backgroundColor: pressed ? theme.inputBackground : 'transparent',
+                        opacity: missingCoords ? 0.55 : 1,
+                      },
+                    ]}
+                  >
+                    <Feather name="star" size={14} color={theme.primaryGlow} />
+                    <View style={styles.resultText}>
+                      <Text
+                        style={[styles.resultTitle, { color: theme.foreground }]}
+                        numberOfLines={1}
+                      >
+                        {title}
+                      </Text>
+                      <Text
+                        style={[styles.resultSub, { color: theme.mutedForeground }]}
+                        numberOfLines={1}
+                      >
+                        {region || item.name}
+                      </Text>
+                    </View>
+                    <Feather name="chevron-right" size={16} color={theme.mutedForeground} />
+                  </Pressable>
+                );
+              }}
+            />
+          ) : null}
+        </View>
+      </View>
+
+      <AppAlertModal
+        visible={noCoordsAlert}
+        tone="default"
+        title="위치 정보 없음"
+        message="이 명소에는 좌표 정보가 없어 지도로 이동할 수 없습니다."
+        primaryLabel="확인"
+        onPrimary={() => setNoCoordsAlert(false)}
+        onRequestClose={() => setNoCoordsAlert(false)}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 18,
+  },
+  wrap: {
+    position: 'absolute',
+    left: spacing.lg,
+    right: 0,
+    zIndex: 20,
+  },
+  panel: {
+    borderRadius: 16,
+    padding: spacing.sm,
+    gap: spacing.xs,
+    maxHeight: 320,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 2,
+  },
+  input: {
+    flex: 1,
+    fontSize: 14,
+    paddingVertical: 10,
+  },
+  hint: {
+    fontSize: 12,
+    lineHeight: 17,
+    paddingHorizontal: 4,
+  },
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingHorizontal: 4,
+    paddingVertical: 4,
+  },
+  empty: {
+    fontSize: 13,
+    textAlign: 'center',
+    paddingVertical: spacing.md,
+  },
+  list: {
+    maxHeight: 220,
+  },
+  resultRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: 10,
+    paddingHorizontal: 8,
+    borderRadius: 10,
+  },
+  resultText: {
+    flex: 1,
+    gap: 2,
+  },
+  resultTitle: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  resultSub: {
+    fontSize: 11,
+  },
+});


### PR DESCRIPTION
## 🔎 What

- MAP 탭 우상단 **내 위치(navigation) 버튼 옆**에 돋보기 버튼 추가
- 돋보기 탭 시 상단 **명소 검색 오버레이** 표시, 결과 선택 시 해당 명소로 지도 이동·마커 포커스

## 검색 데이터 소스

- **API** — `GET /spots/search` (`fetchSpotsSearch`)
- 다이어리 관측 위치 선택(`DiaryLocationField`)과 동일 엔드포인트 재사용
- 로컬 spots 캐시 필터링 아님

## 지도 이동

- `KakaoMapWebViewHandle.focusMap(lat, lng, 7, label, spotId)`
- WebView `FOCUS_MAP` → `kakao.maps.LatLng(lat, lng)` + `map.setCenter` / `map.setLevel(7)`
- 클러스터 시트 `onPickSpot`과 동일 패턴 — `spotId`로 포커스 마커 강조

## 좌표 변환

- API `SpotDto.lat` / `SpotDto.lng` (WGS84, geometry Point 4326 → JSON number)
- Kakao Maps: `new kakao.maps.LatLng(lat, lng)` — **lat/lng 순서 유지**

## Test plan

- [ ] MAP 탐험 모드에서 navigation 옆 돋보기 아이콘 표시
- [ ] 돋보기 탭 → 검색창 표시, 지도 탭 또는 재탭으로 닫기
- [ ] `황매산`, `제주` 등 키워드 검색 결과 표시
- [ ] 결과 없음 → "검색 결과가 없습니다"
- [ ] 결과 탭 → 지도 중심 이동 + 해당 명소 마커 포커스
- [ ] API 실패 시 에러 메시지 표시

## 테스트한 명소 예시

- `황매산` — 경남 합천 황매산
- `제주` — 제주 지역 명소 다수

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요? (`develop`)
* [ ] 제목이 이슈 제목과 동일한가요?
* [ ] 최소 1명의 리뷰를 받았나요?
