### PR TITLE
fix: SKY 위치 꺼짐 버그·명소 제보 지역 선택·Star-Index 50점 미만 표기 통일

### DIFF
--- a/backend/admin/spot-reports.html
+++ b/backend/admin/spot-reports.html
@@ -43,7 +43,7 @@
 <body>
   <div class="wrap">
     <h1>명소 제보 관리</h1>
-    <p class="sub">사용자가 GPS와 함께 보낸 새 관측지 제보입니다. 확인 후 DB에 명소를 직접 추가하세요.</p>
+    <p class="sub">사용자가 선택한 관측 위치(현재 위치·명소·직접 입력)와 함께 보낸 새 관측지 제보입니다. 확인 후 DB에 명소를 직접 추가하세요.</p>
 
     <div class="panel">
       <div class="row">
@@ -152,6 +152,7 @@
           ' · ' + escapeHtml(item.user.nickname || item.user.email) + '</div>' +
           '<div class="stats">' +
           '<span class="stat">' + formatStarIndexScore(item.starIndexVal) + '</span>' +
+          (item.placeLabel ? '<span class="stat">위치 ' + escapeHtml(item.placeLabel) + '</span>' : '') +
           '<span class="stat">GPS ' + Number(item.latitude).toFixed(5) + ', ' + Number(item.longitude).toFixed(5) + '</span>' +
           '</div>' +
           '<a class="map" href="' + mapsUrl(item.latitude, item.longitude) + '" target="_blank" rel="noopener">지도에서 보기 ↗</a>' +

