### PR TITLE
fix: Star-Index 갱신 피드백 및 명소 상세 점수 중복 제거

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -379,7 +379,10 @@ function AppContent() {
               starIndexError={observerStarIndex.error}
               starIndexPlaceLabel={observerStarIndex.placeLabel}
               locationUnavailable={observerStarIndex.locationUnavailable}
-              onReloadStarIndex={() => void observerStarIndex.reload()}
+              starIndexRefreshing={observerStarIndex.manualRefreshing}
+              starIndexLastRefreshedAt={observerStarIndex.lastRefreshedAt}
+              starIndexRefreshFeedback={observerStarIndex.refreshFeedback}
+              onReloadStarIndex={() => void observerStarIndex.reload({ force: true })}
               onSessionInvalidated={onSessionInvalidated}
             />
           ) : activeTab === 'sky' ? (

--- a/frontend/components/main/MainTabScreen.tsx
+++ b/frontend/components/main/MainTabScreen.tsx
@@ -1,6 +1,7 @@
 import Feather from '@expo/vector-icons/Feather';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
+  ActivityIndicator,
   Platform,
   Pressable,
   StyleSheet,
@@ -32,7 +33,11 @@ import {
   windLabelFromScore,
 } from '../../lib/star-index-headline';
 import { formatObserverPlaceLabel } from '../../lib/observer-place-label';
-import { formatStarIndexStaleHint } from '../../lib/star-index-stale';
+import {
+  formatLastRefreshLabel,
+  formatStarIndexStaleHint,
+  msUntilNextRefreshLabelChange,
+} from '../../lib/star-index-stale';
 import type { ObserverLocationUnavailable } from '../../lib/use-observer-star-index';
 import { AnimatedStarIndexGauge } from './AnimatedStarIndexGauge';
 
@@ -46,6 +51,9 @@ interface MainTabScreenProps {
   starIndexError: string | null;
   starIndexPlaceLabel: string | null;
   locationUnavailable?: ObserverLocationUnavailable | null;
+  starIndexRefreshing?: boolean;
+  starIndexLastRefreshedAt?: number | null;
+  starIndexRefreshFeedback?: { tone: 'success' | 'error'; message: string } | null;
   onReloadStarIndex: () => void;
   onSessionInvalidated: () => void | Promise<void>;
 }
@@ -209,6 +217,9 @@ export function MainTabScreen({
   starIndexError,
   starIndexPlaceLabel,
   locationUnavailable = null,
+  starIndexRefreshing = false,
+  starIndexLastRefreshedAt = null,
+  starIndexRefreshFeedback = null,
   onReloadStarIndex,
   onSessionInvalidated,
 }: MainTabScreenProps) {
@@ -216,6 +227,37 @@ export function MainTabScreen({
   const [alertSheetOpen, setAlertSheetOpen] = useState(false);
   const [guideSheetOpen, setGuideSheetOpen] = useState(false);
   const [alertEnabled, setAlertEnabled] = useState(false);
+  /** 마지막 갱신 시각 라벨이 경과에 맞게 바뀌도록 주기적 리렌더 */
+  const [refreshLabelTick, setRefreshLabelTick] = useState(0);
+
+  useEffect(() => {
+    if (starIndexLastRefreshedAt == null) return;
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const schedule = () => {
+      const delay = msUntilNextRefreshLabelChange(starIndexLastRefreshedAt);
+      if (delay == null || cancelled) return;
+      timer = setTimeout(() => {
+        if (cancelled) return;
+        setRefreshLabelTick((t) => t + 1);
+        schedule();
+      }, delay);
+    };
+
+    schedule();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [starIndexLastRefreshedAt]);
+
+  const lastRefreshLabel = useMemo(() => {
+    void refreshLabelTick;
+    return starIndexLastRefreshedAt != null
+      ? formatLastRefreshLabel(starIndexLastRefreshedAt)
+      : null;
+  }, [starIndexLastRefreshedAt, refreshLabelTick]);
 
   const refreshAlertBadge = useCallback(async () => {
     try {
@@ -461,16 +503,53 @@ export function MainTabScreen({
         </View>
       ) : null}
 
-      {canLoad && !starIndexLoading && starIndexData ? (
+      {canLoad && starIndexData ? (
         <Pressable
           onPress={onReloadStarIndex}
-          style={({ pressed }) => [styles.refreshTap, pressed && { opacity: 0.7 }]}
+          disabled={starIndexRefreshing}
+          style={({ pressed }) => [
+            styles.refreshTap,
+            starIndexRefreshing && styles.refreshTapBusy,
+            pressed && !starIndexRefreshing && { opacity: 0.7 },
+          ]}
           accessibilityRole="button"
-          accessibilityLabel="Star-Index 새로고침"
+          accessibilityLabel={
+            starIndexRefreshing ? 'Star-Index 갱신 중' : 'Star-Index 새로고침'
+          }
+          accessibilityState={{ busy: starIndexRefreshing }}
         >
-          <Text style={[styles.refreshText, { color: theme.mutedForeground }]}>
-            탭하여 갱신
-          </Text>
+          {starIndexRefreshing ? (
+            <View style={styles.refreshRow}>
+              <ActivityIndicator size="small" color={theme.primaryGlow} />
+              <Text style={[styles.refreshText, { color: theme.primaryGlow }]}>
+                갱신 중…
+              </Text>
+            </View>
+          ) : starIndexRefreshFeedback?.tone === 'error' ? (
+            <Text style={[styles.refreshText, { color: theme.destructive }]}>
+              {starIndexRefreshFeedback.message}
+            </Text>
+          ) : starIndexRefreshFeedback?.tone === 'success' ? (
+            <View style={styles.refreshCol}>
+              <Text style={[styles.refreshText, { color: theme.primaryGlow }]}>
+                탭하여 갱신
+              </Text>
+              <Text style={[styles.refreshSubText, { color: theme.primaryGlow }]}>
+                {starIndexRefreshFeedback.message}
+              </Text>
+            </View>
+          ) : (
+            <View style={styles.refreshCol}>
+              <Text style={[styles.refreshText, { color: theme.mutedForeground }]}>
+                탭하여 갱신
+              </Text>
+              {lastRefreshLabel ? (
+                <Text style={[styles.refreshSubText, { color: theme.mutedForeground }]}>
+                  {lastRefreshLabel}
+                </Text>
+              ) : null}
+            </View>
+          )}
         </Pressable>
       ) : null}
     </View>
@@ -623,9 +702,27 @@ const styles = StyleSheet.create({
   refreshTap: {
     alignItems: 'center',
     paddingVertical: spacing.xs,
+    minHeight: 28,
+    justifyContent: 'center',
+  },
+  refreshTapBusy: {
+    opacity: 0.92,
+  },
+  refreshRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  refreshCol: {
+    alignItems: 'center',
+    gap: 2,
   },
   refreshText: {
     fontSize: 11,
+  },
+  refreshSubText: {
+    fontSize: 10,
+    opacity: 0.85,
   },
   retryBtn: {
     paddingVertical: spacing.xs,

--- a/frontend/components/map/MapSpotDetailModal.tsx
+++ b/frontend/components/map/MapSpotDetailModal.tsx
@@ -17,10 +17,7 @@ import {
 import type { StarIndexResponseDto } from '../../lib/types/api';
 import { useAuth } from '../../contexts/auth-context';
 import { isSpotBookmarked, toggleSpotBookmark } from '../../lib/spot-activity-storage';
-import {
-  getStarIndexScoreDisplay,
-  starIndexResponseToCardModel,
-} from '../../lib/star-index-display';
+import { starIndexResponseToCardModel } from '../../lib/star-index-display';
 import { Button, Card, SpotCard, StarIndexCard, StatefulCard, type StatefulCardError } from '../ui';
 import { CorrectionScoreInput } from './CorrectionScoreInput';
 
@@ -62,9 +59,6 @@ export function MapSpotDetailModal({
   const { theme } = useTheme();
   const { user } = useAuth();
   const starProps = data ? starIndexResponseToCardModel(data) : null;
-  const appScoreDisplay = data
-    ? getStarIndexScoreDisplay(data.score)
-    : null;
 
   const [bookmarked, setBookmarked] = useState(false);
   const [bookmarkBusy, setBookmarkBusy] = useState(false);
@@ -193,11 +187,11 @@ export function MapSpotDetailModal({
                 {data ? (
                   <SpotCard
                     bare
+                    showIndex={false}
                     name={data.name}
                     region={`${data.lat.toFixed(4)} · ${data.lng.toFixed(4)}`}
                     elevation={data.elevationM}
                     bortleClass={data.bortleClass}
-                    starIndex={data.score}
                     hasParking={false}
                     hasToilet={false}
                   />
@@ -208,40 +202,18 @@ export function MapSpotDetailModal({
                 title="Star-Index 보정 제보"
                 description="점수가 불안정할 경우, 현장에서 느낀 Star-Index 점수를 제보해 주세요."
               >
-                <View style={styles.corrStatsRow}>
-                  <View style={styles.corrStat}>
-                    <Text style={[styles.corrStatLabel, { color: theme.mutedForeground }]}>
-                      제보
-                    </Text>
-                    <Text
-                      style={[
-                        styles.corrStatValue,
-                        { color: theme.foreground, fontFamily: 'SpaceMono-Regular' },
-                      ]}
-                    >
-                      {submissionCount}건
-                    </Text>
-                  </View>
-                  {appScoreDisplay ? (
-                    <View style={[styles.corrStat, styles.corrStatRight]}>
-                      <Text style={[styles.corrStatLabel, { color: theme.mutedForeground }]}>
-                        앱 표시 점수
-                      </Text>
-                      <Text
-                        style={[
-                          styles.corrStatValue,
-                          {
-                            color: appScoreDisplay.measurable
-                              ? theme.primaryGlow
-                              : theme.destructive,
-                            fontFamily: 'SpaceMono-Regular',
-                          },
-                        ]}
-                      >
-                        {appScoreDisplay.label}
-                      </Text>
-                    </View>
-                  ) : null}
+                <View style={styles.corrStat}>
+                  <Text style={[styles.corrStatLabel, { color: theme.mutedForeground }]}>
+                    제보
+                  </Text>
+                  <Text
+                    style={[
+                      styles.corrStatValue,
+                      { color: theme.foreground, fontFamily: 'SpaceMono-Regular' },
+                    ]}
+                  >
+                    {submissionCount}건
+                  </Text>
                 </View>
 
                 <CorrectionScoreInput
@@ -319,15 +291,7 @@ const styles = StyleSheet.create({
   headerActions: { flexDirection: 'row', alignItems: 'center', gap: 16 },
   scroll: { flex: 1 },
   scrollInner: { padding: 16, gap: 12, paddingBottom: 40 },
-  corrStatsRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    justifyContent: 'space-between',
-    gap: 16,
-    marginBottom: 4,
-  },
-  corrStat: { gap: 4 },
-  corrStatRight: { alignItems: 'flex-end' },
+  corrStat: { gap: 4, marginBottom: 4 },
   corrStatLabel: {
     fontSize: 12,
     fontWeight: '500',

--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -295,7 +295,9 @@ interface SpotCardProps {
   region:      string;
   elevation:   number;
   bortleClass: number;
-  starIndex:   number;
+  starIndex?:  number;
+  /** false면 우측 INDEX 점수 숨김 (명소 상세 등 상단 Star-Index 카드와 중복 방지) */
+  showIndex?:  boolean;
   hasParking:  boolean;
   hasToilet:   boolean;
   distanceKm?: number;
@@ -305,11 +307,11 @@ interface SpotCardProps {
 
 export function SpotCard({
   name, region, elevation, bortleClass,
-  starIndex, hasParking, hasToilet, distanceKm, onPress,
+  starIndex = 0, showIndex = true, hasParking, hasToilet, distanceKm, onPress,
   bare = false,
 }: SpotCardProps) {
   const { theme } = useTheme();
-  const scoreDisplay = getStarIndexScoreDisplay(starIndex);
+  const scoreDisplay = showIndex ? getStarIndexScoreDisplay(starIndex) : null;
 
   const bortleVariant =
     bortleClass <= 3 ? 'glow' :
@@ -324,24 +326,26 @@ export function SpotCard({
             {region}{distanceKm != null ? `  ·  ${distanceKm.toFixed(0)}km` : ''}
           </Text>
         </View>
-        <View style={{ alignItems: 'flex-end' }}>
-          <Text
-            style={[
-              styles.spotScore,
-              {
-                color: scoreDisplay.measurable ? theme.primaryGlow : theme.destructive,
-                fontFamily: 'SpaceMono-Regular',
-                fontSize: scoreDisplay.measurable ? 22 : 13,
-                lineHeight: scoreDisplay.measurable ? 24 : 18,
-              },
-            ]}
-          >
-            {scoreDisplay.label}
-          </Text>
-          <Text style={[styles.spotScoreLabel, { color: theme.mutedForeground }]}>
-            INDEX
-          </Text>
-        </View>
+        {scoreDisplay ? (
+          <View style={{ alignItems: 'flex-end' }}>
+            <Text
+              style={[
+                styles.spotScore,
+                {
+                  color: scoreDisplay.measurable ? theme.primaryGlow : theme.destructive,
+                  fontFamily: 'SpaceMono-Regular',
+                  fontSize: scoreDisplay.measurable ? 22 : 13,
+                  lineHeight: scoreDisplay.measurable ? 24 : 18,
+                },
+              ]}
+            >
+              {scoreDisplay.label}
+            </Text>
+            <Text style={[styles.spotScoreLabel, { color: theme.mutedForeground }]}>
+              INDEX
+            </Text>
+          </View>
+        ) : null}
       </View>
 
       <View style={[styles.divider, { backgroundColor: theme.borderSubtle }]} />

--- a/frontend/lib/observer-star-index/use-observer-star-index.ts
+++ b/frontend/lib/observer-star-index/use-observer-star-index.ts
@@ -100,13 +100,30 @@ export function useObserverStarIndex({
       !observerCoordsReady &&
       !gpsPermissionBlocked);
 
-  const reload = useCallback(async (opts?: { silent?: boolean }) => {
+  const [manualRefreshing, setManualRefreshing] = useState(false);
+  const [lastRefreshedAt, setLastRefreshedAt] = useState<number | null>(null);
+  const [refreshFeedback, setRefreshFeedback] = useState<{
+    tone: 'success' | 'error';
+    message: string;
+  } | null>(null);
+
+  const reload = useCallback(async (opts?: { silent?: boolean; force?: boolean }) => {
     const silent = opts?.silent ?? false;
+    const force = opts?.force ?? false;
     const seq = ++reloadSeqRef.current;
     const isLatest = () => reloadSeqRef.current === seq;
     const applyLoading = (value: boolean) => {
-      if (isLatest()) setLoading(value);
+      if (!isLatest()) return;
+      if (force && dataRef.current) {
+        setManualRefreshing(value);
+        return;
+      }
+      setLoading(value);
     };
+    if (force && isLatest()) {
+      setManualRefreshing(true);
+      setRefreshFeedback(null);
+    }
     let lat: number | undefined;
     let lng: number | undefined;
     let permStatus = locationPermissionStatus ?? resolvedPermissionRef.current;
@@ -155,16 +172,35 @@ export function useObserverStarIndex({
 
     const hasCoords = hasFiniteCoords(lat, lng);
 
+    const finishManualRefresh = (feedback?: { tone: 'success' | 'error'; message: string }) => {
+      if (!force || !isLatest()) return;
+      setManualRefreshing(false);
+      if (feedback) setRefreshFeedback(feedback);
+    };
+
     if (!locationPrefLoaded) {
       if (!silent && isLatest()) {
         applyLoading(true);
         setError(null);
+      }
+      if (force) {
+        finishManualRefresh({
+          tone: 'error',
+          message: '설정을 불러오는 중이에요. 잠시 후 다시 시도해 주세요.',
+        });
       }
       return;
     }
 
     if (locationEnabled && !hasCoords && reloadGpsBlocked) {
       if (!isLatest()) return;
+      if (force) {
+        finishManualRefresh({
+          tone: 'error',
+          message: '위치 권한이 필요해요. 마이페이지 또는 시스템 설정을 확인해 주세요.',
+        });
+        return;
+      }
       setData(null);
       setError(null);
       setPlaceLabel(null);
@@ -179,6 +215,20 @@ export function useObserverStarIndex({
       (!locationEnabled || reloadGpsBlocked)
     ) {
       if (!isLatest()) return;
+      if (force && !locationEnabled) {
+        finishManualRefresh({
+          tone: 'error',
+          message: '마이페이지(ME)에서 위치 사용을 켜 주세요.',
+        });
+        return;
+      }
+      if (force && reloadGpsBlocked) {
+        finishManualRefresh({
+          tone: 'error',
+          message: '위치 권한이 필요해요. 마이페이지 또는 시스템 설정을 확인해 주세요.',
+        });
+        return;
+      }
       setData(null);
       setError(null);
       setPlaceLabel(null);
@@ -197,11 +247,24 @@ export function useObserverStarIndex({
         applyLoading(true);
         setError(null);
       }
+      if (force) {
+        finishManualRefresh({
+          tone: 'error',
+          message: '현재 위치를 가져오지 못했어요. 잠시 후 다시 시도해 주세요.',
+        });
+      }
       return;
     }
 
     if (!hasCoords && !activeSpotId) {
       if (!isLatest()) return;
+      if (force) {
+        finishManualRefresh({
+          tone: 'error',
+          message: '측정할 위치를 찾지 못했어요.',
+        });
+        return;
+      }
       setData(null);
       setError(null);
       setPlaceLabel(null);
@@ -211,6 +274,7 @@ export function useObserverStarIndex({
     }
 
     if (
+      !force &&
       hasCoords &&
       !coordsChangedEnough(lastFetchedCoordsRef.current, lat!, lng!) &&
       dataRef.current
@@ -221,7 +285,7 @@ export function useObserverStarIndex({
 
     let revalidateSilent = silent;
 
-    if (hasCoords) {
+    if (hasCoords && !force) {
       const cached = await loadLocalStarIndexCache(lat!, lng!);
       if (cached && isLatest()) {
         setData(cached.data);
@@ -237,7 +301,7 @@ export function useObserverStarIndex({
         applyLoading(true);
         setError(null);
       }
-    } else if (!silent && isLatest()) {
+    } else if ((!silent || force) && isLatest()) {
       applyLoading(true);
       setError(null);
     }
@@ -253,6 +317,10 @@ export function useObserverStarIndex({
         resolveObserverPlaceLabel(lat!, lng!, isLatest, setPlaceLabel, (label) => {
           void saveLocalStarIndexCache(lat!, lng!, d, label);
         });
+        if (force) {
+          setLastRefreshedAt(Date.now());
+          finishManualRefresh({ tone: 'success', message: '방금 갱신됨' });
+        }
         return;
       }
 
@@ -261,25 +329,39 @@ export function useObserverStarIndex({
       const d = await fetchStarIndex(activeSpotId!);
       if (!isLatest()) return;
       setData(d);
+      if (force) {
+        setLastRefreshedAt(Date.now());
+        finishManualRefresh({ tone: 'success', message: '방금 갱신됨' });
+      }
     } catch (e) {
       if (!isLatest()) return;
       if (e instanceof SessionExpiredError) {
         await onSessionInvalidated();
+        if (force) finishManualRefresh();
         return;
       }
-      if (revalidateSilent && dataRef.current) {
+      if (revalidateSilent && dataRef.current && !force) {
         return;
       }
-      if (e instanceof ApiRequestError) {
-        setError(starIndexLoadErrorMessage(e));
-      } else {
-        setError('Star-Index를 불러오지 못했습니다.');
+      const errMsg =
+        e instanceof ApiRequestError
+          ? starIndexLoadErrorMessage(e)
+          : 'Star-Index를 불러오지 못했습니다.';
+      if (force && dataRef.current) {
+        finishManualRefresh({
+          tone: 'error',
+          message: '갱신에 실패했어요. 다시 시도해주세요.',
+        });
+        return;
       }
+      setError(errMsg);
       setData(null);
       setPlaceLabel(null);
       setFromGps(false);
     } finally {
-      if (!revalidateSilent || !dataRef.current) {
+      if (force) {
+        if (isLatest()) setManualRefreshing(false);
+      } else if (!revalidateSilent || !dataRef.current) {
         applyLoading(false);
       }
     }
@@ -295,6 +377,14 @@ export function useObserverStarIndex({
   ]);
 
   reloadFnRef.current = reload;
+
+  useEffect(() => {
+    if (refreshFeedback?.tone !== 'success') return;
+    const timer = setTimeout(() => {
+      setRefreshFeedback((prev) => (prev?.tone === 'success' ? null : prev));
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [refreshFeedback]);
 
   useEffect(() => {
     void reloadFnRef.current?.();
@@ -362,6 +452,9 @@ export function useObserverStarIndex({
     fromGps,
     awaitingLocation,
     locationUnavailable,
+    manualRefreshing,
+    lastRefreshedAt,
+    refreshFeedback,
     reload,
     resolveSpotIdForSave,
   };

--- a/frontend/lib/star-index-stale.ts
+++ b/frontend/lib/star-index-stale.ts
@@ -21,6 +21,35 @@ export function formatStarIndexStaleHint(cachedAt?: string): string {
 
 import { sanitizeApiErrorMessage } from './sanitize-api-error';
 
+/** 수동 갱신 완료 시각 표시 */
+export function formatLastRefreshLabel(atMs: number, nowMs = Date.now()): string {
+  const delta = nowMs - atMs;
+  if (delta < 60_000) return '방금 갱신됨';
+  const mins = Math.max(1, Math.round(delta / 60_000));
+  if (mins < 60) return `${mins}분 전 갱신`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `약 ${hours}시간 전 갱신`;
+  return '갱신됨';
+}
+
+/** formatLastRefreshLabel 문구가 바뀌기까지 남은 ms (24h 이후는 null) */
+export function msUntilNextRefreshLabelChange(
+  atMs: number,
+  nowMs = Date.now(),
+): number | null {
+  const delta = nowMs - atMs;
+  if (delta < 60_000) return 60_000 - delta + 250;
+  if (delta < 60 * 60_000) {
+    const mins = Math.floor(delta / 60_000);
+    return (mins + 1) * 60_000 - delta + 250;
+  }
+  if (delta < 24 * 60 * 60_000) {
+    const hours = Math.floor(delta / (60 * 60_000));
+    return (hours + 1) * 60 * 60_000 - delta + 250;
+  }
+  return null;
+}
+
 export function starIndexLoadErrorMessage(e: unknown): string {
   if (e && typeof e === 'object' && 'status' in e && 'message' in e) {
     const status = (e as { status: number }).status;


### PR DESCRIPTION
## 🔎 What

### 1. 메인 탭 Star-Index 수동 갱신 피드백 (`b51121f`)
- **기존 문제:** 「탭하여 갱신」 탭 시 좌표가 거의 같으면 `reload()`가 조기 return → API 미호출, 로딩/완료 피드백 없음
- `reload({ force: true })`로 좌표 동일·로컬 캐시(45분 TTL) 우회 후 `GET /star-index` 재요청
- 갱신 중 스피너·중복 탭 방지, 성공 시 「방금 갱신됨」, 실패 시 위치/권한별 안내 또는 「갱신에 실패했어요」
- **「탭하여 갱신」** CTA는 항상 표시, 마지막 갱신 시각은 보조 줄(`N분 전 갱신`)로 표시
- 메인 탭에 머물러도 경과 라벨이 바뀌도록 `msUntilNextRefreshLabelChange` 타이머 추가

### 2. 명소 상세 점수 중복 제거 (`fbf5a0b`)
- 명소 상세에서 점수가 4곳에 반복 표시되던 문제 개선
- **상단 Star-Index 카드에만** 점수 유지
- 명소 카드 우측 INDEX 점수 제거 (`SpotCard showIndex={false}`)
- 보정 제보 카드 「앱 표시 점수」 제거 (제보 건수·슬라이더 입력은 유지)

## 갱신 API / 점수 동일 여부
- 백엔드 `refresh=true` 옵션 없음 — 기존 `GET /star-index` 재호출
- **점수가 같아도** `갱신 중…` → `방금 갱신됨`이면 API 성공·갱신 완료로 판단 (동일 격자·1H 캐시면 결과 동일 가능)
- 429(60초 10회)는 기존 백엔드 Throttle — 이번 PR에서 추가한 제한 아님

## 추가 상태값
- `manualRefreshing`, `lastRefreshedAt`, `refreshFeedback` (hook)
- `starIndexRefreshing`, `starIndexLastRefreshedAt`, `starIndexRefreshFeedback` (MainTabScreen props)

## 🔗 Issue

* closes: #이슈번호

## ✅ 체크리스트

* [x] 브랜치 base가 적절한가요? (`develop`)
* [ ] 제목이 이슈 제목과 동일한가요?
* [ ] 최소 1명의 리뷰를 받았나요?

## Test plan
- [x] 메인 「탭하여 갱신」 → 갱신 중… → 방금 갱신됨 (점수 동일해도 OK)
- [x] 10번 연속 탭 시 갱신 중 버튼 비활성화
- [x] 1분 경과 후 메인 탭 유지 시 「1분 전 갱신」 등 라벨 갱신
- [x] 위치 권한 거부/앱 위치 OFF 시 갱신 탭 → 해당 안내 문구
- [x] 명소 상세: 상단 Star-Index에만 점수, 명소·보정 카드에 INDEX/앱 표시 점수 없음
