### PR TITLE
feat: Star-Index 가이드 헤더 고정, 촬영 가이드 중복 버튼 제거

### DIFF
--- a/frontend/components/guide/PhotographyGuideModal.tsx
+++ b/frontend/components/guide/PhotographyGuideModal.tsx
@@ -11,7 +11,6 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useTheme } from '../../themes/ThemeContext';
 import type { ThemeTokens } from '../../themes/themes';
-import { Button } from '../ui';
 
 interface PhotographyGuideModalProps {
   visible: boolean;
@@ -105,10 +104,6 @@ export function PhotographyGuideModal({
             본 내용은 일반 참고용이며 기기 매뉴얼·현장 안전 수칙이 우선합니다.
           </Text>
         </ScrollView>
-
-        <View style={[styles.footer, { borderTopColor: theme.border }]}>
-          <Button label="확인" variant="primary" fullWidth onPress={onClose} />
-        </View>
       </View>
     </Modal>
   );
@@ -166,9 +161,4 @@ const styles = StyleSheet.create({
   bulletDot: { fontSize: 14, lineHeight: 21, width: 18 },
   bulletText: { flex: 1, fontSize: 13, lineHeight: 21 },
   disclaimer: { fontSize: 12, lineHeight: 18, marginTop: 8 },
-  footer: {
-    paddingHorizontal: 16,
-    paddingTop: 12,
-    borderTopWidth: StyleSheet.hairlineWidth,
-  },
 });

--- a/frontend/components/main/MainScoreGuideSheet.tsx
+++ b/frontend/components/main/MainScoreGuideSheet.tsx
@@ -49,8 +49,20 @@ export function MainScoreGuideSheet({ visible, onClose }: MainScoreGuideSheetPro
             },
           ]}
         >
+          <View style={styles.header}>
+            <View style={styles.headerTitleRow}>
+              <Feather name="info" size={18} color={theme.primaryGlow} />
+              <Text style={[styles.title, { color: theme.foreground }]}>
+                Star-Index 가이드
+              </Text>
+            </View>
+            <Pressable onPress={onClose} hitSlop={12} accessibilityLabel="닫기">
+              <Feather name="x" size={20} color={theme.mutedForeground} />
+            </Pressable>
+          </View>
+
           <ScrollView
-            style={{ maxHeight: sheetMaxHeight - spacing.lg * 2 }}
+            style={styles.scroll}
             contentContainerStyle={[
               styles.scrollContent,
               { paddingBottom: Math.max(insets.bottom, spacing.lg) },
@@ -59,18 +71,6 @@ export function MainScoreGuideSheet({ visible, onClose }: MainScoreGuideSheetPro
             bounces
             nestedScrollEnabled
           >
-            <View style={styles.header}>
-              <View style={styles.headerTitleRow}>
-                <Feather name="info" size={18} color={theme.primaryGlow} />
-                <Text style={[styles.title, { color: theme.foreground }]}>
-                  Star-Index 가이드
-                </Text>
-              </View>
-              <Pressable onPress={onClose} hitSlop={12} accessibilityLabel="닫기">
-                <Feather name="x" size={20} color={theme.mutedForeground} />
-              </Pressable>
-            </View>
-
             <Text style={[styles.lead, { color: theme.mutedForeground }]}>
               메인 화면 문구와 같은 기준으로 점수를 해석해요. 숫자가 높을수록 별·은하수
               관측에 유리한 밤에 가깝습니다.
@@ -115,6 +115,9 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     width: '100%',
     maxWidth: 400,
+  },
+  scroll: {
+    flexShrink: 1,
   },
   scrollContent: {
     gap: spacing.sm,


### PR DESCRIPTION
## 🔎 What

- MAIN의 'Star-Index 가이드' 헤더 고정
- ME의 '별 야경 촬영 기본 가이드' 확인 버튼 제거(중복)

## 🔗 Issue 

- Closes: #115 

## ✅ 체크리스트

- [x] 브랜치 base가 적절한가요?
- [x] 제목이 이슈 제목과 동일한가요?
- [ ] 최소 1명의 리뷰를 받았나요?