--- a/backend/src/migrations/1752000000000-add-spot-report-place-label.ts
+++ b/backend/src/migrations/1752000000000-add-spot-report-place-label.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/** 명소 제보 — 선택한 관측 위치 라벨(현재 위치/명소/직접 입력) 저장 */
+export class AddSpotReportPlaceLabel1752000000000 implements MigrationInterface {
+  name = 'AddSpotReportPlaceLabel1752000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE spot_reports
+      ADD COLUMN IF NOT EXISTS place_label varchar(120) NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE spot_reports DROP COLUMN IF EXISTS place_label
+    `);
+  }
+}

--- a/backend/src/spot-reports/dto/create-spot-report.dto.ts
+++ b/backend/src/spot-reports/dto/create-spot-report.dto.ts
@@ -1,11 +1,27 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsString, Max, MaxLength, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
 
 export class CreateSpotReportDto {
   @ApiProperty({ description: '명소 제보 설명', maxLength: 500 })
   @IsString()
   @MaxLength(500)
   message: string;
+
+  @ApiPropertyOptional({
+    description: '선택한 관측 위치 라벨 (현재 위치/명소/직접 입력)',
+    maxLength: 120,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  placeLabel?: string;
 
   @ApiProperty({ minimum: -90, maximum: 90 })
   @IsNumber()

--- a/backend/src/spot-reports/spot-report.entity.ts
+++ b/backend/src/spot-reports/spot-report.entity.ts
@@ -23,6 +23,10 @@ export class SpotReportEntity {
   @Column({ type: 'text' })
   message: string;
 
+  /** 제보자가 선택한 관측 위치 라벨 (현재 위치/명소/직접 입력) */
+  @Column({ name: 'place_label', type: 'varchar', length: 120, nullable: true })
+  placeLabel: string | null;
+
   @Column({ name: 'star_index_val', type: 'smallint' })
   starIndexVal: number;
 

--- a/backend/src/spot-reports/spot-reports.service.ts
+++ b/backend/src/spot-reports/spot-reports.service.ts
@@ -47,6 +47,7 @@ export class SpotReportsService {
       latitude: dto.lat,
       longitude: dto.lng,
       message,
+      placeLabel: dto.placeLabel?.trim() || null,
       starIndexVal: starResult.score,
       weatherSnapshot: starResult.weatherSnapshot,
     });
@@ -72,6 +73,7 @@ export class SpotReportsService {
         'r.latitude AS latitude',
         'r.longitude AS longitude',
         'r.message AS message',
+        'r.place_label AS "placeLabel"',
         'r.star_index_val AS "starIndexVal"',
         'r.weather_snapshot AS "weatherSnapshot"',
         'r.created_at AS "createdAt"',
@@ -85,6 +87,7 @@ export class SpotReportsService {
         latitude: number;
         longitude: number;
         message: string;
+        placeLabel: string | null;
         starIndexVal: number;
         weatherSnapshot: SpotReportEntity['weatherSnapshot'];
         createdAt: Date;
@@ -98,6 +101,7 @@ export class SpotReportsService {
       latitude: row.latitude,
       longitude: row.longitude,
       message: row.message,
+      placeLabel: row.placeLabel,
       starIndexVal: row.starIndexVal,
       weatherSnapshot: row.weatherSnapshot,
       createdAt: row.createdAt.toISOString(),

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -413,7 +413,6 @@ function AppContent() {
             <RecordsTabScreen
               observerLat={deviceLat}
               observerLng={deviceLng}
-              useDeviceLocation={deviceLocationActive}
               onSessionInvalidated={onSessionInvalidated}
               starIndexPlaceLabel={observerStarIndex.placeLabel}
             />

--- a/frontend/components/main/AnimatedStarIndexGauge.tsx
+++ b/frontend/components/main/AnimatedStarIndexGauge.tsx
@@ -265,7 +265,8 @@ export function AnimatedStarIndexGauge({
             style={[
               styles.score,
               {
-                color: theme.foreground,
+                // 50점 미만(관측 어려움)은 숫자도 빨간색으로 — 그 외 구간은 흰색 유지
+                color: display.measurable ? theme.foreground : theme.destructive,
                 fontFamily: 'SpaceMono-Regular',
               },
             ]}

--- a/frontend/components/map/MapClusterSpotsSheet.tsx
+++ b/frontend/components/map/MapClusterSpotsSheet.tsx
@@ -234,7 +234,7 @@ export function MapClusterSpotsSheet({
                             color: scDisplay?.measurable
                               ? theme.primaryGlow
                               : theme.destructive,
-                            fontSize: scDisplay?.measurable ? 18 : 12,
+                            fontSize: 18,
                           },
                         ]}
                         numberOfLines={1}

--- a/frontend/components/records/DiaryLocationField.tsx
+++ b/frontend/components/records/DiaryLocationField.tsx
@@ -36,6 +36,9 @@ interface DiaryLocationFieldProps {
   observerLng?: number | null;
   placeLabel?: string | null;
   disabled?: boolean;
+  /** 필드 라벨·모달 제목 — 맥락에 맞게 교체 (기본: 일기 작성용 '관측 위치') */
+  fieldLabel?: string;
+  pickerTitle?: string;
   onSessionInvalidated: () => Promise<void>;
 }
 
@@ -57,6 +60,8 @@ export function DiaryLocationField({
   observerLng,
   placeLabel,
   disabled = false,
+  fieldLabel = '관측 위치',
+  pickerTitle = '관측 위치 선택',
   onSessionInvalidated,
 }: DiaryLocationFieldProps) {
   const { theme } = useTheme();
@@ -164,7 +169,7 @@ export function DiaryLocationField({
 
   return (
     <View style={styles.wrap}>
-      <Text style={[styles.label, { color: theme.foreground }]}>관측 위치</Text>
+      <Text style={[styles.label, { color: theme.foreground }]}>{fieldLabel}</Text>
 
       <AppPressable
         onPress={() => !disabled && setPickerOpen(true)}
@@ -178,7 +183,7 @@ export function DiaryLocationField({
           },
         ]}
         accessibilityRole="button"
-        accessibilityLabel="관측 위치 선택"
+        accessibilityLabel={pickerTitle}
       >
         <Feather name="map-pin" size={18} color={theme.primaryGlow} style={styles.selectorIcon} />
         <View style={styles.selectorTextBlock}>
@@ -214,7 +219,7 @@ export function DiaryLocationField({
             onPress={(e) => e.stopPropagation()}
           >
             <Text style={[styles.modalTitle, { color: theme.foreground }]}>
-              관측 위치 선택
+              {pickerTitle}
             </Text>
 
             {searchErr ? (

--- a/frontend/components/records/RecordsTabScreen.tsx
+++ b/frontend/components/records/RecordsTabScreen.tsx
@@ -30,7 +30,6 @@ import {
 interface RecordsTabScreenProps {
   observerLat?: number | null;
   observerLng?: number | null;
-  useDeviceLocation?: boolean;
   onSessionInvalidated: () => Promise<void>;
   starIndexPlaceLabel?: string | null;
 }
@@ -38,7 +37,6 @@ interface RecordsTabScreenProps {
 export function RecordsTabScreen({
   observerLat = null,
   observerLng = null,
-  useDeviceLocation = true,
   onSessionInvalidated,
   starIndexPlaceLabel = null,
 }: RecordsTabScreenProps) {
@@ -121,7 +119,7 @@ export function RecordsTabScreen({
             <SpotReportSection
               observerLat={observerLat}
               observerLng={observerLng}
-              useDeviceLocation={useDeviceLocation}
+              placeLabel={starIndexPlaceLabel}
               onSessionInvalidated={onSessionInvalidated}
             />
           ) : null}

--- a/frontend/components/records/SpotReportSection.tsx
+++ b/frontend/components/records/SpotReportSection.tsx
@@ -1,12 +1,10 @@
 /**
- * 명소 제보 — GPS + 텍스트를 관리자에게 전송
+ * 명소 제보 — 일기와 동일한 관측 위치 선택(현재 위치/명소 검색/직접 입력) + 설명을 관리자에게 전송
  */
 
 import Feather from '@expo/vector-icons/Feather';
-import * as Location from 'expo-location';
 import React, { useCallback, useState } from 'react';
 import {
-  Platform,
   StyleSheet,
   Text,
   TextInput,
@@ -17,45 +15,69 @@ import {
   SessionExpiredError,
   submitSpotReport,
 } from '../../lib/api-client';
+import { fetchSpotById } from '../../lib/spots-api';
 import { spacing } from '../../themes/design-tokens';
 import { useTheme } from '../../themes/ThemeContext';
 import { Button } from '../ui';
 import { GlassCard } from '../ui/GlassCard';
 import { DiarySectionHeader } from './DiarySectionHeader';
+import {
+  DiaryLocationField,
+  type DiaryLocationValue,
+} from './DiaryLocationField';
 
 interface SpotReportSectionProps {
   observerLat?: number | null;
   observerLng?: number | null;
-  useDeviceLocation?: boolean;
+  placeLabel?: string | null;
   onSessionInvalidated: () => Promise<void>;
 }
 
-async function resolveGps(
+function hasCoords(lat?: number | null, lng?: number | null): boolean {
+  return lat != null && lng != null && Number.isFinite(lat) && Number.isFinite(lng);
+}
+
+function initialLocation(placeLabel?: string | null): DiaryLocationValue {
+  return {
+    mode: 'current',
+    spotId: null,
+    label: placeLabel?.trim() || '현재 위치',
+  };
+}
+
+/** 선택한 위치를 제보용 좌표·라벨로 변환. GPS 없이도 명소·직접 입력으로 제보 가능 */
+async function resolveReportLocation(
+  location: DiaryLocationValue,
   observerLat: number | null | undefined,
   observerLng: number | null | undefined,
-  useDeviceLocation: boolean,
-): Promise<{ lat: number; lng: number } | null> {
-  if (useDeviceLocation && Platform.OS !== 'web') {
-    try {
-      const perm = await Location.getForegroundPermissionsAsync();
-      if (perm.status === Location.PermissionStatus.GRANTED) {
-        const pos = await Location.getCurrentPositionAsync({
-          accuracy: Location.Accuracy.Balanced,
-        });
-        return { lat: pos.coords.latitude, lng: pos.coords.longitude };
-      }
-    } catch {
-      /* 폴백 */
+): Promise<{ lat: number; lng: number; label: string } | null> {
+  if (location.mode === 'custom') {
+    if (hasCoords(location.customLat, location.customLng)) {
+      return {
+        lat: location.customLat as number,
+        lng: location.customLng as number,
+        label: location.label,
+      };
     }
+    return null;
   }
 
-  if (
-    observerLat != null &&
-    observerLng != null &&
-    Number.isFinite(observerLat) &&
-    Number.isFinite(observerLng)
-  ) {
-    return { lat: observerLat, lng: observerLng };
+  if (location.mode === 'spot' && location.spotId) {
+    const spot = await fetchSpotById(location.spotId);
+    return {
+      lat: spot.lat,
+      lng: spot.lng,
+      label: location.spotFullName || location.label,
+    };
+  }
+
+  // 현재 위치 — GPS 좌표가 있을 때만
+  if (hasCoords(observerLat, observerLng)) {
+    return {
+      lat: observerLat as number,
+      lng: observerLng as number,
+      label: location.label?.trim() || '현재 위치',
+    };
   }
 
   return null;
@@ -64,11 +86,14 @@ async function resolveGps(
 export function SpotReportSection({
   observerLat = null,
   observerLng = null,
-  useDeviceLocation = true,
+  placeLabel = null,
   onSessionInvalidated,
 }: SpotReportSectionProps) {
   const { theme } = useTheme();
   const [message, setMessage] = useState('');
+  const [location, setLocation] = useState<DiaryLocationValue>(() =>
+    initialLocation(placeLabel),
+  );
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -85,19 +110,27 @@ export function SpotReportSection({
     setSuccess(null);
 
     try {
-      const coords = await resolveGps(observerLat, observerLng, useDeviceLocation);
-      if (!coords) {
-        setError('위치 권한을 허용하거나 GPS를 켜 주세요.');
+      const resolved = await resolveReportLocation(
+        location,
+        observerLat,
+        observerLng,
+      );
+      if (!resolved) {
+        setError(
+          '관측 위치를 선택해 주세요. 현재 위치 좌표가 없으면 명소 검색이나 직접 입력으로 위치를 골라 주세요.',
+        );
         return;
       }
 
       await submitSpotReport({
         message: trimmed,
-        lat: coords.lat,
-        lng: coords.lng,
+        lat: resolved.lat,
+        lng: resolved.lng,
+        placeLabel: resolved.label?.trim() || undefined,
       });
 
       setMessage('');
+      setLocation(initialLocation(placeLabel));
       setSuccess('제보를 보냈습니다. 검토 후 명소 목록에 반영될 수 있어요.');
     } catch (e) {
       if (e instanceof SessionExpiredError) {
@@ -110,15 +143,33 @@ export function SpotReportSection({
     } finally {
       setBusy(false);
     }
-  }, [message, observerLat, observerLng, onSessionInvalidated, useDeviceLocation]);
+  }, [message, location, observerLat, observerLng, placeLabel, onSessionInvalidated]);
 
   return (
     <GlassCard glow>
       <DiarySectionHeader
         icon="map-pin"
         title="명소 제보"
-        subtitle="목록에 없는 관측지를 알려 주세요. GPS와 Star-Index가 함께 전달됩니다."
+        subtitle="목록에 없는 관측지를 알려 주세요. 선택한 위치와 Star-Index가 함께 전달됩니다."
       />
+
+      <View style={styles.field}>
+        <DiaryLocationField
+          value={location}
+          onChange={(next) => {
+            setLocation(next);
+            setError(null);
+            setSuccess(null);
+          }}
+          observerLat={observerLat}
+          observerLng={observerLng}
+          placeLabel={placeLabel}
+          disabled={busy}
+          fieldLabel="제보 위치"
+          pickerTitle="제보 위치 선택"
+          onSessionInvalidated={onSessionInvalidated}
+        />
+      </View>
 
       <View style={styles.field}>
         <Text style={[styles.label, { color: theme.foreground }]}>명소 설명</Text>

--- a/frontend/components/sky/SkyObserverControlsPanel.tsx
+++ b/frontend/components/sky/SkyObserverControlsPanel.tsx
@@ -79,30 +79,19 @@ function ScoreBlock({
     );
   }
 
-  if (display.measurable) {
-    return (
-      <View style={styles.scoreRow}>
-        <Text style={[styles.scoreValue, { color: theme.starGold }]}>
-          {display.label}
-        </Text>
-        <Text style={[styles.scoreUnit, { color: theme.mutedForeground }]}>
-          / 100
-        </Text>
-      </View>
-    );
-  }
-
-  const raw = display.label.match(/\((\d+)\)\s*$/);
-  const subScore = raw?.[1];
-
   return (
     <View style={styles.scoreRow}>
-      <Text style={[styles.scoreUnmeasurable, { color: theme.destructive }]}>
-        측정불가
+      <Text
+        style={[
+          styles.scoreValue,
+          { color: display.measurable ? theme.starGold : theme.destructive },
+        ]}
+      >
+        {display.label}
       </Text>
-      {subScore != null ? (
-        <Text style={[styles.scoreRaw, { color: theme.destructive }]}>({subScore})</Text>
-      ) : null}
+      <Text style={[styles.scoreUnit, { color: theme.mutedForeground }]}>
+        / 100
+      </Text>
     </View>
   );
 }
@@ -577,15 +566,6 @@ const styles = StyleSheet.create({
   scoreUnit: {
     fontSize: 11,
     fontWeight: '500',
-  },
-  scoreUnmeasurable: {
-    fontSize: 13,
-    fontWeight: '600',
-  },
-  scoreRaw: {
-    fontSize: 20,
-    fontWeight: '300',
-    fontVariant: ['tabular-nums'],
   },
   scoreHint: {
     fontSize: 10,

--- a/frontend/components/sky/SkyObserverEmptyState.tsx
+++ b/frontend/components/sky/SkyObserverEmptyState.tsx
@@ -23,6 +23,7 @@ export function SkyObserverEmptyState({
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
 
+  const locationOff = !locationFeaturesEnabled;
   const locDenied =
     Platform.OS !== 'web' &&
     locationPermissionStatus === Location.PermissionStatus.DENIED;
@@ -49,22 +50,34 @@ export function SkyObserverEmptyState({
 
         <Text style={[styles.title, { color: theme.foreground }]}>가상 밤하늘</Text>
         <Text style={[styles.sub, { color: theme.mutedForeground }]}>
-          위치를 허용하면 지금 서 있는 곳의{'\n'}천구가 화면을 채웁니다.
+          {locationOff
+            ? '위치 사용을 켜면 지금 서 있는 곳의\n천구가 화면을 채웁니다.'
+            : '위치를 허용하면 지금 서 있는 곳의\n천구가 화면을 채웁니다.'}
         </Text>
 
         <GlassCard glow padding={spacing.lg} style={styles.card}>
           <View style={styles.cardHeader}>
             <Feather name="map-pin" size={18} color={theme.primaryGlow} />
             <Text style={[styles.cardTitle, { color: theme.foreground }]}>
-              관측 위치가 필요해요
+              {locationOff ? '위치 사용이 꺼져 있어요' : '관측 위치가 필요해요'}
             </Text>
           </View>
           <Text style={[styles.cardBody, { color: theme.mutedForeground }]}>
-            위치 권한을 허용하거나 MAIN·지도에서 명소를 고르면 별자리와 행성을 볼 수
-            있어요.
+            {locationOff
+              ? '가상 밤하늘은 위치를 기준으로 그려져요. ME 설정이나 아래에서 위치 사용을 켜 주세요.'
+              : '위치 권한을 허용하거나 MAIN·지도에서 명소를 고르면 별자리와 행성을 볼 수 있어요.'}
           </Text>
 
-          {showPermissionCard ? (
+          {locationOff ? (
+            <View style={[styles.permissionBlock, { borderTopColor: theme.borderSubtle }]}>
+              <Button
+                label="위치 사용 켜기"
+                variant="secondary"
+                size="sm"
+                onPress={() => void onRequestLocationPermission?.()}
+              />
+            </View>
+          ) : showPermissionCard ? (
             <View style={[styles.permissionBlock, { borderTopColor: theme.borderSubtle }]}>
               <Text style={[styles.permissionHint, { color: theme.mutedForeground }]}>
                 {locDenied
@@ -90,9 +103,11 @@ export function SkyObserverEmptyState({
           ) : null}
         </GlassCard>
 
-        <Text style={[styles.footerHint, { color: theme.mutedForeground }]}>
-          GPS가 꺼져 있으면 기본 명소 좌표로도 볼 수 있어요.
-        </Text>
+        {!locationOff ? (
+          <Text style={[styles.footerHint, { color: theme.mutedForeground }]}>
+            GPS가 꺼져 있으면 기본 명소 좌표로도 볼 수 있어요.
+          </Text>
+        ) : null}
       </View>
     </View>
   );

--- a/frontend/components/sky/SkyTabScreen.tsx
+++ b/frontend/components/sky/SkyTabScreen.tsx
@@ -147,16 +147,24 @@ export function SkyTabScreen({
   const [locSiLoading, setLocSiLoading] = useState(false);
   const [locSiErr, setLocSiErr] = useState<string | null>(null);
 
-  const obsLat =
-    observerLat != null && Number.isFinite(observerLat)
+  /** 앱 '위치 사용'이 꺼져 있으면 GPS·명소 폴백 모두 무시 — SKY는 빈 상태만 표시 */
+  const obsLat = !locationFeaturesEnabled
+    ? null
+    : observerLat != null && Number.isFinite(observerLat)
       ? observerLat
       : spotFallback?.lat ?? null;
-  const obsLng =
-    observerLng != null && Number.isFinite(observerLng)
+  const obsLng = !locationFeaturesEnabled
+    ? null
+    : observerLng != null && Number.isFinite(observerLng)
       ? observerLng
       : spotFallback?.lng ?? null;
 
   useEffect(() => {
+    // 위치 사용 OFF — 폴백 좌표를 만들지 않아 빈 상태로 떨어지게 한다
+    if (!locationFeaturesEnabled) {
+      setSpotFallback(null);
+      return;
+    }
     const hasSi =
       observerLat != null &&
       observerLng != null &&
@@ -186,7 +194,13 @@ export function SkyTabScreen({
     return () => {
       cancelled = true;
     };
-  }, [observerLat, observerLng, observerSpotId, onSessionInvalidated]);
+  }, [
+    observerLat,
+    observerLng,
+    observerSpotId,
+    locationFeaturesEnabled,
+    onSessionInvalidated,
+  ]);
 
   const {
     data,

--- a/frontend/components/ui/Card.tsx
+++ b/frontend/components/ui/Card.tsx
@@ -168,7 +168,7 @@ export function StarIndexCard({
   const scoreDisplay = getStarIndexScoreDisplay(score);
 
   const status = !scoreDisplay.measurable
-    ? scoreDisplay.label
+    ? '관측 어려움'
     : score >= 75
       ? '관측 적합'
       : '부분 관측';
@@ -229,8 +229,8 @@ export function StarIndexCard({
                 {
                   color: scoreColor,
                   fontFamily: 'SpaceMono-Regular',
-                  fontSize: scoreDisplay.measurable ? 40 : 22,
-                  lineHeight: scoreDisplay.measurable ? 44 : 28,
+                  fontSize: 40,
+                  lineHeight: 44,
                 },
               ]}
             >
@@ -334,8 +334,8 @@ export function SpotCard({
                 {
                   color: scoreDisplay.measurable ? theme.primaryGlow : theme.destructive,
                   fontFamily: 'SpaceMono-Regular',
-                  fontSize: scoreDisplay.measurable ? 22 : 13,
-                  lineHeight: scoreDisplay.measurable ? 24 : 18,
+                  fontSize: 22,
+                  lineHeight: 24,
                 },
               ]}
             >

--- a/frontend/lib/api/observations-api.ts
+++ b/frontend/lib/api/observations-api.ts
@@ -153,6 +153,8 @@ export interface SubmitSpotReportPayload {
   message: string;
   lat: number;
   lng: number;
+  /** 선택한 관측 위치 라벨 (현재 위치/명소/직접 입력) */
+  placeLabel?: string;
 }
 
 export function submitSpotReport(

--- a/frontend/lib/star-index-display.ts
+++ b/frontend/lib/star-index-display.ts
@@ -1,6 +1,10 @@
 import type { StarIndexResponseDto } from './types/api';
 
-/** 가중 합산 점수가 이 값 미만이면 UI에 측정불가(점수) 표시 */
+/**
+ * 이 값 미만이면 별 관측이 어려운 저점수 구간. UI에는 다른 구간과 동일하게 점수 숫자만 표시하고,
+ * 차이는 색·게이지 등 보조 스타일(measurable 플래그)로만 구분한다.
+ * '관측 어려움' 등 상태 라벨은 가이드 시트(MainScoreGuideSheet)에만 노출한다.
+ */
 export const STAR_INDEX_DISPLAY_MIN_SCORE = 50;
 
 export type StarIndexScoreDisplay = {
@@ -9,28 +13,15 @@ export type StarIndexScoreDisplay = {
   gaugePercent: number;
 };
 
-/** 50점 미만 — 원점수를 괄호에 표시 (예: 측정불가(42)) */
-export function formatUnmeasurableStarIndexLabel(score: number): string {
-  const n = Math.round(score);
-  if (!Number.isFinite(n)) return '측정불가';
-  return `측정불가(${n})`;
-}
-
 export function getStarIndexScoreDisplay(score: number): StarIndexScoreDisplay {
   const n = Math.round(score);
-  if (!Number.isFinite(n) || n < STAR_INDEX_DISPLAY_MIN_SCORE) {
-    const clamped = Math.min(100, Math.max(0, Number.isFinite(n) ? n : 0));
-    return {
-      measurable: false,
-      label: formatUnmeasurableStarIndexLabel(score),
-      /** 측정불가여도 MAIN 링·게이지는 원점수 비율로 표시 */
-      gaugePercent: clamped,
-    };
-  }
+  const finite = Number.isFinite(n);
+  const clamped = Math.min(100, Math.max(0, finite ? n : 0));
   return {
-    measurable: true,
-    label: String(n),
-    gaugePercent: Math.min(100, Math.max(0, n)),
+    measurable: finite && n >= STAR_INDEX_DISPLAY_MIN_SCORE,
+    /** 모든 구간 숫자만 — 50점 미만도 예외 없이 원점수 그대로 */
+    label: finite ? String(n) : '—',
+    gaugePercent: clamped,
   };
 }
 

--- a/frontend/lib/star-index-guide.ts
+++ b/frontend/lib/star-index-guide.ts
@@ -13,9 +13,9 @@ export const STAR_INDEX_GUIDE_ROWS: StarIndexGuideRow[] = [
   {
     minScore: null,
     maxScore: STAR_INDEX_DISPLAY_MIN_SCORE - 1,
-    badge: '측정불가',
+    badge: '관측 어려움',
     title: `${STAR_INDEX_DISPLAY_MIN_SCORE}점 미만`,
-    body: '구름·미세먼지·달빛 등 조건이 좋지 않아 신뢰할 수 있는 점수로 보기 어려워요. 화면에는 측정불가(원점수)로 표시됩니다.',
+    body: '구름·미세먼지·달빛 등 여러 조건이 겹쳐 점수가 매우 낮은 구간이에요. 별을 관측하기 어려운 밤이에요.',
   },
   {
     minScore: STAR_INDEX_DISPLAY_MIN_SCORE,

--- a/frontend/lib/star-index-headline.ts
+++ b/frontend/lib/star-index-headline.ts
@@ -1,7 +1,4 @@
-import {
-  formatUnmeasurableStarIndexLabel,
-  STAR_INDEX_DISPLAY_MIN_SCORE,
-} from './star-index-display';
+import { STAR_INDEX_DISPLAY_MIN_SCORE } from './star-index-display';
 
 /** MAIN 화면 헤드라인 — 점수 구간별 UX 카피 */
 export type StarIndexHeadline = {
@@ -16,10 +13,10 @@ export function getStarIndexHeadline(score: number): StarIndexHeadline {
 
   if (!Number.isFinite(n) || n < STAR_INDEX_DISPLAY_MIN_SCORE) {
     return {
-      line1: '현재 하늘은',
-      highlight: formatUnmeasurableStarIndexLabel(score),
-      line2: '예요',
-      hint: '조건이 좋지 않아요. 잠시 후 다시 확인해 보세요.',
+      line1: '오늘 밤은',
+      highlight: '별 보기 어려운 ',
+      line2: '하늘이에요',
+      hint: '관측 조건이 전반적으로 좋지 않아요.',
     };
   }
 
@@ -83,7 +80,7 @@ function scoreBandLabel(score: number): string {
   if (score >= 80) return '양호';
   if (score >= 70) return '보통';
   if (score >= STAR_INDEX_DISPLAY_MIN_SCORE) return '나쁨';
-  return formatUnmeasurableStarIndexLabel(score);
+  return '관측 어려움';
 }
 
 export function windLabelFromScore(windScore: number): string {


### PR DESCRIPTION
## 🔎 What

### 1. SKY — 위치 꺼도 밤하늘 보이는 버그
- 앱 '위치 사용' OFF면 GPS·명소 폴백 모두 무시하고 빈 상태만 표시하도록 게이팅
- 위치 OFF 빈 상태에 전용 안내 + '위치 사용 켜기' 버튼 추가
- (위치 ON + GPS만 없을 때 명소 기준 표시는 기존 폴백으로 유지)
<img width="200" alt="image" src="https://github.com/user-attachments/assets/312432d5-9fe6-4f96-ac7e-bb8502ff1e4c" />


### 2. 명소 제보 — GPS → 위치 선택
- 일기의 위치 선택 UI(`DiaryLocationField`) 재사용: 현재 위치 / 명소 검색 / 직접 입력
- GPS 없이도 명소·직접 입력만으로 제보 가능
- 제보 맥락에 맞게 '제보 위치'로 라벨 표기 (공용 컴포넌트에 prop 추가)
- 선택 위치 라벨 저장: `spot_reports.place_label` 컬럼 추가 + 관리자 화면 표시
<img width="200" alt="image" src="https://github.com/user-attachments/assets/b2ea883c-68ec-4afc-aa25-cf2f1cae9b43" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/9ef6dea9-c3af-43ca-8cf1-017ae071b109" />


### 3. Star-Index — 50점 미만 표기 통일
- 모든 구간 숫자 점수만 표시 (`측정불가(42)` 표기 제거), 폰트 크기 통일
- 50점 미만 구분은 색·게이지로만 (MAIN 중앙 점수도 빨간색)
- 상태명 '측정불가' → '관측 어려움', 헤드라인·가이드 문구 정리
- 상태 라벨은 가이드 시트(ⓘ)에만 노출
<img width="200" alt="image" src="https://github.com/user-attachments/assets/78ea2c11-0f62-473d-8200-2be122bd8748" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/948690ab-47b1-4066-993c-1c18327e2c9d" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/18133acb-961a-4f31-8774-e86f8526d6db" />


## 🔗 Issue 

- Closes: #105 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
