### PR TITLE
refactor: 알림 네이밍, 설명 문구 수정

### DIFF
--- a/frontend/components/onboarding/OnboardingFlow.tsx
+++ b/frontend/components/onboarding/OnboardingFlow.tsx
@@ -37,7 +37,7 @@ const NOTIF_INFO_ITEMS = [
   },
   {
     icon: '★',
-    title: 'Star-Index 알림',
+    title: '기준 명소 알림',
     desc: '기준 명소 점수가 올라가면 하루 1회 알려 드려요.',
   },
 ] as const;

--- a/frontend/components/profile/ProfileTabScreen.tsx
+++ b/frontend/components/profile/ProfileTabScreen.tsx
@@ -388,11 +388,11 @@ export function ProfileTabScreen({
                   <SettingRow
                     theme={theme}
                     icon="star"
-                    title="Star-Index 알림"
+                    title="기준 명소 알림"
                     subtitle={
                       prefs.starIndexAlertEnabled && !prefs.alertSpotId
                         ? '기준 명소를 선택해야 알림이 발송됩니다'
-                        : `기준 명소 Star-Index가 ${starIndexThreshold}점 이상이면 하루 1회 알려 드려요`
+                        : `기준 명소 점수가 ${starIndexThreshold}점 이상이면 하루 1회 알려 드려요`
                     }
                     toggle
                     value={prefs.starIndexAlertEnabled}

--- a/frontend/lib/notification-copy.ts
+++ b/frontend/lib/notification-copy.ts
@@ -9,7 +9,7 @@ export function locationStarIndexAlertMeSubtitle(
   if (!enabled) {
     return '위치한 곳 점수가 선택한 기준을 넘으면 하루 1회 알려 드려요';
   }
-  return `알림 기준 ${threshold}점 이상 · 하루 1회`;
+  return `위치한 곳 점수가 ${threshold}점 이상이면 하루 1회 알려 드려요`;
 }
 
 export const LOCATION_ALERT_THRESHOLD_HINT =


### PR DESCRIPTION
## 🔎 What

- '위치한 곳 알림'의 설명 문구를 친절한 톤으로 변경
- 'Star-Index 알림'을 '기준 명소 알림'으로 변경 

<img width="250" alt="image" src="https://github.com/user-attachments/assets/fb64f235-4982-4b1e-a870-1ca3b719e97c" />

## 🔗 Issue 

- Closes: #112 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
